### PR TITLE
SPARK-1677-Shows app name as Startup instead of Spark on Mac OS X

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -748,6 +748,7 @@
 					jrepreferred="true">
 			<arch name="x86_64"/>
 			<arch name="i386"/>
+			<option value="-Xdock:name=Spark"/>
 
 		</appbundler>
 


### PR DESCRIPTION
This should now display "Spark" instead of "Startup"