### PR TITLE
SPARK-1853: Fix NPE when not adding an avatar.

### DIFF
--- a/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/src/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -165,11 +165,21 @@ public class StatusBar extends JPanel implements VCardListener {
 	}
 
 	public void setAvatar(Icon icon) {
-		Image image = ImageCombiner.iconToImage(icon);
-		if (icon.getIconHeight() > 64 || icon.getIconWidth() > 64) {
-			imageLabel.setIcon(new ImageIcon(image.getScaledInstance(-1, 64, Image.SCALE_SMOOTH)));
-		} else {
-			imageLabel.setIcon(icon);
+		if ( icon == null )
+		{
+			imageLabel.setIcon( null );
+		}
+		else
+		{
+			Image image = ImageCombiner.iconToImage( icon );
+			if ( icon.getIconHeight() > 64 || icon.getIconWidth() > 64 )
+			{
+				imageLabel.setIcon( new ImageIcon( image.getScaledInstance( -1, 64, Image.SCALE_SMOOTH ) ) );
+			}
+			else
+			{
+				imageLabel.setIcon( icon );
+			}
 		}
 		imageLabel.setBorder(null);
 		revalidate();


### PR DESCRIPTION
This prevents a non-existing avatar from being processed.