### PR TITLE
SPARK-1855: Don't show contact list after logoff.

### DIFF
--- a/src/java/org/jivesoftware/MainWindow.java
+++ b/src/java/org/jivesoftware/MainWindow.java
@@ -414,7 +414,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
             Runtime.getRuntime().exec(command);
             System.exit(0);
             return true;
-        } catch (IOException e) {
+        } catch (Exception e) {
             Log.error("Error trying to restart application with script", e);
             return false;
         }

--- a/src/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/src/java/org/jivesoftware/spark/ui/ContactList.java
@@ -218,9 +218,11 @@ public class ContactList extends JPanel implements ActionListener,
         });
 
         // Save state on shutdown.
+        final ContactList instance = this;
         SparkManager.getMainWindow().addMainWindowListener(new MainWindowListener() {
             public void shutdown() {
                 saveState();
+                SparkManager.getConnection().removeConnectionListener( instance );
             }
 
             public void mainWindowActivated() {


### PR DESCRIPTION
When logging off, the contact list is first hidden, but pops up again as part of the
connection-close event handling. This causes "an error has occurred, would you like to
reconnect" type of message to be displayed. This should be prevented.