### PR TITLE
SPARK-1752: File transfer manager should always be initialized

### DIFF
--- a/src/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
+++ b/src/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
@@ -147,37 +147,12 @@ public class SparkTransferManager {
             @Override
             public void connected( XMPPConnection xmppConnection )
             {
-
             }
 
             @Override
             public void authenticated( XMPPConnection xmppConnection, boolean b )
             {
                 transferManager = FileTransferManager.getInstanceFor( SparkManager.getConnection() );
-
-                final ContactList contactList = SparkManager.getWorkspace().getContactList();
-
-                // Create the listener
-                transferManager.addFileTransferListener( request -> SwingUtilities.invokeLater( () -> handleTransferRequest(request, contactList) ) );
-
-                // Add Send File to Chat Room
-                addSendFileButton();
-
-                contactList.addFileDropListener( ( files, component ) -> {
-                    if (component instanceof ContactItem) {
-                        ContactItem item = (ContactItem)component;
-
-                        ChatRoom chatRoom = null;
-                        for (File file : files) {
-                            chatRoom = sendFile(file, item.getJID());
-                        }
-
-                        if (chatRoom != null) {
-                            SparkManager.getChatManager().getChatContainer().activateChatRoom(chatRoom);
-                        }
-                    }
-                } );
-
             }
 
             public void connectionClosed() {
@@ -197,6 +172,30 @@ public class SparkTransferManager {
             public void reconnectionFailed(Exception e) {
             }
         });
+
+        final ContactList contactList = SparkManager.getWorkspace().getContactList();
+
+        // Create the listener
+        transferManager = FileTransferManager.getInstanceFor( SparkManager.getConnection() );
+        transferManager.addFileTransferListener( request -> SwingUtilities.invokeLater( () -> handleTransferRequest(request, contactList) ) );
+
+        // Add Send File to Chat Room
+        addSendFileButton();
+
+        contactList.addFileDropListener( ( files, component ) -> {
+            if (component instanceof ContactItem) {
+                ContactItem item = (ContactItem)component;
+
+                ChatRoom chatRoom = null;
+                for (File file : files) {
+                    chatRoom = sendFile(file, item.getJID());
+                }
+
+                if (chatRoom != null) {
+                    SparkManager.getChatManager().getChatContainer().activateChatRoom(chatRoom);
+                }
+            }
+        } );
 
         try {
             robot = new Robot();


### PR DESCRIPTION
The file transfer manager should, if enabled, always get initialized.
The old code depended on a authentication to succeed. However, if that
occurred before the file transfer manager was invoked, initialization
would never occur.