### PR TITLE
Remove %dir from spark binary in RPM spec

### DIFF
--- a/build/rpm/spark.spec
+++ b/build/rpm/spark.spec
@@ -56,7 +56,7 @@ exit 0
 
 
 %files
-%dir /usr/bin/spark
+%attr(0755, root, root) /usr/bin/spark
 %dir /usr/share/spark/bin
 %dir /usr/share/spark
 %dir /usr/share/spark/xtra


### PR DESCRIPTION
Build says : 
[rpm] RPM build errors:
[rpm] error: Not a directory: /var/atlassian/bamboo-home/xml-data/build-dir/SPARK-NIGHTLYRPM-JOB1/work/rpm/BUILDROOT/Spark-2.7.7.841-1.x86_64/usr/bin/spark

Because it was a %dir. Changed to a file with 755 permission and owned by root. 