### PR TITLE
Apple installer improvements

### DIFF
--- a/src/plugins/apple/build.xml
+++ b/src/plugins/apple/build.xml
@@ -29,7 +29,9 @@
                classpathref="lib.classpath"
                source="1.7"
                debug="true"
-               target="1.7"/>
+               target="1.7">
+            <compilerarg value="-XDignore.symbol.file"/>
+        </javac>
         <copy todir="${classes.dir}">
             <fileset dir="${resources.dir}">
                 <include name="**/*"/>


### PR DESCRIPTION
The missing symbols are included in the oracle jdk in rt.jar. By added the compiler argument -DXignore.symbol.file to the apple plugin build, everything compiles.
info on the compiler switch
https://github.com/mcourteaux/MultiTouch-Gestures-Java
https://stackoverflow.com/questions/4065401/using-internal-sun-classes-with-javac

Another option is to include AppleJavaExtensions.jar lib. It looks like Apple hasn't updated AppleJavaExtensions.jar in a few years, with the last version being 1.6 in 2011
https://developer.apple.com/legacy/library/samplecode/AppleJavaExtensions/Introduction/Intro.html

