### PR TITLE
SPARK-1827 - Shouldn't allow broadcast to selected users when it is disabled in Client Control

### DIFF
--- a/src/java/org/jivesoftware/resource/default.properties
+++ b/src/java/org/jivesoftware/resource/default.properties
@@ -109,11 +109,8 @@ DISABLE_AVATAR_TAB = false
 # If true, disable the "Plugins" menu item
 DISABLE_PLUGINS_MENU_ITEM = false
 
-# If true, disable the option to transfer files
+# If true, disable the option to transfer files and images
 DISABLE_FILE_XFER = false
-
-# If true, disable the option to take screenshots
-DISABLE_SCREENSHOTS = false
 
 # If true, disable the option to remove contacts and groups in roster
 DISABLE_REMOVALS = false

--- a/src/java/org/jivesoftware/resource/default.properties
+++ b/src/java/org/jivesoftware/resource/default.properties
@@ -109,6 +109,27 @@ DISABLE_AVATAR_TAB = false
 # If true, disable the "Plugins" menu item
 DISABLE_PLUGINS_MENU_ITEM = false
 
+# If true, disable the option to transfer files
+DISABLE_FILE_XFER = false
+
+# If true, disable the option to remove contacts and groups in roster
+DISABLE_REMOVALS = false
+
+# If true, disable the option to rename contacts and groups in roster
+DISABLE_RENAMES = false
+
+# If true, disable the options to move and copy contacts
+DISABLE_MOVE_AND_COPY = false
+
+# If true, disable the option to edit the profile
+DISABLE_EDIT_PROFILE = false
+
+# If true, disable the "View notes" option under "Actions"
+DISABLE_VIEW_NOTES = false
+
+# If true, disable the "View task list" option under "Actions"
+DISABLE_VIEW_TASK_LIST = false
+
 #################################################
 ################## File Transfer ################
 #################################################

--- a/src/java/org/jivesoftware/resource/default.properties
+++ b/src/java/org/jivesoftware/resource/default.properties
@@ -112,6 +112,9 @@ DISABLE_PLUGINS_MENU_ITEM = false
 # If true, disable the option to transfer files
 DISABLE_FILE_XFER = false
 
+# If true, disable the option to take screenshots
+DISABLE_SCREENSHOTS = false
+
 # If true, disable the option to remove contacts and groups in roster
 DISABLE_REMOVALS = false
 

--- a/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
+++ b/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
@@ -70,10 +70,14 @@ public class ChatRoomTransferDecorator implements KeyListener, FileDropListener,
         	sendFileButton.addActionListener(this);
         }
 
-        sendScreenShotButton = UIComponentRegistry.getButtonFactory().createScreenshotButton();
-        sendScreenShotButton.setToolTipText(Res.getString("message.send.picture"));
-        chatRoom.addChatRoomButton(sendScreenShotButton);
-        sendScreenShotButton.addActionListener(this);
+        // See if we should disable the ability to take screenshots
+        if (!Default.getBoolean("DISABLE_SCREENSHOTS")) {
+        	sendScreenShotButton = UIComponentRegistry.getButtonFactory().createScreenshotButton();
+        	sendScreenShotButton.setToolTipText(Res.getString("message.send.picture"));
+
+        	chatRoom.addChatRoomButton(sendScreenShotButton);
+        	sendScreenShotButton.addActionListener(this);
+        }
     }
 
     public void keyTyped(KeyEvent e) {

--- a/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
+++ b/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
@@ -19,6 +19,7 @@
  */
 package org.jivesoftware.spark.filetransfer;
 
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.spark.SparkManager;
 import org.jivesoftware.spark.ui.ChatRoom;
@@ -60,17 +61,18 @@ public class ChatRoomTransferDecorator implements KeyListener, FileDropListener,
         chatRoom.getChatInputEditor().addKeyListener(this);
         chatRoom.addClosingListener(this);
 
+        // See if we should disable the ability to transfer files
+        if (!Default.getBoolean("DISABLE_FILE_XFER")) {
+        	sendFileButton = UIComponentRegistry.getButtonFactory().createSendFileButton();
+        	sendFileButton.setToolTipText(Res.getString("message.send.file.to.user"));
 
-        sendFileButton = UIComponentRegistry.getButtonFactory().createSendFileButton();
-        sendFileButton.setToolTipText(Res.getString("message.send.file.to.user"));
-
-        chatRoom.addChatRoomButton(sendFileButton);
+        	chatRoom.addChatRoomButton(sendFileButton);
+        	sendFileButton.addActionListener(this);
+        }
 
         sendScreenShotButton = UIComponentRegistry.getButtonFactory().createScreenshotButton();
         sendScreenShotButton.setToolTipText(Res.getString("message.send.picture"));
         chatRoom.addChatRoomButton(sendScreenShotButton);
-
-        sendFileButton.addActionListener(this);
         sendScreenShotButton.addActionListener(this);
     }
 

--- a/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
+++ b/src/java/org/jivesoftware/spark/filetransfer/ChatRoomTransferDecorator.java
@@ -19,7 +19,6 @@
  */
 package org.jivesoftware.spark.filetransfer;
 
-import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.spark.SparkManager;
 import org.jivesoftware.spark.ui.ChatRoom;
@@ -55,29 +54,23 @@ public class ChatRoomTransferDecorator implements KeyListener, FileDropListener,
     private ChatRoomButton sendScreenShotButton;
 
     public ChatRoomTransferDecorator(final ChatRoom chatRoom) {
-        this.chatRoom = chatRoom;
+    	this.chatRoom = chatRoom;
 
-        chatRoom.addFileDropListener(this);
-        chatRoom.getChatInputEditor().addKeyListener(this);
-        chatRoom.addClosingListener(this);
+    	chatRoom.addFileDropListener(this);
+    	chatRoom.getChatInputEditor().addKeyListener(this);
+    	chatRoom.addClosingListener(this);
 
-        // See if we should disable the ability to transfer files
-        if (!Default.getBoolean("DISABLE_FILE_XFER")) {
-        	sendFileButton = UIComponentRegistry.getButtonFactory().createSendFileButton();
-        	sendFileButton.setToolTipText(Res.getString("message.send.file.to.user"));
+    	sendFileButton = UIComponentRegistry.getButtonFactory().createSendFileButton();
+    	sendFileButton.setToolTipText(Res.getString("message.send.file.to.user"));
 
-        	chatRoom.addChatRoomButton(sendFileButton);
-        	sendFileButton.addActionListener(this);
-        }
+    	chatRoom.addChatRoomButton(sendFileButton);
+    	sendFileButton.addActionListener(this);
 
-        // See if we should disable the ability to take screenshots
-        if (!Default.getBoolean("DISABLE_SCREENSHOTS")) {
-        	sendScreenShotButton = UIComponentRegistry.getButtonFactory().createScreenshotButton();
-        	sendScreenShotButton.setToolTipText(Res.getString("message.send.picture"));
+    	sendScreenShotButton = UIComponentRegistry.getButtonFactory().createScreenshotButton();
+    	sendScreenShotButton.setToolTipText(Res.getString("message.send.picture"));
 
-        	chatRoom.addChatRoomButton(sendScreenShotButton);
-        	sendScreenShotButton.addActionListener(this);
-        }
+    	chatRoom.addChatRoomButton(sendScreenShotButton);
+    	sendScreenShotButton.addActionListener(this);
     }
 
     public void keyTyped(KeyEvent e) {

--- a/src/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
+++ b/src/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
@@ -138,10 +138,9 @@ public class SparkTransferManager {
     }
 
     private SparkTransferManager() {
-        boolean enabled = Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE);
-        if (!enabled) {
-            return;
-        }
+    	
+    	// See if we should disable the option to transfer files and images
+    	if (Default.getBoolean("DISABLE_FILE_XFER") || !Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) return;
 
         SparkManager.getConnection().addConnectionListener(new ConnectionListener() {
             @Override

--- a/src/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/src/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1505,11 +1505,11 @@ moveToOffline(moveToOfflineContactItem);
             }
         };
 
-        // See if we should disable the option to transfer files
-        if (!Default.getBoolean("DISABLE_FILE_XFER")) {
+        // See if we should disable the option to transfer files and images
+        if (!Default.getBoolean("DISABLE_FILE_XFER") && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) {
         	sendAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.DOCUMENT_16x16));
         	sendAction.putValue(Action.NAME, Res.getString("menuitem.send.a.file"));
-        	if ((item.getPresence() != null) && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) popup.add(sendAction);
+        	if (item.getPresence() != null) popup.add(sendAction);
         }
         
         popup.addSeparator();
@@ -1670,11 +1670,10 @@ moveToOffline(moveToOfflineContactItem);
         final JPopupMenu popup = new JPopupMenu();
         final JMenuItem sendMessagesMenu = new JMenuItem(Res.getString("menuitem.send.a.message"), SparkRes.getImageIcon(SparkRes.SMALL_MESSAGE_IMAGE));
 
-
         fireContextMenuListenerPopup(popup, items);
 
         // See if we should disable all "Broadcast" menu items
-        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) popup.add(sendMessagesMenu);
+        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM") && Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) popup.add(sendMessagesMenu);
 
         sendMessagesMenu.addActionListener( e1 -> sendMessages(items) );
 

--- a/src/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/src/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1379,14 +1379,20 @@ moveToOffline(moveToOfflineContactItem);
         JMenuItem rename = new JMenuItem(Res.getString("menuitem.rename"));
         JMenuItem expand = new JMenuItem(Res.getString("menuitem.expand.all.groups"));
         JMenuItem collapse = new JMenuItem(Res.getString("menuitem.collapse.all.groups"));
-        
+
         if (!group.isSharedGroup()) {
             popup.addSeparator();
-            popup.add(delete);
-            popup.add(rename);
+
+            // See if we should disable the "Delete" menu option
+            if (!Default.getBoolean("DISABLE_REMOVALS")) popup.add(delete);
+
+            // See if we should disable the "Rename" menu option
+            if (!Default.getBoolean("DISABLE_RENAMES")) popup.add(rename);
         }
-        
-        popup.addSeparator();
+
+        // Only display a horizontal separator if at least one of those options is present 
+        if (!Default.getBoolean("DISABLE_REMOVALS") || !Default.getBoolean("DISABLE_RENAMES")) popup.addSeparator();
+
         popup.add(expand);
         popup.add(collapse);
 
@@ -1499,15 +1505,14 @@ moveToOffline(moveToOfflineContactItem);
             }
         };
 
-        sendAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.DOCUMENT_16x16));
-        sendAction.putValue(Action.NAME, Res.getString("menuitem.send.a.file"));
-
-        if ((item.getPresence() != null) && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) {
-            popup.add(sendAction);
+        // See if we should disable the option to transfer files
+        if (!Default.getBoolean("DISABLE_FILE_XFER")) {
+        	sendAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.DOCUMENT_16x16));
+        	sendAction.putValue(Action.NAME, Res.getString("menuitem.send.a.file"));
+        	if ((item.getPresence() != null) && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) popup.add(sendAction);
         }
-
+        
         popup.addSeparator();
-
 
         String groupName = item.getGroupName();
         ContactGroup contactGroup = getContactGroup(groupName);
@@ -1551,13 +1556,13 @@ moveToOffline(moveToOfflineContactItem);
             }
         }
 
-
-        if (!contactGroup.isSharedGroup() && !isInSharedGroup) {
-            popup.add(removeAction);
+        // See if we should disable the option to remove a contact
+        if (!Default.getBoolean("DISABLE_REMOVALS")) {
+        	if (!contactGroup.isSharedGroup() && !isInSharedGroup) popup.add(removeAction);
         }
 
-        popup.add(renameMenu);
-
+        // See if we should disable the option to rename a contact
+        if (!Default.getBoolean("DISABLE_RENAMES")) popup.add(renameMenu); 
 
         Action viewProfile = new AbstractAction() {
 			private static final long serialVersionUID = -2562731455090634805L;

--- a/src/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/src/java/org/jivesoftware/spark/ui/ContactList.java
@@ -2572,8 +2572,9 @@ SwingUtilities.invokeLater( () -> loadContactList() );
         if (unfiledGroup == null) {
             // Add Unfiled Group
         	if(EventQueue.isDispatchThread()) {
-			unfiledGroup = UIComponentRegistry.createContactGroup(Res.getString("unfiled"));
-                addContactGroup(unfiledGroup);
+        		unfiledGroup = UIComponentRegistry.createContactGroup(Res.getString("unfiled"));
+        		// Only show the "Unfiled" group if it is not empty
+        		if (unfiledGroup.hasAvailableContacts()) addContactGroup(unfiledGroup);
         	}
         	else {
         		try {

--- a/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -69,6 +69,7 @@ import org.jivesoftware.spark.util.SwingWorker;
 import org.jivesoftware.spark.util.TaskEngine;
 import org.jivesoftware.spark.util.UIComponentRegistry;
 import org.jivesoftware.spark.util.log.Log;
+import org.jivesoftware.sparkimpl.plugin.manager.Enterprise;
 import org.jivesoftware.sparkimpl.plugin.privacy.PrivacyManager;
 import org.jivesoftware.sparkimpl.plugin.privacy.list.SparkPrivacyList;
 import org.jivesoftware.sparkimpl.profile.VCardEditor;
@@ -150,7 +151,10 @@ public class StatusBar extends JPanel implements VCardListener {
         } );
 
         // See if we should disable the option to edit the profile if clicking on the Avatar image
-        if (!Default.getBoolean("DISABLE_EDIT_PROFILE")) {
+        
+        boolean enabled = Enterprise.containsFeature(Enterprise.VCARD_FEATURE);
+        
+        if ((!Default.getBoolean("DISABLE_EDIT_PROFILE")) && (enabled)) {
 
             // Show profile when clicking on Avatar image
         	imageLabel.addMouseListener(new MouseAdapter() {

--- a/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -149,24 +149,29 @@ public class StatusBar extends JPanel implements VCardListener {
             }
         } );
 
-        // Show profile on double click of image label
-        imageLabel.addMouseListener(new MouseAdapter() {
-            public void mouseClicked(MouseEvent mouseEvent) {
-                if (mouseEvent.getClickCount() == 1) {
-                    VCardManager vcardManager = SparkManager.getVCardManager();
-                    VCardEditor editor = new VCardEditor();
-                    editor.editProfile(vcardManager.getVCard(), SparkManager.getWorkspace());
-                }
-            }
+        // See if we should disable the option to edit the profile if clicking on the Avatar image
+        if (!Default.getBoolean("DISABLE_EDIT_PROFILE")) {
 
-            public void mouseEntered(MouseEvent e) {
-                imageLabel.setCursor(GraphicUtils.HAND_CURSOR);
-            }
+            // Show profile when clicking on Avatar image
+        	imageLabel.addMouseListener(new MouseAdapter() {
+        		public void mouseClicked(MouseEvent mouseEvent) {
+        			if (mouseEvent.getClickCount() == 1) {
+        				VCardManager vcardManager = SparkManager.getVCardManager();
+        				VCardEditor editor = new VCardEditor();
+        				editor.editProfile(vcardManager.getVCard(), SparkManager.getWorkspace());
+        			}
+        		}
 
-            public void mouseExited(MouseEvent e) {
-                imageLabel.setCursor(GraphicUtils.DEFAULT_CURSOR);
-            }
-        });
+        		public void mouseEntered(MouseEvent e) {
+        			imageLabel.setCursor(GraphicUtils.HAND_CURSOR);
+        		}
+
+        		public void mouseExited(MouseEvent e) {
+        			imageLabel.setCursor(GraphicUtils.DEFAULT_CURSOR);
+        		}
+        	});
+
+        }
 
         final TimerTask task = new SwingTimerTask() {
             public void doRun() {

--- a/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -83,140 +83,140 @@ public class StatusBar extends JPanel implements VCardListener {
 
 	private List<StatusItem> statusList = new ArrayList<>();
 
-    private JLabel imageLabel = new JLabel();
-    private JLabel descriptiveLabel = new JLabel();
-    private JLabel nicknameLabel = new JLabel();
-    private StatusPanel statusPanel = new StatusPanel();
+	private JLabel imageLabel = new JLabel();
+	private JLabel descriptiveLabel = new JLabel();
+	private JLabel nicknameLabel = new JLabel();
+	private StatusPanel statusPanel = new StatusPanel();
 
-    private CommandPanel commandPanel ;
-    private Image backgroundImage;
-    private Runnable changePresenceRunnable;
+	private CommandPanel commandPanel ;
+	private Image backgroundImage;
+	private Runnable changePresenceRunnable;
 
-    private Presence currentPresence;
+	private Presence currentPresence;
 
 	public StatusBar() {
 		this(true);
 	}
 
-    public StatusBar(boolean doLayout) {
+	public StatusBar(boolean doLayout) {
+
 		commandPanel = UIComponentRegistry.createCommandPanel();
-	if (doLayout) {
-		setLayout(new GridBagLayout());
 
-		backgroundImage = Default.getImageIcon(Default.TOP_BOTTOM_BACKGROUND_IMAGE).getImage();
+		if (doLayout) {
+			setLayout(new GridBagLayout());
+
+			backgroundImage = Default.getImageIcon(Default.TOP_BOTTOM_BACKGROUND_IMAGE).getImage();
 
 
 
-		ImageIcon brandedImage = Default.getImageIcon(Default.BRANDED_IMAGE);
-		if (brandedImage != null && brandedImage.getIconWidth() > 1) {
-			final JLabel brandedLabel = new JLabel(brandedImage);
-			add(brandedLabel, new GridBagConstraints(3, 0, 1, 3, 1.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 2, 2, 2), 0, 0));
+			ImageIcon brandedImage = Default.getImageIcon(Default.BRANDED_IMAGE);
+			if (brandedImage != null && brandedImage.getIconWidth() > 1) {
+				final JLabel brandedLabel = new JLabel(brandedImage);
+				add(brandedLabel, new GridBagConstraints(3, 0, 1, 3, 1.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 2, 2, 2), 0, 0));
+			}
+
+
+			add(imageLabel, new GridBagConstraints(0, 0, 1, 3, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.BOTH, new Insets(2, 8, 2, 2), 0, 0));
+
+			add(nicknameLabel, new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(2, 12, 0, 0), 0, 0));
+			add(statusPanel, new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(0, 7, 0, 0), 0, 0));
+			add(commandPanel, new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0, GridBagConstraints.SOUTHWEST, GridBagConstraints.NONE, new Insets(0, 5, 0, 0), 0, 0));
+			nicknameLabel.setToolTipText(SparkManager.getConnection().getUser());
+			nicknameLabel.setFont(new Font(Font.DIALOG, Font.BOLD, 12));
+			setStatus(Res.getString("status.online"));
 		}
 
+		buildStatusItemList();
 
-        add(imageLabel, new GridBagConstraints(0, 0, 1, 3, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.BOTH, new Insets(2, 8, 2, 2), 0, 0));
+		// SPARK-1521, if we log in as invisible, default status should be "Invisible"
+		currentPresence = getPresenceOnStart();
 
-        add(nicknameLabel, new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(2, 12, 0, 0), 0, 0));
-        add(statusPanel, new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(0, 7, 0, 0), 0, 0));
-        add(commandPanel, new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0, GridBagConstraints.SOUTHWEST, GridBagConstraints.NONE, new Insets(0, 5, 0, 0), 0, 0));
-        nicknameLabel.setToolTipText(SparkManager.getConnection().getUser());
-        nicknameLabel.setFont(new Font(Font.DIALOG, Font.BOLD, 12));
-        setStatus(Res.getString("status.online"));
-	}
+		updatePresence();        
 
-        buildStatusItemList();
-        
-        // SPARK-1521, if we log in as invisible, default status should be "Invisible"
-        currentPresence = getPresenceOnStart();
+		//setBorder(BorderFactory.createLineBorder(new Color(197, 213, 230), 1));
 
-	updatePresence();        
+		SparkManager.getSessionManager().addPresenceListener( presence -> {
+			presence.setStatus(StringUtils.modifyWildcards(presence.getStatus()));
+			changeAvailability(presence);
 
-        //setBorder(BorderFactory.createLineBorder(new Color(197, 213, 230), 1));
+			// SPARK-1524:
+			// after reconnected if we had the 'invisible' presence
+			// we should re-send it
+			if (PresenceManager.isInvisible(currentPresence)) {
+				TimerTask task = new SwingTimerTask() {
+					public void doRun() {
+						PrivacyManager.getInstance().goToInvisible();
+					}
+				};
+				TaskEngine.getInstance().schedule(task, 500);
+			}
+		} );
 
-        SparkManager.getSessionManager().addPresenceListener( presence -> {
-        presence.setStatus(StringUtils.modifyWildcards(presence.getStatus()));
-            changeAvailability(presence);
+		// See if we should disable the option to edit the profile if clicking on the Avatar image
+		// NOTE: There seems to be a bug where the enterprise VCARD_FEATURE is always returned as boolean 'true'
+		
+		if (!Default.getBoolean("DISABLE_EDIT_PROFILE") && Enterprise.containsFeature(Enterprise.VCARD_FEATURE)) {
+			// Show profile when clicking on Avatar image
+			imageLabel.addMouseListener(new MouseAdapter() {
+				public void mouseClicked(MouseEvent mouseEvent) {
+					if (mouseEvent.getClickCount() == 1) {
+						VCardManager vcardManager = SparkManager.getVCardManager();
+						VCardEditor editor = new VCardEditor();
+						editor.editProfile(vcardManager.getVCard(), SparkManager.getWorkspace());
+					}
+				}
 
-            // SPARK-1524:
-            // after reconnected if we had the 'invisible' presence
-            // we should re-send it
-            if (PresenceManager.isInvisible(currentPresence)) {
-                TimerTask task = new SwingTimerTask() {
-                    public void doRun() {
-                        PrivacyManager.getInstance().goToInvisible();
-                    }
-                };
-                TaskEngine.getInstance().schedule(task, 500);
-            }
-        } );
+				public void mouseEntered(MouseEvent e) {
+					imageLabel.setCursor(GraphicUtils.HAND_CURSOR);
+				}
 
-        // See if we should disable the option to edit the profile if clicking on the Avatar image
-        
-        boolean enabled = Enterprise.containsFeature(Enterprise.VCARD_FEATURE);
-        
-        if ((!Default.getBoolean("DISABLE_EDIT_PROFILE")) && (enabled)) {
+				public void mouseExited(MouseEvent e) {
+					imageLabel.setCursor(GraphicUtils.DEFAULT_CURSOR);
+				}
+			});
 
-            // Show profile when clicking on Avatar image
-        	imageLabel.addMouseListener(new MouseAdapter() {
-        		public void mouseClicked(MouseEvent mouseEvent) {
-        			if (mouseEvent.getClickCount() == 1) {
-        				VCardManager vcardManager = SparkManager.getVCardManager();
-        				VCardEditor editor = new VCardEditor();
-        				editor.editProfile(vcardManager.getVCard(), SparkManager.getWorkspace());
-        			}
-        		}
+		}
 
-        		public void mouseEntered(MouseEvent e) {
-        			imageLabel.setCursor(GraphicUtils.HAND_CURSOR);
-        		}
+		final TimerTask task = new SwingTimerTask() {
+			public void doRun() {
+				SparkManager.getVCardManager().addVCardListener(SparkManager.getWorkspace().getStatusBar());
+			}
+		};
 
-        		public void mouseExited(MouseEvent e) {
-        			imageLabel.setCursor(GraphicUtils.DEFAULT_CURSOR);
-        		}
-        	});
-
-        }
-
-        final TimerTask task = new SwingTimerTask() {
-            public void doRun() {
-                SparkManager.getVCardManager().addVCardListener(SparkManager.getWorkspace().getStatusBar());
-            }
-        };
-
-        TaskEngine.getInstance().schedule(task, 3000);
+		TaskEngine.getInstance().schedule(task, 3000);
 		changePresenceRunnable = () -> updatePresence();
 
 
-    }
+	}
 
-    public void setAvatar(Icon icon) {
-        Image image = ImageCombiner.iconToImage(icon);
-        if (icon.getIconHeight() > 64 || icon.getIconWidth() > 64) {
-            imageLabel.setIcon(new ImageIcon(image.getScaledInstance(-1, 64, Image.SCALE_SMOOTH)));
-        } else {
-            imageLabel.setIcon(icon);
-        }
-        imageLabel.setBorder(null);
-        revalidate();
-    }
+	public void setAvatar(Icon icon) {
+		Image image = ImageCombiner.iconToImage(icon);
+		if (icon.getIconHeight() > 64 || icon.getIconWidth() > 64) {
+			imageLabel.setIcon(new ImageIcon(image.getScaledInstance(-1, 64, Image.SCALE_SMOOTH)));
+		} else {
+			imageLabel.setIcon(icon);
+		}
+		imageLabel.setBorder(null);
+		revalidate();
+	}
 
-    public CommandPanel getCommandPanel()
-    {
-	return commandPanel;
-    }
+	public CommandPanel getCommandPanel()
+	{
+		return commandPanel;
+	}
 
-    public void setNickname(String nickname) {
-        nicknameLabel.setText(nickname);
-    }
+	public void setNickname(String nickname) {
+		nicknameLabel.setText(nickname);
+	}
 
-    /**
-     * Sets the current status text in the Status Manager.
-     *
-     * @param status the status to set.
-     */
-    public void setStatus(String status) {
-        statusPanel.setStatus(status);
-    }
+	/**
+	 * Sets the current status text in the Status Manager.
+	 *
+	 * @param status the status to set.
+	 */
+	public void setStatus(String status) {
+		statusPanel.setStatus(status);
+	}
 
 	protected void updatePresence() {
 		setStatus(currentPresence.getStatus());
@@ -226,446 +226,446 @@ public class StatusBar extends JPanel implements VCardListener {
 		}
 	}
 
-    public void showPopup(MouseEvent e) {
-        final JPopupMenu popup = new JPopupMenu();
+	public void showPopup(MouseEvent e) {
+		final JPopupMenu popup = new JPopupMenu();
 
-        List<CustomStatusItem> custom = CustomMessages.load();
-        if (custom == null) {
-            custom = new ArrayList<>();
-        }
+		List<CustomStatusItem> custom = CustomMessages.load();
+		if (custom == null) {
+			custom = new ArrayList<>();
+		}
 
-        // Sort Custom Messages
-        Collections.sort( custom, ( a, b ) -> ( a.getStatus().compareToIgnoreCase( b.getStatus() ) ) );
+		// Sort Custom Messages
+		Collections.sort( custom, ( a, b ) -> ( a.getStatus().compareToIgnoreCase( b.getStatus() ) ) );
 
-        // Build menu from StatusList
-        for (final StatusItem statusItem : statusList) {
-            final Action statusAction = new AbstractAction() {
+		// Build menu from StatusList
+		for (final StatusItem statusItem : statusList) {
+			final Action statusAction = new AbstractAction() {
 				private static final long serialVersionUID = -192865863435381702L;
 
 				public void actionPerformed(ActionEvent actionEvent) {
-                    final String text = statusItem.getText();
-                    final StatusItem si = getStatusItem(text);
-                    if (si == null) {
-                        // Custom status
-                        Log.error("Unable to find status item for status - " + text);
-                        return;
-                    }
+					final String text = statusItem.getText();
+					final StatusItem si = getStatusItem(text);
+					if (si == null) {
+						// Custom status
+						Log.error("Unable to find status item for status - " + text);
+						return;
+					}
 
-                    SwingWorker worker = new SwingWorker() {
-                        public Object construct() {
-                            return changePresence(si.getPresence());
-                        }
+					SwingWorker worker = new SwingWorker() {
+						public Object construct() {
+							return changePresence(si.getPresence());
+						}
 
-                        public void finished() {
-                            setStatus((String) getValue());
-                        }
-                    };
-                    worker.start();
-                }
-            };
+						public void finished() {
+							setStatus((String) getValue());
+						}
+					};
+					worker.start();
+				}
+			};
 
-            statusAction.putValue(Action.NAME, statusItem.getText());
-            statusAction.putValue(Action.SMALL_ICON, statusItem.getIcon());
+			statusAction.putValue(Action.NAME, statusItem.getText());
+			statusAction.putValue(Action.SMALL_ICON, statusItem.getIcon());
 
-            // Has Children
-            boolean hasChildren = false;
-            for (Object aCustom : custom) {
-                final CustomStatusItem cItem = (CustomStatusItem) aCustom;
-                String type = cItem.getType();
-                if (type.equals(statusItem.getText())) {
-                    hasChildren = true;
-                }
-            }
+			// Has Children
+			boolean hasChildren = false;
+			for (Object aCustom : custom) {
+				final CustomStatusItem cItem = (CustomStatusItem) aCustom;
+				String type = cItem.getType();
+				if (type.equals(statusItem.getText())) {
+					hasChildren = true;
+				}
+			}
 
-            if (!hasChildren) {
-                // Add as Menu Item
-                popup.add(statusAction);
-            }
-            else {
+			if (!hasChildren) {
+				// Add as Menu Item
+				popup.add(statusAction);
+			}
+			else {
 
-                final JMenu mainStatusItem = new JMenu(statusAction);
+				final JMenu mainStatusItem = new JMenu(statusAction);
 
 
-                popup.add(mainStatusItem);
+				popup.add(mainStatusItem);
 
-                // Add Custom Messages
-                for (Object aCustom : custom) {
-                    final CustomStatusItem customItem = (CustomStatusItem) aCustom;
-                    String type = customItem.getType();
-                    final String customStatus = customItem.getStatus();
-                    if (type.equals(statusItem.getText())) {
-                        // Add Child Menu
-                        Action action = new AbstractAction() {
+				// Add Custom Messages
+				for (Object aCustom : custom) {
+					final CustomStatusItem customItem = (CustomStatusItem) aCustom;
+					String type = customItem.getType();
+					final String customStatus = customItem.getStatus();
+					if (type.equals(statusItem.getText())) {
+						// Add Child Menu
+						Action action = new AbstractAction() {
 							private static final long serialVersionUID = -1264239704492879742L;
 
 							public void actionPerformed(ActionEvent actionEvent) {
-                                final String text = mainStatusItem.getText();
-                                final StatusItem si = getStatusItem(text);
-                                if (si == null) {
-                                    // Custom status
-                                    Log.error("Unable to find status item for status - " + text);
-                                    return;
-                                }
+								final String text = mainStatusItem.getText();
+								final StatusItem si = getStatusItem(text);
+								if (si == null) {
+									// Custom status
+									Log.error("Unable to find status item for status - " + text);
+									return;
+								}
 
-                                SwingWorker worker = new SwingWorker() {
-                                    public Object construct() {
-                                    	Presence presence = PresenceManager.copy(si.getPresence());
-                                    	presence.setStatus(customStatus);
+								SwingWorker worker = new SwingWorker() {
+									public Object construct() {
+										Presence presence = PresenceManager.copy(si.getPresence());
+										presence.setStatus(customStatus);
 										presence.setPriority(customItem.getPriority());
-                                        return changePresence(presence);
-                                    }
+										return changePresence(presence);
+									}
 
-                                    public void finished() {
-                                        setStatus((String) getValue());
-                                    }
-                                };
-                                worker.start();
-                            }
-                        };
-                        action.putValue(Action.NAME, customItem.getStatus());
-                        action.putValue(Action.SMALL_ICON, statusItem.getIcon());
-                        mainStatusItem.add(action);
-                    }
-                }
+									public void finished() {
+										setStatus((String) getValue());
+									}
+								};
+								worker.start();
+							}
+						};
+						action.putValue(Action.NAME, customItem.getStatus());
+						action.putValue(Action.SMALL_ICON, statusItem.getIcon());
+						mainStatusItem.add(action);
+					}
+				}
 
-                // If menu has children, allow it to still be clickable.
-                mainStatusItem.addMouseListener(new MouseAdapter() {
-                    public void mouseClicked(MouseEvent mouseEvent) {
-                        statusAction.actionPerformed(null);
-                        popup.setVisible(false);
-                    }
-                });
-            }
-        }
-
-
-        //SPARK-1521. Add privacy menu if Privacy Manager is active and have any visible lists
-        final PrivacyManager pmanager = PrivacyManager.getInstance();
-        if (pmanager.isPrivacyActive() && pmanager.getPrivacyLists().size() > 0) {
-            
-            JMenu privMenu = new JMenu(Res.getString("privacy.status.menu.entry"));
-            privMenu.setIcon(SparkRes.getImageIcon("PRIVACY_ICON_SMALL"));
-            
-            for (SparkPrivacyList plist : pmanager.getPrivacyLists()) {
-                JMenuItem it = new JMenuItem(plist.getListName());
-                privMenu.add(it);
-                if (plist.isActive()) {
-                    it.setIcon(SparkRes.getImageIcon("PRIVACY_LIGHTNING"));
-                } else {
-                    it.setIcon(null);
-                }
-                final SparkPrivacyList finalList = plist;
-                it.addActionListener( e1 -> PrivacyManager.getInstance().setListAsActive(finalList.getListName()) );
-            }
-
-            if (pmanager.hasActiveList()) {
-                JMenuItem remMenu = new JMenuItem(Res.getString("privacy.menuitem.deactivate.current.list", pmanager.getActiveList().getListName()),
-                        SparkRes.getImageIcon("PRIVACY_DEACTIVATE_LIST"));
-                remMenu.addActionListener( e1 -> pmanager.declineActiveList() );
-                privMenu.addSeparator();
-                privMenu.add(remMenu);
-            }
-
-            popup.add(privMenu);
-        }
-
-        // Add change message
-        final JMenuItem changeStatusMenu = new JMenuItem(Res.getString("menuitem.set.status.message"), SparkRes.getImageIcon(SparkRes.BLANK_IMAGE));
-        popup.addSeparator();
+				// If menu has children, allow it to still be clickable.
+				mainStatusItem.addMouseListener(new MouseAdapter() {
+					public void mouseClicked(MouseEvent mouseEvent) {
+						statusAction.actionPerformed(null);
+						popup.setVisible(false);
+					}
+				});
+			}
+		}
 
 
-        popup.add(changeStatusMenu);
-        changeStatusMenu.addActionListener( e1 -> CustomMessages.addCustomMessage() );
+		//SPARK-1521. Add privacy menu if Privacy Manager is active and have any visible lists
+		final PrivacyManager pmanager = PrivacyManager.getInstance();
+		if (pmanager.isPrivacyActive() && pmanager.getPrivacyLists().size() > 0) {
+
+			JMenu privMenu = new JMenu(Res.getString("privacy.status.menu.entry"));
+			privMenu.setIcon(SparkRes.getImageIcon("PRIVACY_ICON_SMALL"));
+
+			for (SparkPrivacyList plist : pmanager.getPrivacyLists()) {
+				JMenuItem it = new JMenuItem(plist.getListName());
+				privMenu.add(it);
+				if (plist.isActive()) {
+					it.setIcon(SparkRes.getImageIcon("PRIVACY_LIGHTNING"));
+				} else {
+					it.setIcon(null);
+				}
+				final SparkPrivacyList finalList = plist;
+				it.addActionListener( e1 -> PrivacyManager.getInstance().setListAsActive(finalList.getListName()) );
+			}
+
+			if (pmanager.hasActiveList()) {
+				JMenuItem remMenu = new JMenuItem(Res.getString("privacy.menuitem.deactivate.current.list", pmanager.getActiveList().getListName()),
+						SparkRes.getImageIcon("PRIVACY_DEACTIVATE_LIST"));
+				remMenu.addActionListener( e1 -> pmanager.declineActiveList() );
+				privMenu.addSeparator();
+				privMenu.add(remMenu);
+			}
+
+			popup.add(privMenu);
+		}
+
+		// Add change message
+		final JMenuItem changeStatusMenu = new JMenuItem(Res.getString("menuitem.set.status.message"), SparkRes.getImageIcon(SparkRes.BLANK_IMAGE));
+		popup.addSeparator();
 
 
-        Action editMessagesAction = new AbstractAction() {
+		popup.add(changeStatusMenu);
+		changeStatusMenu.addActionListener( e1 -> CustomMessages.addCustomMessage() );
+
+
+		Action editMessagesAction = new AbstractAction() {
 			private static final long serialVersionUID = 7148051050075679995L;
 
 			public void actionPerformed(ActionEvent actionEvent) {
-                CustomMessages.editCustomMessages();
-            }
-        };
+				CustomMessages.editCustomMessages();
+			}
+		};
 
-        editMessagesAction.putValue(Action.NAME, Res.getString("menuitem.edit.status.message"));
-        popup.add(editMessagesAction);
+		editMessagesAction.putValue(Action.NAME, Res.getString("menuitem.edit.status.message"));
+		popup.add(editMessagesAction);
 
-        final JPanel panel = getStatusPanel();
-        popup.show(panel, 0, panel.getHeight());
-    }
+		final JPanel panel = getStatusPanel();
+		popup.show(panel, 0, panel.getHeight());
+	}
 
 	protected JPanel getStatusPanel() {
 		return statusPanel;
 	}
 
-    public void changeAvailability(final Presence presence) {
-    	// SPARK-1524: if we were reconnected because of the error
-    	// then we get presence with the mode == null. 
-    	if (presence.getMode() == null)
-    		return;
-    	
-        if ((presence.getMode() == currentPresence.getMode()) && (presence.getType() == currentPresence.getType()) && (presence.getStatus().equals(currentPresence.getStatus()))) {
-            ExtensionElement pe = presence.getExtension("x", "vcard-temp:x:update");
-            if (pe != null) {
-                // Update VCard
-                loadVCard();
-            }
-            return;
-        }
-        currentPresence = presence;
+	public void changeAvailability(final Presence presence) {
+		// SPARK-1524: if we were reconnected because of the error
+		// then we get presence with the mode == null. 
+		if (presence.getMode() == null)
+			return;
 
-        SwingUtilities.invokeLater(changePresenceRunnable);
-    }
+		if ((presence.getMode() == currentPresence.getMode()) && (presence.getType() == currentPresence.getType()) && (presence.getStatus().equals(currentPresence.getStatus()))) {
+			ExtensionElement pe = presence.getExtension("x", "vcard-temp:x:update");
+			if (pe != null) {
+				// Update VCard
+				loadVCard();
+			}
+			return;
+		}
+		currentPresence = presence;
 
-    /**
-     * Populates the current Dnd List.
-     */
-    private void buildStatusItemList() {
-        for (Presence presence : PresenceManager.getPresences()) {
-            Icon icon = PresenceManager.getIconFromPresence(presence);
-            StatusItem item = new StatusItem(presence, icon);
-            statusList.add(item);
-        }
+		SwingUtilities.invokeLater(changePresenceRunnable);
+	}
 
-        final Icon availableIcon = PresenceManager.getIconFromPresence(new Presence(Presence.Type.available));
+	/**
+	 * Populates the current Dnd List.
+	 */
+	private void buildStatusItemList() {
+		for (Presence presence : PresenceManager.getPresences()) {
+			Icon icon = PresenceManager.getIconFromPresence(presence);
+			StatusItem item = new StatusItem(presence, icon);
+			statusList.add(item);
+		}
 
-        // Set default presence icon (Avaialble)
-        statusPanel.setIcon(availableIcon);
-    }
+		final Icon availableIcon = PresenceManager.getIconFromPresence(new Presence(Presence.Type.available));
 
-
-    public Collection<StatusItem> getStatusList() {
-        return statusList;
-    }
-
-    public Collection<CustomStatusItem> getCustomStatusList()
-    {
-    	List<CustomStatusItem> custom = CustomMessages.load();
-    	if (custom == null)
-    		custom = new ArrayList<>();
-
-    	// Sort Custom Messages
-        Collections.sort( custom, ( a, b ) -> ( a.getStatus().compareToIgnoreCase( b.getStatus() ) ) );
-
-    	return custom;
-    }
-
-    public Presence getPresence() {
-        return currentPresence;
-    }
-
-    public StatusItem getStatusItem(String label) {
-        for (StatusItem aStatusList : statusList) {
-            if (aStatusList.getText().equals(label)) {
-                return aStatusList;
-            }
-        }
-        return null;
-    }
-
-    public void paintComponent(Graphics g) {
-    	  super.paintComponent(g);
-    	  if (backgroundImage != null) {
-    		  double scaleX = getWidth() / (double)backgroundImage.getWidth(null);
-    		  double scaleY = getHeight() / (double)backgroundImage.getHeight(null);
-    		  AffineTransform xform = AffineTransform.getScaleInstance(scaleX, scaleY);
-    		  ((Graphics2D)g).drawImage(backgroundImage, xform, this);
-    	  }
-    }
+		// Set default presence icon (Avaialble)
+		statusPanel.setIcon(availableIcon);
+	}
 
 
-    public void loadVCard() {
-        final Runnable loadVCard = () -> {
-            VCard vcard = SparkManager.getVCardManager().getVCard();
-            updateVCardInformation(vcard);
-        };
+	public Collection<StatusItem> getStatusList() {
+		return statusList;
+	}
 
-        TaskEngine.getInstance().submit(loadVCard);
-    }
+	public Collection<CustomStatusItem> getCustomStatusList()
+	{
+		List<CustomStatusItem> custom = CustomMessages.load();
+		if (custom == null)
+			custom = new ArrayList<>();
 
-    protected void updateVCardInformation(final VCard vCard) {
-        SwingUtilities.invokeLater( () -> {
-            if (vCard.getError() == null) {
-                String firstName = vCard.getFirstName();
-                String lastName = vCard.getLastName();
-                String nickname = vCard.getNickName();
-                if (ModelUtil.hasLength(firstName) && ModelUtil.hasLength(lastName)) {
-                    setNickname(firstName + " " + lastName);
-                }
-                else if (ModelUtil.hasLength(firstName)) {
-                    setNickname(firstName);
-                }
-                else if (ModelUtil.hasLength(nickname)) {
-                    setNickname(nickname);
-                }
-                else {
-                    nickname = SparkManager.getSessionManager().getUsername();
-                    setNickname(nickname);
-                }
-            }
-            else {
-                String nickname = SparkManager.getSessionManager().getUsername();
-                setNickname(nickname);
-                return;
-            }
+		// Sort Custom Messages
+		Collections.sort( custom, ( a, b ) -> ( a.getStatus().compareToIgnoreCase( b.getStatus() ) ) );
 
+		return custom;
+	}
 
-            byte[] avatarBytes = null;
-            try {
-                avatarBytes = vCard.getAvatar();
-            }
-            catch (Exception e) {
-                Log.error("Cannot retrieve avatar bytes.", e);
-            }
+	public Presence getPresence() {
+		return currentPresence;
+	}
+
+	public StatusItem getStatusItem(String label) {
+		for (StatusItem aStatusList : statusList) {
+			if (aStatusList.getText().equals(label)) {
+				return aStatusList;
+			}
+		}
+		return null;
+	}
+
+	public void paintComponent(Graphics g) {
+		super.paintComponent(g);
+		if (backgroundImage != null) {
+			double scaleX = getWidth() / (double)backgroundImage.getWidth(null);
+			double scaleY = getHeight() / (double)backgroundImage.getHeight(null);
+			AffineTransform xform = AffineTransform.getScaleInstance(scaleX, scaleY);
+			((Graphics2D)g).drawImage(backgroundImage, xform, this);
+		}
+	}
 
 
-            if (avatarBytes != null && avatarBytes.length > 0) {
-                try {
-                    ImageIcon avatarIcon = new ImageIcon(avatarBytes);
-                    avatarIcon = VCardManager.scale(avatarIcon);
-                    setAvatar(avatarIcon);
-                    imageLabel.invalidate();
-                    imageLabel.validate();
-                    imageLabel.repaint();
-                }
-                catch (Exception e) {
-                    // no issue
-                }
-            }
-            else {
-                imageLabel.setIcon(null);
-                imageLabel.setBorder(null);
-                imageLabel.invalidate();
-                imageLabel.validate();
-                imageLabel.repaint();
-            }
-        } );
+	public void loadVCard() {
+		final Runnable loadVCard = () -> {
+			VCard vcard = SparkManager.getVCardManager().getVCard();
+			updateVCardInformation(vcard);
+		};
 
-    }
-    
-    public static Presence copyPresence(Presence presence) {
-    	return new Presence(presence.getType(), presence.getStatus(), presence.getPriority(), presence.getMode());
-    }
+		TaskEngine.getInstance().submit(loadVCard);
+	}
 
-    /**
-     * Return the nickname Component used to display the users profile name.
-     *
-     * @return the label.
-     */
-    public JLabel getNicknameLabel() {
-        return nicknameLabel;
-    }
+	protected void updateVCardInformation(final VCard vCard) {
+		SwingUtilities.invokeLater( () -> {
+			if (vCard.getError() == null) {
+				String firstName = vCard.getFirstName();
+				String lastName = vCard.getLastName();
+				String nickname = vCard.getNickName();
+				if (ModelUtil.hasLength(firstName) && ModelUtil.hasLength(lastName)) {
+					setNickname(firstName + " " + lastName);
+				}
+				else if (ModelUtil.hasLength(firstName)) {
+					setNickname(firstName);
+				}
+				else if (ModelUtil.hasLength(nickname)) {
+					setNickname(nickname);
+				}
+				else {
+					nickname = SparkManager.getSessionManager().getUsername();
+					setNickname(nickname);
+				}
+			}
+			else {
+				String nickname = SparkManager.getSessionManager().getUsername();
+				setNickname(nickname);
+				return;
+			}
 
-    private class StatusPanel extends JPanel {
+
+			byte[] avatarBytes = null;
+			try {
+				avatarBytes = vCard.getAvatar();
+			}
+			catch (Exception e) {
+				Log.error("Cannot retrieve avatar bytes.", e);
+			}
+
+
+			if (avatarBytes != null && avatarBytes.length > 0) {
+				try {
+					ImageIcon avatarIcon = new ImageIcon(avatarBytes);
+					avatarIcon = VCardManager.scale(avatarIcon);
+					setAvatar(avatarIcon);
+					imageLabel.invalidate();
+					imageLabel.validate();
+					imageLabel.repaint();
+				}
+				catch (Exception e) {
+					// no issue
+				}
+			}
+			else {
+				imageLabel.setIcon(null);
+				imageLabel.setBorder(null);
+				imageLabel.invalidate();
+				imageLabel.validate();
+				imageLabel.repaint();
+			}
+		} );
+
+	}
+
+	public static Presence copyPresence(Presence presence) {
+		return new Presence(presence.getType(), presence.getStatus(), presence.getPriority(), presence.getMode());
+	}
+
+	/**
+	 * Return the nickname Component used to display the users profile name.
+	 *
+	 * @return the label.
+	 */
+	public JLabel getNicknameLabel() {
+		return nicknameLabel;
+	}
+
+	private class StatusPanel extends JPanel {
 		private static final long serialVersionUID = -5086334443225239032L;
 		private JLabel iconLabel;
-        private JLabel statusLabel;
+		private JLabel statusLabel;
 
-        public StatusPanel() {
-            super();
+		public StatusPanel() {
+			super();
 
-            setOpaque(false);
+			setOpaque(false);
 
-            iconLabel = new JLabel();
-            statusLabel = new JLabel();
+			iconLabel = new JLabel();
+			statusLabel = new JLabel();
 
-            setLayout(new GridBagLayout());
+			setLayout(new GridBagLayout());
 
-            // Remove padding from icon label
-            iconLabel.setIconTextGap(0);
+			// Remove padding from icon label
+			iconLabel.setIconTextGap(0);
 
-            add(iconLabel, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
-            add(statusLabel, new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 2, 0, 0), 0, 0));
+			add(iconLabel, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+			add(statusLabel, new GridBagConstraints(1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 2, 0, 0), 0, 0));
 
-            statusLabel.setFont(new Font(Font.DIALOG, Font.PLAIN, 11));
-            
-            // See if we should disable ability to change presence status
+			statusLabel.setFont(new Font(Font.DIALOG, Font.PLAIN, 11));
+
+			// See if we should disable ability to change presence status
 			if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE")) statusLabel.setIcon(SparkRes.getImageIcon(SparkRes.DOWN_ARROW_IMAGE));
-			            
-            statusLabel.setHorizontalTextPosition(JLabel.LEFT);
 
-            setOpaque(false);
+			statusLabel.setHorizontalTextPosition(JLabel.LEFT);
 
-            final Border border = BorderFactory.createEmptyBorder(2, 2, 2, 2);
-            setBorder(border);
+			setOpaque(false);
 
-        	// See if we should disable ability to change presence status
-            if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE")) {
-            	statusLabel.addMouseListener(new MouseAdapter() {
-            		public void mouseReleased(MouseEvent e) {
-            			showPopup(e);
-            		}
-                
-            		public void mouseEntered(MouseEvent e) {
-            			setCursor(GraphicUtils.HAND_CURSOR);
-            			setBorder(BorderFactory.createBevelBorder(0));
-            		}
+			final Border border = BorderFactory.createEmptyBorder(2, 2, 2, 2);
+			setBorder(border);
 
-            		public void mouseExited(MouseEvent e) {
-            			setCursor(GraphicUtils.DEFAULT_CURSOR);
-            			setBorder(border);
-            		}
+			// See if we should disable ability to change presence status
+			if(!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE")) {
+				statusLabel.addMouseListener(new MouseAdapter() {
+					public void mouseReleased(MouseEvent e) {
+						showPopup(e);
+					}
 
-            		public void mousePressed(MouseEvent e) {
-            			setBorder(BorderFactory.createBevelBorder(1));
-            		}
-                	
-            	});
-            }            
+					public void mouseEntered(MouseEvent e) {
+						setCursor(GraphicUtils.HAND_CURSOR);
+						setBorder(BorderFactory.createBevelBorder(0));
+					}
 
-        }
+					public void mouseExited(MouseEvent e) {
+						setCursor(GraphicUtils.DEFAULT_CURSOR);
+						setBorder(border);
+					}
 
-        public void setStatus(String status) {
-            int length = status.length();
-            String visualStatus = status;
-            if (length > 30) {
-                visualStatus = status.substring(0, 27) + "...";
-            }
+					public void mousePressed(MouseEvent e) {
+						setBorder(BorderFactory.createBevelBorder(1));
+					}
 
-            statusLabel.setText(visualStatus);
-            statusLabel.setToolTipText(status);
-        }
+				});
+			}            
 
-        public void setIcon(Icon icon) {
-            iconLabel.setIcon(icon);
-        }
-    }
+		}
 
-    public void setBackgroundImage(Image image) {
-        this.backgroundImage = image;
-    }
+		public void setStatus(String status) {
+			int length = status.length();
+			String visualStatus = status;
+			if (length > 30) {
+				visualStatus = status.substring(0, 27) + "...";
+			}
 
-    public void setDescriptiveText(String text) {
-        descriptiveLabel.setText(text);
-    }
+			statusLabel.setText(visualStatus);
+			statusLabel.setToolTipText(status);
+		}
 
-    public Dimension getPreferredSize() {
-        Dimension dim = super.getPreferredSize();
-        dim.width = 0;
-        return dim;
-    }
+		public void setIcon(Icon icon) {
+			iconLabel.setIcon(icon);
+		}
+	}
+
+	public void setBackgroundImage(Image image) {
+		this.backgroundImage = image;
+	}
+
+	public void setDescriptiveText(String text) {
+		descriptiveLabel.setText(text);
+	}
+
+	public Dimension getPreferredSize() {
+		Dimension dim = super.getPreferredSize();
+		dim.width = 0;
+		return dim;
+	}
 
 
-    public void vcardChanged(VCard vcard) {
-        updateVCardInformation(vcard);
-    }
+	public void vcardChanged(VCard vcard) {
+		updateVCardInformation(vcard);
+	}
 
-    protected Runnable getChangePresenceRunnable() {
-        return changePresenceRunnable;
-    }
+	protected Runnable getChangePresenceRunnable() {
+		return changePresenceRunnable;
+	}
 
-    protected Presence getCurrentPresence() {
-        return currentPresence;
-    }
+	protected Presence getCurrentPresence() {
+		return currentPresence;
+	}
 
-    private String changePresence(Presence presence) {
-        // SPARK-1521. Other clients can see "Invisible" status while we are disappearing.
-        // So we send "Offline" instead of "Invisible" for them.
-    	boolean isNewPresenceInvisible = PresenceManager
+	private String changePresence(Presence presence) {
+		// SPARK-1521. Other clients can see "Invisible" status while we are disappearing.
+		// So we send "Offline" instead of "Invisible" for them.
+		boolean isNewPresenceInvisible = PresenceManager
 				.isInvisible(presence);
 		if (isNewPresenceInvisible && !PrivacyManager.getInstance().isPrivacyActive()) {
-        	JOptionPane.showMessageDialog(null, Res.getString("dialog.invisible.privacy.lists.not.supported"));
-        }
-        
+			JOptionPane.showMessageDialog(null, Res.getString("dialog.invisible.privacy.lists.not.supported"));
+		}
+
 		Presence copyPresence = copyPresence(presence);
 		if (isNewPresenceInvisible) {
 			copyPresence.setStatus(Res.getString("status.offline"));
@@ -678,7 +678,7 @@ public class StatusBar extends JPanel implements VCardListener {
 		// he/she goes to invisible.
 		if (isNewPresenceInvisible
 				&& SparkManager.getChatManager().getChatContainer()
-						.hasGroupChatRooms()) {
+				.hasGroupChatRooms()) {
 			int reply = JOptionPane
 					.showConfirmDialog(
 							null,
@@ -702,17 +702,17 @@ public class StatusBar extends JPanel implements VCardListener {
 		// and send "Available" after "Unavailable" presence.
 		if (isNewPresenceInvisible) {
 			SparkManager.getChatManager().getChatContainer()
-					.closeAllGroupChatRooms();
+			.closeAllGroupChatRooms();
 			PrivacyManager.getInstance().goToInvisible();
 		}
 
 		return presence.getStatus();
-    }
-    
+	}
+
 	protected Presence getPresenceOnStart() {
 		return SettingsManager.getLocalPreferences().isLoginAsInvisible() 
-                ? PresenceManager.getUnavailablePresence() 
-                : PresenceManager.getAvailablePresence();
+				? PresenceManager.getUnavailablePresence() 
+						: PresenceManager.getAvailablePresence();
 	}
 
 }

--- a/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -103,10 +103,8 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
     private Set<ChatRoom> broadcastRooms = new HashSet<>();
    
     public void initialize() {
-        boolean enabled = Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE);
-        if (!enabled) {
-            return;
-        }
+        // See if we should disable all "Broadcast" menu items
+    	if (Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM") || !Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) return;
 
         // Add as ContainerDecoratr
         SparkManager.getChatManager().addSparkTabHandler(this);
@@ -118,10 +116,9 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
         final JMenu actionsMenu = SparkManager.getMainWindow().getMenuByName(Res.getString("menuitem.actions"));
         JMenuItem broadcastMenu = new JMenuItem(Res.getString("title.broadcast.message"), SparkRes.getImageIcon(SparkRes.MEGAPHONE_16x16));
         ResourceUtils.resButton(broadcastMenu, Res.getString("title.broadcast.message"));
-        
-        // See if we should disable all "Broadcast" menu items
-        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) actionsMenu.add(broadcastMenu);
-        
+
+        actionsMenu.add(broadcastMenu);
+
         broadcastMenu.addActionListener( e -> broadcastToRoster() );
 
         // Register with action menu
@@ -175,8 +172,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
                     broadcastMessageAction.putValue(Action.NAME, Res.getString("menuitem.broadcast.to.group"));
                     broadcastMessageAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.MEGAPHONE_16x16));
 
-                    // See if we should disable all "Broadcast" menu items
-                    if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) popup.add(broadcastMessageAction);
+                    popup.add(broadcastMessageAction);
                 }
             }
 

--- a/src/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
@@ -141,20 +141,24 @@ public class ContactListAssistantPlugin implements Plugin {
                     if (contactItems.size() == 1) {
                         // Add right after the rename item.
                         if (index != -1) {
-                            popup.add(moveToMenu, index + 1);
-                            popup.add(copyToMenu, index + 2);
+                        	// See if we should disable the "Move to" and "Copy to" menu options
+                        	if (!Default.getBoolean("DISABLE_MOVE_AND_COPY")) {
+                        		popup.add(moveToMenu, index + 1);
+                        		popup.add(copyToMenu, index + 2);
+                        	}
                         }
                     }
                     else if (contactItems.size() > 1) {
-                        popup.addSeparator();
-                        popup.add(moveToMenu);
-                        popup.add(copyToMenu);
-                        
+                    	// See if we should disable the "Move to" and "Copy to" menu options
+                    	if (!Default.getBoolean("DISABLE_MOVE_AND_COPY")) {                    	
+                    		popup.addSeparator();
+                    		popup.add(moveToMenu);
+                    		popup.add(copyToMenu);
+                    	}                        
+
                         // Clean up the extra separator if "Broadcast" menu items are disabled
                         if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) popup.addSeparator();                        
                     }
-
-
                 }
             }
 

--- a/src/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
@@ -36,6 +36,7 @@ import org.jivesoftware.spark.ui.ContactList;
 import org.jivesoftware.spark.util.SwingWorker;
 import org.jivesoftware.spark.util.UIComponentRegistry;
 import org.jivesoftware.spark.util.log.Log;
+import org.jivesoftware.sparkimpl.plugin.manager.Enterprise;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 
@@ -157,7 +158,7 @@ public class ContactListAssistantPlugin implements Plugin {
                     	}                        
 
                         // Clean up the extra separator if "Broadcast" menu items are disabled
-                        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM")) popup.addSeparator();                        
+                        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM") && Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) popup.addSeparator();                        
                     }
                 }
             }

--- a/src/java/org/jivesoftware/sparkimpl/plugin/scratchpad/ScratchPadPlugin.java
+++ b/src/java/org/jivesoftware/sparkimpl/plugin/scratchpad/ScratchPadPlugin.java
@@ -20,6 +20,7 @@
 package org.jivesoftware.sparkimpl.plugin.scratchpad;
 
 import org.jdesktop.swingx.calendar.DateUtils;
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.resource.SparkRes;
 import org.jivesoftware.spark.SparkManager;
@@ -115,9 +116,12 @@ public class ScratchPadPlugin implements Plugin {
             // Add To toolbar
             final JMenu actionsMenu = SparkManager.getMainWindow().getMenuByName(Res.getString("menuitem.actions"));
             actionsMenu.addSeparator();
-            actionsMenu.add(taskMenu);
-            actionsMenu.add(notesMenu);
 
+            // See if we should disable the "View task list" option under "Actions"
+            if (!Default.getBoolean("DISABLE_VIEW_TASK_LIST")) actionsMenu.add(taskMenu);
+
+            // See if we should disable the "View notes" option under "Actions"
+            if (!Default.getBoolean("DISABLE_VIEW_NOTES")) actionsMenu.add(notesMenu);
 
             // Start notifications.
             new TaskNotification();

--- a/src/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/src/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -19,6 +19,7 @@
  */
 package org.jivesoftware.sparkimpl.profile;
 
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.resource.SparkRes;
 import org.jivesoftware.smack.SmackException;
@@ -228,7 +229,9 @@ public class VCardManager {
 
         int size = contactsMenu.getMenuComponentCount();
 
-        communicatorMenu.insert(editProfileMenu, 1);
+        // See if we should disable the "Edit my profile" option under "File"
+        if (!Default.getBoolean("DISABLE_EDIT_PROFILE")) communicatorMenu.insert(editProfileMenu, 1);
+
         editProfileMenu.addActionListener( e -> {
             SwingWorker vcardLoaderWorker = new SwingWorker() {
                 public Object construct() {

--- a/src/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/src/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -215,10 +215,9 @@ public class VCardManager {
      * Adds VCard capabilities to menus and other components in Spark.
      */
     private void initializeUI() {
-        boolean enabled = Enterprise.containsFeature(Enterprise.VCARD_FEATURE);
-        if (!enabled) {
-            return;
-        }
+
+        // See if we should disable the "Edit my profile" option under "File"
+        if (Default.getBoolean("DISABLE_EDIT_PROFILE") || !Enterprise.containsFeature(Enterprise.VCARD_FEATURE)) return;
 
         // Add Actions Menu
         final JMenu contactsMenu = SparkManager.getMainWindow().getMenuByName(Res.getString("menuitem.contacts"));
@@ -229,8 +228,7 @@ public class VCardManager {
 
         int size = contactsMenu.getMenuComponentCount();
 
-        // See if we should disable the "Edit my profile" option under "File"
-        if (!Default.getBoolean("DISABLE_EDIT_PROFILE")) communicatorMenu.insert(editProfileMenu, 1);
+        communicatorMenu.insert(editProfileMenu, 1);
 
         editProfileMenu.addActionListener( e -> {
             SwingWorker vcardLoaderWorker = new SwingWorker() {


### PR DESCRIPTION
When Broadcasting is disabled in Client Control, Spark only removes Broadcast option from in the main menu and in context menu of a group. But users are still able to select a group of users and send a broadcast to them.