### PR TITLE
Spark-1812 Vcard fields not updating automatically when viewing a profile

### DIFF
--- a/src/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/src/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -773,6 +773,7 @@ public class VCardManager {
             VCardProvider provider = new VCardProvider();
             parser.setInput(in);
             parser.next(); // progress past the first start tag.
+            parser.next();
             VCard vcard = provider.parse(parser);
 
             // Check to see if the file is older 10 minutes. If so, reload.


### PR DESCRIPTION
I read there might be a bug in the parser cause it to not always advance .  a workaround appears to be to add another next().  This resolved the issue for me in my testing.