### PR TITLE
Reload vCards in pre-2.8 schema

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -785,6 +785,12 @@ public class VCardManager {
                     addToQueue(jid);
                 }
             }
+            else
+            {
+            	//vCard xml schema changed 2.7->2.8
+            	//if we have a valid file, but no valid timestamp - reload the vCard (probably in old style) 
+            	addToQueue(jid);
+            }
 
             addVCard(jid, vcard);
             in.close();


### PR DESCRIPTION
After updating from 2.7.6 to 2.8.3 recently our vCards stopped showing information and would no longer update.

Looking at vCard xml it looks like the schema changed after 2.7 which added an extra root node causing files saved in 2.7 not to parse correctly. As the file exists Spark won't fetch the vCard, but because the parser can't get the timestamp (or any other data), it won't refresh it either causing it to get stuck and appear empty. This change regrabs the vCard in that scenario, saving it in the new schema in the process.