### PR TITLE
Closes SPARK-1531 - Added handling of urls starting with 'www'

### DIFF
--- a/src/java/org/jivesoftware/spark/util/BrowserLauncher.java
+++ b/src/java/org/jivesoftware/spark/util/BrowserLauncher.java
@@ -26,10 +26,13 @@ import java.net.URI;
 public class BrowserLauncher {
 
 	public static void openURL(String url) throws Exception {
-		if (url.startsWith("http") || url.startsWith("ftp") || url.startsWith("file")) {
+		if (url.startsWith("http") || url.startsWith("ftp") || url.startsWith("file") || url.startsWith("www")) {
 
 			if (url.startsWith("file") && url.contains(" ")) {
 				url = url.replace(" ", "%20");
+			}
+			if (url.startsWith("www")) {
+				url = "http://" + url;
 			}
 			Desktop.getDesktop().browse(new URI(url));
 		} else {


### PR DESCRIPTION
Brought BrowserLauncher.openURL() more in line with ChatArea.getMarkup() so all text highlighted as a URL should successfully open a browser window.  Should Close SPARK-1531.
