### PR TITLE
Revert "Correct Broadcast message . Now broadcastPlugin handle broadcast mess…"

### DIFF
--- a/src/java/org/jivesoftware/spark/ChatManager.java
+++ b/src/java/org/jivesoftware/spark/ChatManager.java
@@ -757,23 +757,7 @@ public class ChatManager implements ChatManagerListener {
         boolean isChatFrameInFocus = getChatContainer().getChatFrame().isInFocus();
         boolean isSelectedTab = getChatContainer().getSelectedComponent() == component;
         for (SparkTabHandler decorator : sparkTabHandlers) {
-            boolean isHandled = decorator.isTabHandled(tab, component, isSelectedTab, isChatFrameInFocus );
-            if (isHandled) {
-                tab.validateTab();
-                return;
-            }
-        }
-    }
-    
-    public void notifySparkBroadcastTabHandlers(Component component) {
-        final SparkTab tab = chatContainer.getTabContainingComponent(component);
-        if (tab == null) {
-            return;
-        }
-        boolean isChatFrameInFocus = getChatContainer().getChatFrame().isInFocus();
-        boolean isSelectedTab = getChatContainer().getSelectedComponent() == component;
-        for (SparkTabHandler decorator : sparkTabHandlers) {
-            boolean isHandled = decorator.isTabBroadcastHandled(tab, component, isSelectedTab, isChatFrameInFocus  );
+            boolean isHandled = decorator.isTabHandled(tab, component, isSelectedTab, isChatFrameInFocus);
             if (isHandled) {
                 tab.validateTab();
                 return;
@@ -901,7 +885,5 @@ public class ChatManager implements ChatManagerListener {
 		public void processMessage(Chat arg0, Message arg1) {			
 			// TODO Auto-generated method stub			
 		}
-    }
-
-	   	
+    }    	
 }

--- a/src/java/org/jivesoftware/spark/decorator/DefaultTabHandler.java
+++ b/src/java/org/jivesoftware/spark/decorator/DefaultTabHandler.java
@@ -43,10 +43,6 @@ public class DefaultTabHandler extends SparkTabHandler {
 
     }
 
-
-    public boolean isTabBroadcastHandled(SparkTab tab, Component component, boolean isSelectedTab, boolean chatFrameFocused) {
-    return false;
-    }
     public boolean isTabHandled(SparkTab tab, Component component, boolean isSelectedTab, boolean chatFrameFocused) {
 
         if (component instanceof ChatRoom) {

--- a/src/java/org/jivesoftware/spark/ui/ChatContainer.java
+++ b/src/java/org/jivesoftware/spark/ui/ChatContainer.java
@@ -778,6 +778,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
             final ContainerComponent comp = (ContainerComponent)o;
             chatFrame.setTitle(comp.getFrameTitle());
             chatFrame.setIconImage(comp.getTabIcon().getImage());
+
             SparkManager.getChatManager().notifySparkTabHandlers(comp.getGUI());
         }
     }
@@ -1017,7 +1018,6 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
     public void fireChatRoomStateUpdated(final ChatRoom room) {
         final int index = indexOfComponent(room);
         if (index != -1) {
-	
             SparkManager.getChatManager().notifySparkTabHandlers(room);
         }
     }
@@ -1035,8 +1035,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
                     SparkManager.getNativeManager().stopFlashing(chatFrame);
 
                     // Notify decorators
-                    //SparkManager.getChatManager().notifySparkTabHandlers(component);
-		    SparkManager.getChatManager().notifySparkBroadcastTabHandlers(component);
+                    SparkManager.getChatManager().notifySparkTabHandlers(component);
                 }
                 catch (Exception ex) {
                     Log.error("Could not stop flashing because " + ex.getMessage(), ex);

--- a/src/java/org/jivesoftware/spark/ui/SparkTabHandler.java
+++ b/src/java/org/jivesoftware/spark/ui/SparkTabHandler.java
@@ -33,8 +33,8 @@ import java.awt.Color;
  */
 public abstract class SparkTabHandler {
 
-    public abstract boolean isTabHandled(SparkTab tab, Component component, boolean isSelectedTab, boolean chatFrameFocused );
-    public abstract boolean isTabBroadcastHandled(SparkTab tab, Component component, boolean isSelectedTab, boolean chatFrameFocused);
+    public abstract boolean isTabHandled(SparkTab tab, Component component, boolean isSelectedTab, boolean chatFrameFocused);
+
     /**
      * Updates the SparkTab to show it is in a stale state.
      *

--- a/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -327,7 +327,6 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, PacketLi
 	    chatRoom = (ChatRoomImpl)container.getChatRoom(jid);
 	}
 	catch (ChatRoomNotFoundException e) {
-
 	    chatRoom = new ChatRoomImpl(jid, nickname, nickname);
 	    SparkManager.getChatManager().getChatContainer().addChatRoom(chatRoom);
 	}
@@ -385,7 +384,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, PacketLi
 	            broadcastRooms.remove(room);
 
 	            // Notify decorators
-	            SparkManager.getChatManager().notifySparkBroadcastTabHandlers(room);
+	            SparkManager.getChatManager().notifySparkTabHandlers(room);
 	            waiting = false;
 	        }
 	    }
@@ -415,8 +414,34 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, PacketLi
     }
 
 
-    public boolean isTabHandled(SparkTab tab, Component component, boolean isSelectedTab, boolean chatFrameFocused , boolean isBroadcast) {
-    return false;
+    public boolean isTabHandled(SparkTab tab, Component component, boolean isSelectedTab, boolean chatFrameFocused) {
+        if (component instanceof ChatRoom) {
+            ChatRoom chatroom = (ChatRoom)component;
+            if (broadcastRooms.contains(chatroom)) {
+                final ChatRoomImpl room = (ChatRoomImpl)component;
+                tab.setIcon(SparkRes.getImageIcon(SparkRes.INFORMATION_IMAGE));
+                String nickname = room.getTabTitle();
+                nickname = Res.getString("message.broadcast.from", nickname);
+                tab.setTabTitle(nickname);
+
+
+                if ((!chatFrameFocused || !isSelectedTab) && room.getUnreadMessageCount() > 0) {
+                    // Make tab red.
+                    tab.setTitleColor(Color.red);
+                    tab.setTabBold(true);
+                }
+                else {
+                    tab.setTitleColor(Color.black);
+                    tab.setTabFont(tab.getDefaultFont());
+                    room.clearUnreadMessageCount();
+                }
+
+
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -495,50 +520,4 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, PacketLi
 	alert.toFront();
 	alert.requestFocus();
     }
-
-	
-
-	
-	public boolean isTabBroadcastHandled(SparkTab tab, Component component,
-			boolean isSelectedTab, boolean chatFrameFocused ) {
-		// TODO Auto-generated method stub
-        if (component instanceof ChatRoom) {
-            ChatRoom chatroom = (ChatRoom)component;
-
-            if (broadcastRooms.contains(chatroom)) {
-                final ChatRoomImpl room = (ChatRoomImpl)component;
-                tab.setIcon(SparkRes.getImageIcon(SparkRes.INFORMATION_IMAGE));
-                String nickname = room.getTabTitle();
-                nickname = Res.getString("message.broadcast.from", nickname);
-                tab.setTabTitle(nickname);
-
-                if (!chatFrameFocused || !isSelectedTab) {
-                    // Make tab red.
-		 if(room.getUnreadMessageCount() > 0)
-		 {
-                    tab.setTitleColor(Color.red);
-                    tab.setTabBold(true);
-		 }
-                }
-                else {
-                    tab.setTitleColor(Color.black);
-                    tab.setTabFont(tab.getDefaultFont());
-                    room.clearUnreadMessageCount();
-                }
-
-
-                return true;
-            }
-        }
-
-        return false;
-		
-	}
-
-	@Override
-	public boolean isTabHandled(SparkTab tab, Component component,
-			boolean isSelectedTab, boolean chatFrameFocused) {
-		// TODO Auto-generated method stub
-		return false;
-	}
 }


### PR DESCRIPTION
Reverts igniterealtime/Spark#98

Looks like Fastpath is again in the way. It is using SparkTabHandler and these changes cause Bamboo not to build:
[javac] /opt/j2ee/domains/igniterealtime.org/bamboo/atlassian-bamboo-5.9.7/data/xml-data/build-dir/SPARK-INSTALL4J-JOB1/src/plugins/fastpath/src/java/org/jivesoftware/fastpath/FastpathTabHandler.java:36: error: FastpathTabHandler is not abstract and does not override abstract method isTabBroadcastHandled(SparkTab,Component,boolean,boolean) in SparkTabHandler
03-Mar-2016 12:53:37 	    [javac] public class FastpathTabHandler extends SparkTabHandler {