### PR TITLE
SPARK-1091 mac dmg builder

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -794,7 +794,8 @@
 			<arg line="attach '${target}/tmp.dmg' -readwrite -noverify -noautoopen -noidme -mountpoint '${target}/tmp'"/>
 		</exec>
 
-		<exec executable="cp">
+		<!-- SPARK-1091 commented out since it wasn't working with Bamboo remote agent // TODO: fix it
+		 <exec executable="cp">
 			<arg line="${basedir}/build/installer/mac/RightDSStore ${basedir}/build/tmp/.DS_Store"/>
 		</exec>
 
@@ -803,20 +804,20 @@
 			<arg value="${mac.volname}"/>
 			<arg value="images/mac/background/"/>
 			<arg value="648"/>
-			<!-- width-->
+
 			<arg value="450"/>
-			<!-- height-->
+
 			<arg value="200"/>
-			<!-- x1-->
+
 			<arg value="205"/>
-			<!-- y1-->
+
 			<arg value="430"/>
-			<!-- x2-->
+
 			<arg value="205"/>
-			<!-- y2-->
+
 			<arg value="80"/>
-			<!-- icon size-->
-		</exec>
+
+		</exec> -->
 
 		<echo message="detach tmp"/>
 		<exec executable="hdiutil" failonerror="true">


### PR DESCRIPTION
commented out since it wasn't working with Bamboo remote agent.  Same temp fix appears to have been used with the openfire dmg builder. Unable to test.