### PR TITLE
SPARK-1650: Fix file select dialog (for transfer)

### DIFF
--- a/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
+++ b/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
@@ -135,13 +135,19 @@ public class ChatRoomTransferDecorator implements KeyListener, FileDropListener,
 
             public void finished() {
                 FileDialog fileChooser = SparkManager.getTransferManager().getFileChooser(SparkManager.getChatManager().getChatContainer().getChatFrame(), Res.getString("title.select.file.to.send"));
+                if (SparkManager.getTransferManager().getDefaultDirectory() != null)
+                {
+                    fileChooser.setDirectory(SparkManager.getTransferManager().getDefaultDirectory().getAbsolutePath());
+                }
                 fileChooser.setVisible(true);
 
-                if (fileChooser.getDirectory() == null || fileChooser.getFile() == null) {
+                final File[] files = fileChooser.getFiles();
+                if ( files.length == 0) {
+                    // no selection
                     return;
                 }
 
-                File file = new File(fileChooser.getDirectory(), fileChooser.getFile());
+                File file = files[0]; // Single-file selection is used. Using the first array item is safe.
 
                 if (file.exists()) {
                     SparkManager.getTransferManager().setDefaultDirectory(file.getParentFile());

--- a/src/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
+++ b/src/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
@@ -327,17 +327,23 @@ public class SparkTransferManager {
 
     public void sendFileTo(ContactItem item) {
         FileDialog fileChooser = getFileChooser(SparkManager.getMainWindow(), Res.getString("title.select.file.to.send"));
+        if (defaultDirectory != null)
+        {
+            fileChooser.setDirectory( defaultDirectory.getAbsolutePath() );
+        }
         fileChooser.setVisible(true);
 
-        if (fileChooser.getDirectory() == null || fileChooser.getFile() == null) {
+        final File[] files = fileChooser.getFiles();
+        if ( files.length == 0) {
+            // no selection
             return;
         }
 
-        File file = new File(fileChooser.getDirectory(), fileChooser.getFile());
+        File file = files[0]; // Single-file selection is used. Using the first array item is safe.
 
         if (file.exists()) {
             defaultDirectory = file.getParentFile();
-            sendFile(file, item.getJID());
+            sendFile( file, item.getJID() );
         }
 
     }
@@ -773,7 +779,25 @@ public class SparkTransferManager {
      * @param directory the default directory.
      */
     public void setDefaultDirectory(File directory) {
-        defaultDirectory = directory;
+        if (directory == null) {
+            defaultDirectory = null;
+        } else if (directory.isDirectory() ) {
+            defaultDirectory = directory;
+        } else {
+            File parent = defaultDirectory.getParentFile();
+            if (parent != null && parent.isDirectory()) {
+                defaultDirectory = parent;
+            }
+        }
+    }
+
+    /**
+     * Returns the current default directory to store files.
+     *
+     * @return the default directory.
+     */
+    public File getDefaultDirectory() {
+        return defaultDirectory;
     }
 
     /**


### PR DESCRIPTION
The file selection dialog fails to pass the selected file to Spark
under some conditions (which include native implementation of the OS
and filesystem). This commit fixes this behavior.