### PR TITLE
SPARK-1757 & SPARK-1649: Don't process MUC history as regular messages.

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
@@ -610,17 +610,18 @@ public class GroupChatRoom extends ChatRoom
 
             if ( ModelUtil.hasLength( message.getBody() ) )
             {
-                // Update transcript
-                super.insertMessage( message );
-
                 final String from = XmppStringUtils.parseResource( message.getFrom() );
 
                 if ( inf != null )
                 {
+                    // This is part of the MUC history. No need to add it to the transcript again.
+
+                    // Add to the UI component that shows the chat.
                     getTranscriptWindow().insertHistoryMessage( from, message.getBody(), sentDate );
                 }
                 else
                 {
+                    // A 'regular' chat message.
                     if ( isBlocked( message.getFrom() ) )
                     {
                         return;
@@ -633,6 +634,10 @@ public class GroupChatRoom extends ChatRoom
                         return;
                     }
 
+                    // Update transcript
+                    super.insertMessage( message );
+
+                    // Add to the UI component that shows the chat.
                     getTranscriptWindow().insertMessage( from, message, getColor( from ), getMessageBackground( from, message.getBody() ) );
                 }
             }


### PR DESCRIPTION
when joining a multi user chat room, the recent history of that room can be sent to the client.

A bug in Spark caused these mesages to be processed as history (which is good), but also as
regular/new messages (which is wrong). As a result of this, the messages could be presented in
the wrong order on screen (SPARK-1757), as the original date of the message was not processed.
Also, all event listeners got triggered, causing other components to act as if a new message
was received. This causes issues like SPARK-1649 (unwanted notifications). Finally, the history
was being saved in the local history - which can introduce some duplication there (when a room
is rejoined frequently).