### PR TITLE
SPARK-1822 - Add additional default properties to control GUI settings

### DIFF
--- a/src/java/org/jivesoftware/resource/default.properties
+++ b/src/java/org/jivesoftware/resource/default.properties
@@ -109,6 +109,27 @@ DISABLE_AVATAR_TAB = false
 # If true, disable the "Plugins" menu item
 DISABLE_PLUGINS_MENU_ITEM = false
 
+# If true, disable the option to transfer files
+DISABLE_FILE_XFER = false
+
+# If true, disable the option to remove contacts and groups in roster
+DISABLE_REMOVALS = false
+
+# If true, disable the option to rename contacts and groups in roster
+DISABLE_RENAMES = false
+
+# If true, disable the options to move and copy contacts
+DISABLE_MOVE_AND_COPY = false
+
+# If true, disable the option to edit the profile
+DISABLE_EDIT_PROFILE = false
+
+# If true, disable the "View notes" option under "Actions"
+DISABLE_VIEW_NOTES = false
+
+# If true, disable the "View task list" option under "Actions"
+DISABLE_VIEW_TASK_LIST = false
+
 #################################################
 ################## File Transfer ################
 #################################################

--- a/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
+++ b/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
@@ -19,6 +19,7 @@
  */
 package org.jivesoftware.spark.filetransfer;
 
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.spark.SparkManager;
 import org.jivesoftware.spark.ui.ChatRoom;
@@ -60,17 +61,18 @@ public class ChatRoomTransferDecorator implements KeyListener, FileDropListener,
         chatRoom.getChatInputEditor().addKeyListener(this);
         chatRoom.addClosingListener(this);
 
+        // See if we should disable the ability to transfer files
+        if (!Default.getBoolean("DISABLE_FILE_XFER")) {
+        	sendFileButton = UIComponentRegistry.getButtonFactory().createSendFileButton();
+        	sendFileButton.setToolTipText(Res.getString("message.send.file.to.user"));
 
-        sendFileButton = UIComponentRegistry.getButtonFactory().createSendFileButton();
-        sendFileButton.setToolTipText(Res.getString("message.send.file.to.user"));
-
-        chatRoom.addChatRoomButton(sendFileButton);
+        	chatRoom.addChatRoomButton(sendFileButton);
+        	sendFileButton.addActionListener(this);
+        }
 
         sendScreenShotButton = UIComponentRegistry.getButtonFactory().createScreenshotButton();
         sendScreenShotButton.setToolTipText(Res.getString("message.send.picture"));
         chatRoom.addChatRoomButton(sendScreenShotButton);
-
-        sendFileButton.addActionListener(this);
         sendScreenShotButton.addActionListener(this);
     }
 

--- a/src/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/src/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1379,14 +1379,20 @@ moveToOffline(moveToOfflineContactItem);
         JMenuItem rename = new JMenuItem(Res.getString("menuitem.rename"));
         JMenuItem expand = new JMenuItem(Res.getString("menuitem.expand.all.groups"));
         JMenuItem collapse = new JMenuItem(Res.getString("menuitem.collapse.all.groups"));
-        
+
         if (!group.isSharedGroup()) {
             popup.addSeparator();
-            popup.add(delete);
-            popup.add(rename);
+
+            // See if we should disable the "Delete" menu option
+            if (!Default.getBoolean("DISABLE_REMOVALS")) popup.add(delete);
+
+            // See if we should disable the "Rename" menu option
+            if (!Default.getBoolean("DISABLE_RENAMES")) popup.add(rename);
         }
-        
-        popup.addSeparator();
+
+        // Only display a horizontal separator if at least one of those options is present 
+        if (!Default.getBoolean("DISABLE_REMOVALS") || !Default.getBoolean("DISABLE_RENAMES")) popup.addSeparator();
+
         popup.add(expand);
         popup.add(collapse);
 
@@ -1499,15 +1505,14 @@ moveToOffline(moveToOfflineContactItem);
             }
         };
 
-        sendAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.DOCUMENT_16x16));
-        sendAction.putValue(Action.NAME, Res.getString("menuitem.send.a.file"));
-
-        if ((item.getPresence() != null) && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) {
-            popup.add(sendAction);
+        // See if we should disable the option to transfer files
+        if (!Default.getBoolean("DISABLE_FILE_XFER")) {
+        	sendAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.DOCUMENT_16x16));
+        	sendAction.putValue(Action.NAME, Res.getString("menuitem.send.a.file"));
+        	if ((item.getPresence() != null) && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) popup.add(sendAction);
         }
-
+        
         popup.addSeparator();
-
 
         String groupName = item.getGroupName();
         ContactGroup contactGroup = getContactGroup(groupName);
@@ -1551,13 +1556,13 @@ moveToOffline(moveToOfflineContactItem);
             }
         }
 
-
-        if (!contactGroup.isSharedGroup() && !isInSharedGroup) {
-            popup.add(removeAction);
+        // See if we should disable the option to remove a contact
+        if (!Default.getBoolean("DISABLE_REMOVALS")) {
+        	if (!contactGroup.isSharedGroup() && !isInSharedGroup) popup.add(removeAction);
         }
 
-        popup.add(renameMenu);
-
+        // See if we should disable the option to rename a contact
+        if (!Default.getBoolean("DISABLE_RENAMES")) popup.add(renameMenu); 
 
         Action viewProfile = new AbstractAction() {
 			private static final long serialVersionUID = -2562731455090634805L;

--- a/src/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/src/java/org/jivesoftware/spark/ui/ContactList.java
@@ -2572,8 +2572,9 @@ SwingUtilities.invokeLater( () -> loadContactList() );
         if (unfiledGroup == null) {
             // Add Unfiled Group
         	if(EventQueue.isDispatchThread()) {
-			unfiledGroup = UIComponentRegistry.createContactGroup(Res.getString("unfiled"));
-                addContactGroup(unfiledGroup);
+        		unfiledGroup = UIComponentRegistry.createContactGroup(Res.getString("unfiled"));
+        		// Only show the "Unfiled" group if it is not empty
+        		if (unfiledGroup.hasAvailableContacts()) addContactGroup(unfiledGroup);
         	}
         	else {
         		try {

--- a/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -149,24 +149,29 @@ public class StatusBar extends JPanel implements VCardListener {
             }
         } );
 
-        // Show profile on double click of image label
-        imageLabel.addMouseListener(new MouseAdapter() {
-            public void mouseClicked(MouseEvent mouseEvent) {
-                if (mouseEvent.getClickCount() == 1) {
-                    VCardManager vcardManager = SparkManager.getVCardManager();
-                    VCardEditor editor = new VCardEditor();
-                    editor.editProfile(vcardManager.getVCard(), SparkManager.getWorkspace());
-                }
-            }
+        // See if we should disable the option to edit the profile if clicking on the Avatar image
+        if (!Default.getBoolean("DISABLE_EDIT_PROFILE")) {
 
-            public void mouseEntered(MouseEvent e) {
-                imageLabel.setCursor(GraphicUtils.HAND_CURSOR);
-            }
+            // Show profile when clicking on Avatar image
+        	imageLabel.addMouseListener(new MouseAdapter() {
+        		public void mouseClicked(MouseEvent mouseEvent) {
+        			if (mouseEvent.getClickCount() == 1) {
+        				VCardManager vcardManager = SparkManager.getVCardManager();
+        				VCardEditor editor = new VCardEditor();
+        				editor.editProfile(vcardManager.getVCard(), SparkManager.getWorkspace());
+        			}
+        		}
 
-            public void mouseExited(MouseEvent e) {
-                imageLabel.setCursor(GraphicUtils.DEFAULT_CURSOR);
-            }
-        });
+        		public void mouseEntered(MouseEvent e) {
+        			imageLabel.setCursor(GraphicUtils.HAND_CURSOR);
+        		}
+
+        		public void mouseExited(MouseEvent e) {
+        			imageLabel.setCursor(GraphicUtils.DEFAULT_CURSOR);
+        		}
+        	});
+
+        }
 
         final TimerTask task = new SwingTimerTask() {
             public void doRun() {

--- a/src/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
@@ -141,20 +141,24 @@ public class ContactListAssistantPlugin implements Plugin {
                     if (contactItems.size() == 1) {
                         // Add right after the rename item.
                         if (index != -1) {
-                            popup.add(moveToMenu, index + 1);
-                            popup.add(copyToMenu, index + 2);
+                        	// See if we should disable the "Move to" and "Copy to" menu options
+                        	if (!Default.getBoolean("DISABLE_MOVE_AND_COPY")) {
+                        		popup.add(moveToMenu, index + 1);
+                        		popup.add(copyToMenu, index + 2);
+                        	}
                         }
                     }
                     else if (contactItems.size() > 1) {
-                        popup.addSeparator();
-                        popup.add(moveToMenu);
-                        popup.add(copyToMenu);
-                        
+                    	// See if we should disable the "Move to" and "Copy to" menu options
+                    	if (!Default.getBoolean("DISABLE_MOVE_AND_COPY")) {                    	
+                    		popup.addSeparator();
+                    		popup.add(moveToMenu);
+                    		popup.add(copyToMenu);
+                    	}                        
+
                         // Clean up the extra separator if "Broadcast" menu items are disabled
                         if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) popup.addSeparator();                        
                     }
-
-
                 }
             }
 

--- a/src/java/org/jivesoftware/sparkimpl/plugin/scratchpad/ScratchPadPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/scratchpad/ScratchPadPlugin.java
@@ -20,6 +20,7 @@
 package org.jivesoftware.sparkimpl.plugin.scratchpad;
 
 import org.jdesktop.swingx.calendar.DateUtils;
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.resource.SparkRes;
 import org.jivesoftware.spark.SparkManager;
@@ -115,9 +116,12 @@ public class ScratchPadPlugin implements Plugin {
             // Add To toolbar
             final JMenu actionsMenu = SparkManager.getMainWindow().getMenuByName(Res.getString("menuitem.actions"));
             actionsMenu.addSeparator();
-            actionsMenu.add(taskMenu);
-            actionsMenu.add(notesMenu);
 
+            // See if we should disable the "View task list" option under "Actions"
+            if (!Default.getBoolean("DISABLE_VIEW_TASK_LIST")) actionsMenu.add(taskMenu);
+
+            // See if we should disable the "View notes" option under "Actions"
+            if (!Default.getBoolean("DISABLE_VIEW_NOTES")) actionsMenu.add(notesMenu);
 
             // Start notifications.
             new TaskNotification();

--- a/src/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/src/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -19,6 +19,7 @@
  */
 package org.jivesoftware.sparkimpl.profile;
 
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.resource.SparkRes;
 import org.jivesoftware.smack.SmackException;
@@ -228,7 +229,9 @@ public class VCardManager {
 
         int size = contactsMenu.getMenuComponentCount();
 
-        communicatorMenu.insert(editProfileMenu, 1);
+        // See if we should disable the "Edit my profile" option under "File"
+        if (!Default.getBoolean("DISABLE_EDIT_PROFILE")) communicatorMenu.insert(editProfileMenu, 1);
+
         editProfileMenu.addActionListener( e -> {
             SwingWorker vcardLoaderWorker = new SwingWorker() {
                 public Object construct() {


### PR DESCRIPTION
Updated to include the following new settings in the _default.properties_ file:

_# If true, disable the option to transfer files_
**DISABLE_FILE_XFER = false**

_# If true, disable the option to remove contacts and groups in roster_
**DISABLE_REMOVALS = false**

_# If true, disable the option to rename contacts and groups in roster_
**DISABLE_RENAMES = false**

_# If true, disable the options to move and copy contacts_
**DISABLE_MOVE_AND_COPY = false**

_# If true, disable the option to edit the profile_
**DISABLE_EDIT_PROFILE = false**

_# If true, disable the "View notes" option under "Actions"_
**DISABLE_VIEW_NOTES = false**

_# If true, disable the "View task list" option under "Actions"_
**DISABLE_VIEW_TASK_LIST = false**