### PR TITLE
Duplicate conditional in NetworkAddressManager.java

### DIFF
--- a/src/plugins/sip/src/java/net/java/sipmack/sip/NetworkAddressManager.java
+++ b/src/plugins/sip/src/java/net/java/sipmack/sip/NetworkAddressManager.java
@@ -353,7 +353,7 @@ public class NetworkAddressManager {
             InetAddressWrapper other = o;
 
             if (this.value < other.getValue()) return -1;
-            else if (this.value < other.getValue()) return 0;
+            else if (this.value == other.getValue()) return 0;
             else return 1;
         }
     }


### PR DESCRIPTION
Looks like this should be `==` when returning 0.