### PR TITLE
Notifications settings shouldn't be blank when updates are disabled

### DIFF
--- a/src/java/org/jivesoftware/sparkimpl/preference/notifications/NotificationsUI.java
+++ b/src/java/org/jivesoftware/sparkimpl/preference/notifications/NotificationsUI.java
@@ -119,10 +119,9 @@ public class NotificationsUI extends JPanel {
         ResourceUtils.resButton(betaCheckBox, Res.getString("menuitem.check.for.updates"));
         if(!Default.getBoolean(Default.DISABLE_UPDATES)){
         	pn.add(betaCheckBox, new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
-        	   
+        }   
         	add(pn);	
-        }
-        
+
         windowFocusBox.addChangeListener(new ChangeListener(){
         	public void stateChanged(ChangeEvent ce){
         		if(shouldWindowPopup()) {


### PR DESCRIPTION
https://igniterealtime.org/issues/browse/SPARK-1645