### PR TITLE
Don't declare transitive Smack dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,11 +86,6 @@
         </dependency>
         <dependency>
             <groupId>org.igniterealtime.smack</groupId>
-            <artifactId>smack-sasl-javax</artifactId>
-            <version>${dependency.smack.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-extensions</artifactId>
             <version>${dependency.smack.version}</version>
         </dependency>
@@ -122,11 +117,6 @@
         <dependency>
             <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-compression-jzlib</artifactId>
-            <version>${dependency.smack.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.igniterealtime.smack</groupId>
-            <artifactId>smack-resolver-javax</artifactId>
             <version>${dependency.smack.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
The artifacts smack-resolver-javax and smack-sasl-javax are transitive
dependencies of smack-java7. That is all we need to depend on.