### PR TITLE
Fix for SPARK-1872: Should resize large photo when applying as an avatar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -217,6 +217,11 @@
             <version>4.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.coobird</groupId>
+            <artifactId>thumbnailator</artifactId>
+            <version>0.4.8</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
@@ -442,18 +442,7 @@ public class VCardEditor {
 	vcard.setPhoneHome("CELL", homePanel.getMobile());
 
 	// Save Avatar
-	final File avatarFile = avatarPanel.getAvatarFile();
 	byte[] avatarBytes = avatarPanel.getAvatarBytes();
-
-	if (avatarFile != null) {
-	    avatarBytes = GraphicUtils.getBytesFromImage(avatarFile);
-	    ImageIcon icon = new ImageIcon(avatarBytes);
-	    Image image = icon.getImage();
-	    if (icon.getIconHeight() > 128 || icon.getIconWidth() > 128) {
-	        image = image.getScaledInstance(-1, 128, Image.SCALE_SMOOTH);
-	    } 
-
-	}
 
 	// If avatar bytes, persist as vcard.
 	if (avatarBytes != null) {
@@ -467,7 +456,7 @@ public class VCardEditor {
 	    vcard.save(SparkManager.getConnection());
 
 	    // Notify users.
-	    if (avatarFile != null || avatarBytes != null) {
+	    if (avatarBytes != null) {
 		Presence presence = SparkManager.getWorkspace().getStatusBar()
 			.getPresence();
 		Presence newPresence = new Presence(presence.getType(),


### PR DESCRIPTION
Implemented a image resizing and cropping functionality to resize and crop large images.
Vcards doesn't support large sized images and requires square images. This fix meet both of these requirements.