### PR TITLE
Move to File separator Jira-1699

### DIFF
--- a/src/java/org/jivesoftware/sparkimpl/plugin/filetransfer/transfer/ui/ReceiveFileTransfer.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/filetransfer/transfer/ui/ReceiveFileTransfer.java
@@ -502,7 +502,7 @@ public class ReceiveFileTransfer extends JPanel {
             }
 
             public void mousePressed(MouseEvent e) {
-                launchFile(Downloads.getDownloadDirectory()+"\\"+request.getFileName());
+                launchFile(Downloads.getDownloadDirectory()+File.separator+request.getFileName());
             }
         });
 
@@ -768,7 +768,7 @@ public class ReceiveFileTransfer extends JPanel {
             return;
         Desktop dt = Desktop.getDesktop();
         try {
-            dt.browse(getFileURI(filePath));
+	    dt.browse(getFileURI(filePath));
         } catch (Exception ex) {
             ex.printStackTrace();
         }


### PR DESCRIPTION
Changed "//" to File.separator for support both Windows and unix