### PR TITLE
SPARK-1875: Spark history search should show context

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscript.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscript.java
@@ -71,20 +71,29 @@ public class ChatTranscript {
      * @return the messages that included search keywords.
      */
     public List<HistoryMessage> getMessage(String text) {
-    	if(text == null || "".equals(text)) {
-    		return messages;
-    	} else {
-	    	List<HistoryMessage> searchResult = new ArrayList<>();
-	    	for(HistoryMessage message : messages) {
-	    		// ignore keywords' case
-	    		if( message.getBody().toLowerCase().contains( text.toLowerCase() ) ) {
-	    			searchResult.add(message);
-	    		}
-	    	}
-	    	return searchResult;
-    	}
+        if (text == null || "".equals(text)) {
+            return messages;
+        } else {
+            List<HistoryMessage> searchResult = new ArrayList<>();
+            int iter = 0;
+            HistoryMessage previous = null;
+            for(HistoryMessage message : messages) {
+                iter++;
+                if (message.getBody().toLowerCase().contains(text.toLowerCase())) {
+                    if (previous != null) {
+                        searchResult.add(previous);
+                    }
+                    searchResult.add(message);
+                    if (iter + 1 != messages.size()) {
+                        searchResult.add(messages.get(iter + 1));
+                    }
+                }
+                previous = message;
+            }
+            return searchResult;
+        }
     }
-    
+
     /**
      * Clears the Message History if its not needed anymore
      */

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/HistoryTranscript.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/HistoryTranscript.java
@@ -166,8 +166,6 @@ public class HistoryTranscript extends SwingWorker {
 
 	/**
      * Builds html string with the stored messages
-     * @param notificationDateFormatter SimpleDateFormat for formating notifications
-     * @param messageDateFormatter notificationDateFormatter SimpleDateFormat for formating messages
      * @return String containing the messages as html 
      */
     public final String buildString(List<HistoryMessage> messages){


### PR DESCRIPTION
Fixes SPARK-1875:
Added one line before and after searched message.
Added yellow highlighter over searched message.