### PR TITLE
SPARK-1822 - Added new settings to disable certain GUI menu items

### DIFF
--- a/src/java/org/jivesoftware/LoginDialog.java
+++ b/src/java/org/jivesoftware/LoginDialog.java
@@ -460,9 +460,13 @@ public class LoginDialog {
                     new GridBagConstraints(1, 6, 2, 1, 1.0, 0.0,
                             GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL, new Insets(5, 5, 0, 5), 0, 0));
             }
-	    add(loginAsInvisibleBox,
+            
+            // Add option to hide "Login as invisible" selection on the login screen
+            if(!Default.getBoolean("HIDE_LOGIN_AS_INVISIBLE")) {            
+            	add(loginAsInvisibleBox,
                     new GridBagConstraints(1, 7, 2, 1, 1.0, 0.0,
                             GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL, new Insets(5, 5, 0, 5), 0, 0));
+            }
 
             // Add button but disable the login button initially
             savePasswordBox.addActionListener(this);

--- a/src/java/org/jivesoftware/MainWindow.java
+++ b/src/java/org/jivesoftware/MainWindow.java
@@ -474,9 +474,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         
         final boolean maintMode = (myMaintFile.exists() && !myMaintFile.isDirectory())? true:false;
         
-        if (!Default.getBoolean("DISABLE_PREFERENCES_MENU_ITEM") || maintMode) {
-            connectMenu.add(preferenceMenuItem);
-        }        
+        if (!Default.getBoolean("DISABLE_PREFERENCES_MENU_ITEM") || maintMode) connectMenu.add(preferenceMenuItem);
 
         alwaysOnTopItem = new JCheckBoxMenuItem();
         ResourceUtils.resButton(alwaysOnTopItem, Res.getString("menuitem.always.on.top"));

--- a/src/java/org/jivesoftware/MainWindow.java
+++ b/src/java/org/jivesoftware/MainWindow.java
@@ -461,8 +461,22 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         preferenceMenuItem = new JMenuItem(SparkRes.getImageIcon(SparkRes.PREFERENCES_IMAGE));
         preferenceMenuItem.setText(Res.getString("title.spark.preferences"));
         preferenceMenuItem.addActionListener(this);
-        connectMenu.add(preferenceMenuItem);
 
+        /******************************************************************************************************/
+        /* Show the "Preferences" menu item ONLY under the following conditions:                              */
+        /*                                                                                                    */
+        /*   1) We're currently in Maintenance Mode                                                           */
+        /*                          OR                                                                        */
+        /*   2) DISABLE_PREFERENCES_MENU_ITEM = false                                                         */
+        /******************************************************************************************************/
+        
+        File myMaintFile = new File(Default.getString(Default.MAINT_FILESPEC));
+        
+        final boolean maintMode = (myMaintFile.exists() && !myMaintFile.isDirectory())? true:false;
+        
+        if (!Default.getBoolean("DISABLE_PREFERENCES_MENU_ITEM") || maintMode) {
+            connectMenu.add(preferenceMenuItem);
+        }        
 
         alwaysOnTopItem = new JCheckBoxMenuItem();
         ResourceUtils.resButton(alwaysOnTopItem, Res.getString("menuitem.always.on.top"));

--- a/src/java/org/jivesoftware/resource/Default.java
+++ b/src/java/org/jivesoftware/resource/Default.java
@@ -104,6 +104,8 @@ public class Default {
     public static final String HISTORY_DISABLED = "HISTORY_DISABLED";
     public static final String HIDE_HISTORY_SETTINGS = "HIDE_HISTORY_SETTINGS";
     public static final String HIDE_SAVE_PASSWORD_AND_AUTOLOGIN = "HIDE_SAVE_PASSWORD_AND_AUTOLOGIN";
+    public static final String MAINT_FILESPEC = "MAINT_FILESPEC";
+    public static final String HIDE_LOGIN_AS_INVISIBLE = "HIDE_LOGIN_AS_INVISIBLE";
 
     static ClassLoader cl = SparkRes.class.getClassLoader();
 

--- a/src/java/org/jivesoftware/resource/default.properties
+++ b/src/java/org/jivesoftware/resource/default.properties
@@ -99,8 +99,8 @@ MAINT_FILESPEC =
 # If true, don't allow user to manually change presence status
 DISABLE_PRESENCE_STATUS_BAR = false
 
-# If true, disable the OPEN, HIDE and STATUS options in system tray 
-DISABLE_OPEN_HIDE_STATUS_IN_SYSTRAY = false
+# If true, disable the "Status" option in the system tray
+DISABLE_STATUS_IN_SYSTRAY = false
 
 # If true, disable the "Broadcast message" menu item
 DISABLE_BROADCAST_MENU_ITEM = false

--- a/src/java/org/jivesoftware/resource/default.properties
+++ b/src/java/org/jivesoftware/resource/default.properties
@@ -8,7 +8,7 @@ APPLICATION_NAME = Spark
 SHORT_NAME = Spark
 
 ############# Auto Set During Build #############
-APPLICATION_VERSION = 2.7.7
+APPLICATION_VERSION = 2.8.1
 # Passed into ant via cmd line argument:
 #   -Dbuild.number=<build number>
 # If not passed in, this field is ignored.
@@ -84,6 +84,32 @@ DISABLE_UPDATES =
 # If true, Spark cannot shut down
 # users wont be able to shut down Spark
 DISABLE_EXIT = 
+
+# If true, hides "Login as invisible" checkbox on the login screen
+HIDE_LOGIN_AS_INVISIBLE = false
+
+# If true, the "Preferences" menu item will be disabled
+DISABLE_PREFERENCES_MENU_ITEM = false
+
+# This allows an administrator to override the DISABLE_PREFERENCES_MENU_ITEM setting
+# The "Preferences" menu item will be enabled when the specified file exists
+# Specify the maintenance path/file here (i.e. \\\\server\\share\\filename.ext) 
+MAINT_FILESPEC = 
+
+# If true, don't allow user to manually change presence status
+DISABLE_PRESENCE_STATUS_BAR = false
+
+# If true, disable the OPEN, HIDE and STATUS options in system tray 
+DISABLE_OPEN_HIDE_STATUS_IN_SYSTRAY = false
+
+# If true, disable the "Broadcast message" menu item
+DISABLE_BROADCAST_MENU_ITEM = false
+
+# If true, remove the AVATAR tab in profile dialog
+DISABLE_AVATAR_TAB = false
+
+# If true, disable the "Plugins" menu item
+DISABLE_PLUGINS_MENU_ITEM = false
 
 #################################################
 ################## File Transfer ################

--- a/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -568,7 +568,10 @@ public class StatusBar extends JPanel implements VCardListener {
             add(statusLabel, new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 2, 0, 0), 0, 0));
 
             statusLabel.setFont(new Font(Font.DIALOG, Font.PLAIN, 11));
-            statusLabel.setIcon(SparkRes.getImageIcon(SparkRes.DOWN_ARROW_IMAGE));
+            
+        	// Add option to disable the presence status bar
+			if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_BAR")) statusLabel.setIcon(SparkRes.getImageIcon(SparkRes.DOWN_ARROW_IMAGE));
+			            
             statusLabel.setHorizontalTextPosition(JLabel.LEFT);
 
             setOpaque(false);
@@ -576,28 +579,29 @@ public class StatusBar extends JPanel implements VCardListener {
             final Border border = BorderFactory.createEmptyBorder(2, 2, 2, 2);
             setBorder(border);
 
+        	// Add option to disable the presence status bar
+            if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_BAR")) {
+            	statusLabel.addMouseListener(new MouseAdapter() {
+            		public void mouseReleased(MouseEvent e) {
+            			showPopup(e);
+            		}
+                
+            		public void mouseEntered(MouseEvent e) {
+            			setCursor(GraphicUtils.HAND_CURSOR);
+            			setBorder(BorderFactory.createBevelBorder(0));
+            		}
 
-            statusLabel.addMouseListener(new MouseAdapter() {
-                public void mouseReleased(MouseEvent e) {
-                	// Add option to disable the presence status bar
-                	if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_BAR")) showPopup(e);
-                }
+            		public void mouseExited(MouseEvent e) {
+            			setCursor(GraphicUtils.DEFAULT_CURSOR);
+            			setBorder(border);
+            		}
 
-                public void mouseEntered(MouseEvent e) {
-                    setCursor(GraphicUtils.HAND_CURSOR);
-
-                    setBorder(BorderFactory.createBevelBorder(0));
-                }
-
-                public void mouseExited(MouseEvent e) {
-                    setCursor(GraphicUtils.DEFAULT_CURSOR);
-                    setBorder(border);
-                }
-
-                public void mousePressed(MouseEvent e) {
-                    setBorder(BorderFactory.createBevelBorder(1));
-                }
-            });
+            		public void mousePressed(MouseEvent e) {
+            			setBorder(BorderFactory.createBevelBorder(1));
+            		}
+                	
+            	});
+            }            
 
         }
 

--- a/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -579,7 +579,8 @@ public class StatusBar extends JPanel implements VCardListener {
 
             statusLabel.addMouseListener(new MouseAdapter() {
                 public void mouseReleased(MouseEvent e) {
-                    showPopup(e);
+                	// Add option to disable the presence status bar
+                	if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_BAR")) showPopup(e);
                 }
 
                 public void mouseEntered(MouseEvent e) {

--- a/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -118,6 +118,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
         final JMenu actionsMenu = SparkManager.getMainWindow().getMenuByName(Res.getString("menuitem.actions"));
         JMenuItem broadcastMenu = new JMenuItem(Res.getString("title.broadcast.message"), SparkRes.getImageIcon(SparkRes.MEGAPHONE_16x16));
         ResourceUtils.resButton(broadcastMenu, Res.getString("title.broadcast.message"));
+        
         // See if we should disable the "Broadcast" menu item
         if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) actionsMenu.add(broadcastMenu);
         broadcastMenu.addActionListener( e -> broadcastToRoster() );

--- a/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -118,7 +118,8 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
         final JMenu actionsMenu = SparkManager.getMainWindow().getMenuByName(Res.getString("menuitem.actions"));
         JMenuItem broadcastMenu = new JMenuItem(Res.getString("title.broadcast.message"), SparkRes.getImageIcon(SparkRes.MEGAPHONE_16x16));
         ResourceUtils.resButton(broadcastMenu, Res.getString("title.broadcast.message"));
-        actionsMenu.add(broadcastMenu);
+        // See if we should disable the "Broadcast" menu item
+        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) actionsMenu.add(broadcastMenu);
         broadcastMenu.addActionListener( e -> broadcastToRoster() );
 
         // Register with action menu

--- a/src/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
@@ -133,8 +133,7 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatManagerListener
 			.getImageIcon(SparkRes.TRAY_CONNECTING);
 	    }
 	    
-	    // Check if we should disable the Open, Hide and Status options in system tray
-	    if (!Default.getBoolean("DISABLE_OPEN_HIDE_STATUS_IN_SYSTRAY")) popupMenu.add( openMenu );
+	    popupMenu.add( openMenu );
 	    
 	    openMenu.addActionListener( new AbstractAction() {
 
@@ -148,8 +147,7 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatManagerListener
 
 	    });
 	    
-  	    // Check if we should disable the Open, Hide and Status options in system tray	    
-	    if (!Default.getBoolean("DISABLE_OPEN_HIDE_STATUS_IN_SYSTRAY")) popupMenu.add( minimizeMenu );
+	    popupMenu.add( minimizeMenu );
 	    
 	    minimizeMenu.addActionListener( new AbstractAction() {
 		private static final long serialVersionUID = 1L;
@@ -160,8 +158,8 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatManagerListener
 		}
 	    });
 	    
-	    // Check if we should disable the Open, Hide and Status options in system tray	    
-	    if (!Default.getBoolean("DISABLE_OPEN_HIDE_STATUS_IN_SYSTRAY")) {	    
+	    // Check if we should disable the "Status" option in the system tray icon	    
+	    if (!Default.getBoolean("DISABLE_STATUS_IN_SYSTRAY")) {	    
 	    	popupMenu.addSeparator();
 	    	addStatusMessages();
 	    	popupMenu.add(statusMenu);

--- a/src/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
@@ -132,8 +132,10 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatManagerListener
 		connectingIcon = SparkRes
 			.getImageIcon(SparkRes.TRAY_CONNECTING);
 	    }
-
-	    popupMenu.add( openMenu );
+	    
+	    // Check if we should disable the Open, Hide and Status options in system tray
+	    if (!Default.getBoolean("DISABLE_OPEN_HIDE_STATUS_IN_SYSTRAY")) popupMenu.add( openMenu );
+	    
 	    openMenu.addActionListener( new AbstractAction() {
 
 		private static final long serialVersionUID = 1L;
@@ -145,7 +147,10 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatManagerListener
 		}
 
 	    });
-	    popupMenu.add( minimizeMenu );
+	    
+  	    // Check if we should disable the Open, Hide and Status options in system tray	    
+	    if (!Default.getBoolean("DISABLE_OPEN_HIDE_STATUS_IN_SYSTRAY")) popupMenu.add( minimizeMenu );
+	    
 	    minimizeMenu.addActionListener( new AbstractAction() {
 		private static final long serialVersionUID = 1L;
 
@@ -154,9 +159,14 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatManagerListener
 		    SparkManager.getMainWindow().setVisible(false);
 		}
 	    });
-	    popupMenu.addSeparator();
-	    addStatusMessages();
-	    popupMenu.add(statusMenu);
+	    
+	    // Check if we should disable the Open, Hide and Status options in system tray	    
+	    if (!Default.getBoolean("DISABLE_OPEN_HIDE_STATUS_IN_SYSTRAY")) {	    
+	    	popupMenu.addSeparator();
+	    	addStatusMessages();
+	    	popupMenu.add(statusMenu);
+	    }
+	    
 	    statusMenu.addActionListener(new AbstractAction() {
 		private static final long serialVersionUID = 1L;
 

--- a/src/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -202,8 +202,9 @@ public class PluginViewer extends JPanel implements Plugin {
         viewAction.putValue(Action.NAME, Res.getString("menuitem.plugins"));
         viewAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.PLUGIN_IMAGE));
         viewPluginsMenu.setAction(viewAction);
-
-        sparkMenu.insert(viewPluginsMenu, 2);
+        
+        // See if we should disable the "Plugins" menu item
+        if (!Default.getBoolean("DISABLE_PLUGINS_MENU_ITEM")) sparkMenu.insert(viewPluginsMenu, 2);
     }
 
     private boolean uninstall(final PublicPlugin plugin) {

--- a/src/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
+++ b/src/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
@@ -54,6 +54,7 @@ import org.jivesoftware.spark.ui.status.StatusBar;
 import org.jivesoftware.spark.util.GraphicUtils;
 import org.jivesoftware.spark.util.ModelUtil;
 import org.jivesoftware.spark.util.log.Log;
+import org.jivesoftware.resource.Default;
 
 /**
  * Handles the UI for viewing and editing of VCard information.
@@ -92,8 +93,11 @@ public class VCardEditor {
 	homePanel = new HomePanel();
 	tabbedPane.addTab(Res.getString("tab.home"), homePanel);
 
-	avatarPanel = new AvatarPanel();
-	tabbedPane.addTab(Res.getString("tab.avatar"), avatarPanel);
+	// See if we should remove the Avatar tab in profile dialog
+	if (!Default.getBoolean("DISABLE_AVATAR_TAB")) {	
+		avatarPanel = new AvatarPanel();
+		tabbedPane.addTab(Res.getString("tab.avatar"), avatarPanel);
+	}
 
 	// Build the UI
 	buildUI(vCard);
@@ -149,7 +153,10 @@ public class VCardEditor {
 	};
 
 	pane.addPropertyChangeListener(changeListener);
-	avatarPanel.setParentDialog(dlg);
+	
+	// See if we should remove the Avatar tab in profile dialog	
+	if (!Default.getBoolean("DISABLE_AVATAR_TAB")) avatarPanel.setParentDialog(dlg);
+	
 	dlg.setVisible(true);
 	dlg.toFront();
 	dlg.requestFocus();
@@ -183,10 +190,13 @@ public class VCardEditor {
 	homePanel.allowEditing(false);
 	tabbedPane.addTab(Res.getString("tab.home"), homePanel);
 
-	avatarPanel = new AvatarPanel();
-	avatarPanel.allowEditing(false);
-	tabbedPane.addTab(Res.getString("tab.avatar"), avatarPanel);
-
+	// See if we should remove the Avatar tab in profile dialog
+	if (!Default.getBoolean("DISABLE_AVATAR_TAB")) {	
+		avatarPanel = new AvatarPanel();
+		avatarPanel.allowEditing(false);
+		tabbedPane.addTab(Res.getString("tab.avatar"), avatarPanel);
+	}
+	
 	// Build the UI
 	buildUI(vCard);
 	


### PR DESCRIPTION
This PR will allow the following 8 new settings in the **default.properties** file:

- **HIDE_LOGIN_AS_INVISIBLE**
- **DISABLE_PREFERENCES_MENU_ITEM**
- **MAINT_FILESPEC**
- **DISABLE_PRESENCE_STATUS_BAR**
- **DISABLE_STATUS_IN_SYSTRAY**
- **DISABLE_BROADCAST_MENU_ITEM**
- **DISABLE_AVATAR_TAB**
- **DISABLE_PLUGINS_MENU_ITEM**

These allow the administrator increased control over the Spark client installation. Comments in the **default.properties** file describe each setting.