### PR TITLE
SPARK-1758 - Do not show UNFILED group if it's empty

### DIFF
--- a/src/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/src/java/org/jivesoftware/spark/ui/ContactList.java
@@ -2572,8 +2572,9 @@ SwingUtilities.invokeLater( () -> loadContactList() );
         if (unfiledGroup == null) {
             // Add Unfiled Group
         	if(EventQueue.isDispatchThread()) {
-			unfiledGroup = UIComponentRegistry.createContactGroup(Res.getString("unfiled"));
-                addContactGroup(unfiledGroup);
+        		unfiledGroup = UIComponentRegistry.createContactGroup(Res.getString("unfiled"));
+        		// Only show the "Unfiled" group if it is not empty
+        		if (unfiledGroup.hasAvailableContacts()) addContactGroup(unfiledGroup);
         	}
         	else {
         		try {


### PR DESCRIPTION
This PR will resolve the issue of displaying an empty "Unfiled" group in Spark.
