### PR TITLE
Remove path to old ant version and assume it is in the PATH

### DIFF
--- a/build/rpm/spark.spec
+++ b/build/rpm/spark.spec
@@ -23,7 +23,7 @@ Instant Messenger
 
 %build
 cd build
-/opt/apache-ant-1.8.1/bin/ant jar
+ant jar
 cd ..
 
 


### PR DESCRIPTION
The rpm spec file needed ant 1.8.1 to be installed in /opt. I'd rather it assumed that an ant is in the $PATH somewhere. Unless someone thinks it needs a feature from ant 1.8.1??