### PR TITLE
SPARK-1750: Spark should reconnect by default.

### DIFF
--- a/src/java/org/jivesoftware/LoginDialog.java
+++ b/src/java/org/jivesoftware/LoginDialog.java
@@ -292,8 +292,9 @@ public class LoginDialog {
             }
         }
 
+        ReconnectionManager.setEnabledPerDefault( true );
+
         // TODO These were used in Smack 3. Find Smack 4 alternative.
-//        config.setReconnectionAllowed(true);
 //        config.setRosterLoadedAtLogin(true);
 //        if(ModelUtil.hasLength(localPref.getTrustStorePath())) {
 //        	config.setTruststorePath(localPref.getTrustStorePath());

--- a/src/java/org/jivesoftware/spark/util/SwingWorker.java
+++ b/src/java/org/jivesoftware/spark/util/SwingWorker.java
@@ -21,6 +21,8 @@ package org.jivesoftware.spark.util;
 
 
 
+import org.jivesoftware.spark.util.log.Log;
+
 import javax.swing.SwingUtilities;
 
 /**
@@ -138,6 +140,9 @@ public abstract class SwingWorker {
         Runnable doConstruct = () -> {
             try {
                         setValue(construct());
+            }
+            catch ( Exception e ) {
+                Log.error( e );
             }
             finally {
                 threadVar.clear();


### PR DESCRIPTION
This commit restored the automatic reconnection that's attempted
by Spark, when an XMPP connection unexpectedly fails. The commit
makes use of a construct offered by Smack (which was changed from
Smack 3 to 4).