### PR TITLE
Revert "Fix for Spark-1714"

### DIFF
--- a/src/java/org/jivesoftware/sparkimpl/plugin/scratchpad/PrivateNotes.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/scratchpad/PrivateNotes.java
@@ -39,17 +39,16 @@ public class PrivateNotes implements PrivateData {
      */
     public PrivateNotes() {
     }
-     
+
+
     public String getNotes() {
         return notes;
     }
 
     public void setNotes(String notes) {
-	this.notes=notes.replaceAll("&","&amp;");
+        this.notes = notes;
     }
-    public void setMyNotes(String notes) {
-	this.notes=notes;
-    }
+
 
     /**
      * Returns the root element name.
@@ -122,8 +121,8 @@ public class PrivateNotes implements PrivateData {
     }
 
     public static void savePrivateNotes(PrivateNotes notes) {
-	PrivateDataManager manager = new PrivateDataManager(SparkManager.getConnection());
-	
+        PrivateDataManager manager = new PrivateDataManager(SparkManager.getConnection());
+
         PrivateDataManager.addPrivateDataProvider("scratchpad", "scratchpad:notes", new PrivateNotes.Provider());
         try {
             manager.setPrivateData(notes);
@@ -146,9 +145,7 @@ public class PrivateNotes implements PrivateData {
         catch (XMPPException e) {
             Log.error(e);
         }
-	String note=notes.getNotes().replaceAll("&amp;","&");
-        notes.setMyNotes(note);
-        
+
         return notes;
     }
 }


### PR DESCRIPTION
Reverts igniterealtime/Spark#104
Can't open Notes at all after applying this patch. I think my notes were empty before that. No error is generated in the logs.