### PR TITLE
SPARK-1822 - Add additional default properties to control GUI settings

### DIFF
--- a/src/java/org/jivesoftware/resource/Default.java
+++ b/src/java/org/jivesoftware/resource/Default.java
@@ -105,7 +105,6 @@ public class Default {
     public static final String HIDE_HISTORY_SETTINGS = "HIDE_HISTORY_SETTINGS";
     public static final String HIDE_SAVE_PASSWORD_AND_AUTOLOGIN = "HIDE_SAVE_PASSWORD_AND_AUTOLOGIN";
     public static final String MAINT_FILESPEC = "MAINT_FILESPEC";
-    public static final String HIDE_LOGIN_AS_INVISIBLE = "HIDE_LOGIN_AS_INVISIBLE";
 
     static ClassLoader cl = SparkRes.class.getClassLoader();
 

--- a/src/java/org/jivesoftware/resource/default.properties
+++ b/src/java/org/jivesoftware/resource/default.properties
@@ -92,20 +92,18 @@ HIDE_LOGIN_AS_INVISIBLE = false
 DISABLE_PREFERENCES_MENU_ITEM = false
 
 # This allows an administrator to override the DISABLE_PREFERENCES_MENU_ITEM setting
-# The "Preferences" menu item will be enabled when the specified file exists
-# Specify the maintenance path/file here (i.e. \\\\server\\share\\filename.ext) 
-MAINT_FILESPEC = 
+# The "Preferences" menu item will become enabled when the specified file exists
+# Specify the maintenance path/file here (i.e. \\\\server\\share\\filename.ext)
+# It is best to place this file on a read-only network share
+MAINT_FILESPEC =
 
 # If true, don't allow user to manually change presence status
-DISABLE_PRESENCE_STATUS_BAR = false
+DISABLE_PRESENCE_STATUS_CHANGE = false
 
-# If true, disable the "Status" option in the system tray
-DISABLE_STATUS_IN_SYSTRAY = false
-
-# If true, disable the "Broadcast message" menu item
+# If true, disable all "Broadcast" menu items
 DISABLE_BROADCAST_MENU_ITEM = false
 
-# If true, remove the AVATAR tab in profile dialog
+# If true, remove the "Avatar" tab in profile dialog
 DISABLE_AVATAR_TAB = false
 
 # If true, disable the "Plugins" menu item

--- a/src/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/src/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1668,7 +1668,8 @@ moveToOffline(moveToOfflineContactItem);
 
         fireContextMenuListenerPopup(popup, items);
 
-        popup.add(sendMessagesMenu);
+        // See if we should disable all "Broadcast" menu items
+        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) popup.add(sendMessagesMenu);
 
         sendMessagesMenu.addActionListener( e1 -> sendMessages(items) );
 

--- a/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -569,8 +569,8 @@ public class StatusBar extends JPanel implements VCardListener {
 
             statusLabel.setFont(new Font(Font.DIALOG, Font.PLAIN, 11));
             
-        	// Add option to disable the presence status bar
-			if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_BAR")) statusLabel.setIcon(SparkRes.getImageIcon(SparkRes.DOWN_ARROW_IMAGE));
+            // See if we should disable ability to change presence status
+			if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE")) statusLabel.setIcon(SparkRes.getImageIcon(SparkRes.DOWN_ARROW_IMAGE));
 			            
             statusLabel.setHorizontalTextPosition(JLabel.LEFT);
 
@@ -579,8 +579,8 @@ public class StatusBar extends JPanel implements VCardListener {
             final Border border = BorderFactory.createEmptyBorder(2, 2, 2, 2);
             setBorder(border);
 
-        	// Add option to disable the presence status bar
-            if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_BAR")) {
+        	// See if we should disable ability to change presence status
+            if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE")) {
             	statusLabel.addMouseListener(new MouseAdapter() {
             		public void mouseReleased(MouseEvent e) {
             			showPopup(e);

--- a/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -119,8 +119,9 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
         JMenuItem broadcastMenu = new JMenuItem(Res.getString("title.broadcast.message"), SparkRes.getImageIcon(SparkRes.MEGAPHONE_16x16));
         ResourceUtils.resButton(broadcastMenu, Res.getString("title.broadcast.message"));
         
-        // See if we should disable the "Broadcast" menu item
+        // See if we should disable all "Broadcast" menu items
         if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) actionsMenu.add(broadcastMenu);
+        
         broadcastMenu.addActionListener( e -> broadcastToRoster() );
 
         // Register with action menu
@@ -173,7 +174,9 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
 
                     broadcastMessageAction.putValue(Action.NAME, Res.getString("menuitem.broadcast.to.group"));
                     broadcastMessageAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.MEGAPHONE_16x16));
-                    popup.add(broadcastMessageAction);
+
+                    // See if we should disable all "Broadcast" menu items
+                    if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) popup.add(broadcastMessageAction);
                 }
             }
 

--- a/src/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
@@ -20,6 +20,7 @@
 package org.jivesoftware.sparkimpl.plugin.chat;
 
 import org.jivesoftware.resource.Res;
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.roster.Roster;
 import org.jivesoftware.smack.roster.RosterEntry;
@@ -148,7 +149,9 @@ public class ContactListAssistantPlugin implements Plugin {
                         popup.addSeparator();
                         popup.add(moveToMenu);
                         popup.add(copyToMenu);
-                        popup.addSeparator();
+                        
+                        // Clean up the extra separator if "Broadcast" menu items are disabled
+                        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) popup.addSeparator();                        
                     }
 
 

--- a/src/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
@@ -158,8 +158,8 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatManagerListener
 		}
 	    });
 	    
-	    // Check if we should disable the "Status" option in the system tray icon	    
-	    if (!Default.getBoolean("DISABLE_STATUS_IN_SYSTRAY")) {	    
+	    // See if we should disable ability to change presence status	    
+	    if (!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE")) {	    
 	    	popupMenu.addSeparator();
 	    	addStatusMessages();
 	    	popupMenu.add(statusMenu);

--- a/src/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
+++ b/src/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
@@ -352,18 +352,22 @@ public class VCardEditor {
 
         fillUI(vcard);
         
-	// Set avatar
-	byte[] bytes = vcard.getAvatar();
-	if (bytes != null && bytes.length > 0) {
-	    ImageIcon icon = new ImageIcon(bytes);
-	    avatarPanel.setAvatar(icon);
-	    avatarPanel.setAvatarBytes(bytes);
-	    if (avatarLabel != null) {
-		icon = GraphicUtils.scaleImageIcon(icon, 48, 48);
-
-		avatarLabel.setIcon(icon);
-	    }
-	}
+        // Set Avatar
+        byte[] bytes = vcard.getAvatar();
+        if (bytes != null && bytes.length > 0) {
+        	ImageIcon icon = new ImageIcon(bytes);
+	    
+        	// See if we should remove the Avatar tab in profile dialog	    
+        	if (!Default.getBoolean("DISABLE_AVATAR_TAB")) {	    
+        		avatarPanel.setAvatar(icon);
+        		avatarPanel.setAvatarBytes(bytes);
+        	}	    
+	    
+        	if (avatarLabel != null) {
+        		icon = GraphicUtils.scaleImageIcon(icon, 48, 48);
+        		avatarLabel.setIcon(icon);
+        	}
+        }
     }
 
     private void fillUI(VCard vcard){


### PR DESCRIPTION
The following additional settings in the _default.properties_ file are now available:

- HIDE_LOGIN_AS_INVISIBLE
- DISABLE_PREFERENCES_MENU_ITEM
- MAINT_FILESPEC
- DISABLE_PRESENCE_STATUS_CHANGE
- DISABLE_BROADCAST_MENU_ITEM
- DISABLE_AVATAR_TAB
- DISABLE_PLUGINS_MENU_ITEM
