### PR TITLE
Transcript Window should be recomposable.

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/Workspace.java
+++ b/core/src/main/java/org/jivesoftware/spark/Workspace.java
@@ -401,7 +401,7 @@ public class Workspace extends JPanel implements StanzaListener {
         }
 
         // Insert offline message
-        room.getTranscriptWindow().insertMessage(nickname, message, ChatManager.FROM_COLOR, Color.white);
+        room.getTranscriptWindow().insertMessage(nickname, message, ChatManager.FROM_COLOR);
         room.addToTranscript(message, true);
 
         // Send display and notified message back.

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatInputEditor.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatInputEditor.java
@@ -154,8 +154,8 @@ public class ChatInputEditor extends ChatArea implements DocumentListener {
     /**
      * Appends the Text at the end
      */
-    public void setText(String str) {
-        super.setText(str);
+    public void appendText(String str) {
+        super.setText( super.getText() + str);
     }
 
     public void removeUpdate(DocumentEvent e) {
@@ -203,96 +203,13 @@ public class ChatInputEditor extends ChatArea implements DocumentListener {
     }
 
     /**
-     * Inserts text into the current document.
+     * Inserts text into the current document at the current caret position.
      *
      * @param text the text to insert
      * @throws BadLocationException if the location is not available for insertion.
      */
-    @Override
     public void insertText(String text) throws BadLocationException {
         final Document doc = getDocument();
-        styles.removeAttribute("link");
-        doc.insertString(this.getCaret().getDot(), text, styles);
+        doc.insertString(this.getCaret().getDot(), text, null);
     }
-
-    /**
-     * Inserts text into the current document.
-     *
-     * @param text  the text to insert
-     * @param color the color of the text
-     * @throws BadLocationException if the location is not available for insertion.
-     */
-    @Override
-    public void insertText(String text, Color color) throws BadLocationException {
-        final Document doc = getDocument();
-        StyleConstants.setForeground(styles, color);
-        doc.insertString(this.getCaret().getDot(), text, styles);
-    }
-
-    /**
-     * Inserts a link into the current document.
-     *
-     * @param link - the link to insert( ex. http://www.javasoft.com )
-     * @throws BadLocationException if the location is not available for insertion.
-     */
-    @Override
-    public void insertLink(String link) throws BadLocationException {
-        final Document doc = getDocument();
-        styles.addAttribute("link", link);
-
-        StyleConstants.setForeground(styles, (Color)UIManager.get("Link.foreground"));
-        StyleConstants.setUnderline(styles, true);
-        doc.insertString(this.getCaret().getDot(), link, styles);
-        StyleConstants.setUnderline(styles, false);
-        StyleConstants.setForeground(styles, (Color)UIManager.get("TextPane.foreground"));
-        styles.removeAttribute("link");
-        setCharacterAttributes(styles, false);
-
-    }
-    
-     /**
-     * Inserts a network address into the current document. 
-     *
-     * @param address - the address to insert( ex. \superpc\etc\file\ OR http://localhost/ )
-     * @throws BadLocationException if the location is not available for insertion.
-     */
-    @Override
-    public void insertAddress(String address) throws BadLocationException {
-        final Document doc = getDocument();
-        styles.addAttribute("link", address);
-
-        StyleConstants.setForeground(styles, (Color)UIManager.get("Address.foreground"));
-        StyleConstants.setUnderline(styles, true);
-        doc.insertString(this.getCaret().getDot(), address, styles);
-        StyleConstants.setUnderline(styles, false);
-        StyleConstants.setForeground(styles, (Color)UIManager.get("TextPane.foreground"));
-        styles.removeAttribute("link");
-        setCharacterAttributes(styles, false);
-
-    }
-
-    /**
-     * Inserts an emotion icon into the current document.
-     *
-     * @param imageKey - the smiley representation of the image.( ex. :) )
-     * @return true if the image was found, otherwise false.
-     */
-    @Override
-    public boolean insertImage(String imageKey) {
-    	
-        if(!forceEmoticons && !SettingsManager.getLocalPreferences().areEmoticonsEnabled() || !emoticonsAvailable){
-            return false;
-        }
-        final Document doc = getDocument();
-        Icon emotion = emoticonManager.getEmoticonImage(imageKey.toLowerCase());
-        if (emotion == null) {
-            return false;
-        }
-
-        select(doc.getLength(), doc.getLength());
-        insertIcon(emotion);
-
-        return true;
-    }
-    
 }

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatRoomTransferHandler.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatRoomTransferHandler.java
@@ -93,7 +93,7 @@ public class ChatRoomTransferHandler extends TransferHandler {
                 Object o = t.getTransferData(flavors[1]);
                 if (o instanceof String) {
                     // Otherwise fire files dropped event.
-                    chatRoom.getChatInputEditor().insert((String)o);
+                    chatRoom.getChatInputEditor().insertText((String)o);
                     return true;
                 }
             }

--- a/core/src/main/java/org/jivesoftware/spark/ui/CustomTextEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/CustomTextEntry.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.spark.ui;
+
+import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
+
+import javax.swing.text.*;
+import java.awt.*;
+import java.time.ZonedDateTime;
+
+/**
+ * Represents a custom text, which is rendered as a line of text in a particular style.
+ *
+ * Typical examples are notifications that someone is joining or leaving a multi-user chatroom.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class CustomTextEntry extends TranscriptWindowEntry
+{
+    private final String message;
+    private final Color textColor;
+    private final boolean bold;
+    private final boolean italic;
+    private final boolean underline;
+    private final boolean strikeThrough;
+
+    protected CustomTextEntry( ZonedDateTime timestamp, String message, Color textColor, boolean bold, boolean italic, boolean underline, boolean strikeThrough )
+    {
+        super( timestamp );
+        this.message = message;
+        this.textColor = textColor;
+        this.bold = bold;
+        this.italic = italic;
+        this.underline = underline;
+        this.strikeThrough = strikeThrough;
+    }
+
+    protected CustomTextEntry( ZonedDateTime timestamp, String message, Color textColor )
+    {
+        this( timestamp, message, textColor, false, false, false, false );
+    }
+
+    protected AttributeSet getStyle()
+    {
+        final MutableAttributeSet style = new SimpleAttributeSet();
+        StyleConstants.setFontFamily( style, "Dialog" );
+        StyleConstants.setFontSize( style, SettingsManager.getLocalPreferences().getChatRoomFontSize() );
+        StyleConstants.setForeground( style, textColor );
+        StyleConstants.setBold( style, bold );
+        StyleConstants.setItalic( style, italic );
+        StyleConstants.setUnderline( style, underline );
+        StyleConstants.setStrikeThrough( style, strikeThrough );
+        return style;
+    }
+
+    @Override
+    protected void addTo( ChatArea chatArea ) throws BadLocationException
+    {
+        final Document doc = chatArea.getDocument();
+
+        doc.insertString( doc.getLength(), message + "\n", getStyle() );
+        chatArea.setCaretPosition( doc.getLength() );
+    }
+}

--- a/core/src/main/java/org/jivesoftware/spark/ui/HorizontalLineEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/HorizontalLineEntry.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.spark.ui;
+
+import javax.swing.*;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import java.time.ZonedDateTime;
+
+/**
+ * A entry that is displayed as a horizontal line.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class HorizontalLineEntry extends TranscriptWindowEntry
+{
+    public HorizontalLineEntry()
+    {
+        super( ZonedDateTime.now() );
+    }
+
+    public HorizontalLineEntry( ZonedDateTime timestamp )
+    {
+        super( timestamp );
+    }
+
+    @Override
+    protected void addTo( ChatArea chatArea ) throws BadLocationException
+    {
+        final Document doc = chatArea.getDocument();
+
+        chatArea.insertComponent( new JSeparator() );
+        doc.insertString(doc.getLength(), "\n", null );
+        chatArea.setCaretPosition(doc.getLength());
+    }
+}

--- a/core/src/main/java/org/jivesoftware/spark/ui/MessageEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/MessageEntry.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.spark.ui;
+
+import org.jivesoftware.sparkimpl.plugin.emoticons.EmoticonManager;
+import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
+
+import javax.swing.*;
+import javax.swing.text.*;
+import java.awt.*;
+import java.time.ZonedDateTime;
+import java.util.StringTokenizer;
+
+/**
+ * An entry that represents a single (chat) message.
+ *
+ * An entry is displayed in this format: <tt>(timestamp) prefix: message</tt>,
+ * for example: <tt>(10:03) Guus: Hello everyone!</tt>
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class MessageEntry extends TimeStampedEntry
+{
+    private final String prefix;
+    private final Color prefixColor;
+    private final String message;
+    private final Color messageColor;
+    private final Color backgroundColor;
+
+    /**
+     * Creates a new entry using the default background color (white/transparent).
+     *
+     * @param timestamp The timestamp of the entry (cannot be null).
+     * @param prefix The prefix of the message (typically, the name of the author of the message.
+     * @param prefixColor The color to be used for the timestamp and prefix text.
+     * @param message The message text itself.
+     * @param messageColor The color to be used for the message text.
+     */
+    public MessageEntry( ZonedDateTime timestamp, String prefix, Color prefixColor, String message, Color messageColor )
+    {
+        this( timestamp, prefix, prefixColor, message, messageColor, null );
+    }
+
+    /**
+     * Creates a new entry using the default background color (white/transparent).
+     *
+     * @param timestamp The timestamp of the entry (cannot be null).
+     * @param prefix The prefix of the message (typically, the name of the author of the message.
+     * @param prefixColor The color to be used for the timestamp and prefix text.
+     * @param message The message text itself.
+     * @param messageColor The color to be used for the message text.
+     * @param backgroundColor The color to be used for the entire entry (prefix as well ass message text).
+     */
+    public MessageEntry( ZonedDateTime timestamp, String prefix, Color prefixColor, String message, Color messageColor, Color backgroundColor )
+    {
+        super( timestamp );
+        this.prefix = prefix == null ? "" : prefix;
+        this.prefixColor = prefixColor;
+        this.message = message;
+        this.messageColor = messageColor;
+        this.backgroundColor = backgroundColor != null ? backgroundColor : new Color( 255, 255, 255, 0);
+    }
+
+    protected AttributeSet getPrefixStyle()
+    {
+        final MutableAttributeSet style = new SimpleAttributeSet();
+        StyleConstants.setFontFamily( style, "Dialog" );
+        StyleConstants.setFontSize( style, SettingsManager.getLocalPreferences().getChatRoomFontSize() );
+        StyleConstants.setForeground( style, prefixColor );
+        StyleConstants.setBackground( style, backgroundColor );
+        return style;
+    }
+
+    protected AttributeSet getMessageStyle()
+    {
+        final MutableAttributeSet style = new SimpleAttributeSet();
+        StyleConstants.setFontFamily( style, "Dialog" );
+        StyleConstants.setFontSize( style, SettingsManager.getLocalPreferences().getChatRoomFontSize() );
+        StyleConstants.setForeground( style, messageColor );
+        StyleConstants.setBackground( style, backgroundColor );
+        return style;
+    }
+
+    @Override
+    protected void addTo( ChatArea chatArea ) throws BadLocationException
+    {
+        final AttributeSet prefixStyle = getPrefixStyle();
+        final AttributeSet messageStyle = getMessageStyle();
+
+        // First, add the message prefix.
+        final Document doc = chatArea.getDocument();
+        doc.insertString( doc.getLength(), getFormattedTimestamp() + prefix + ": ", prefixStyle );
+
+        // Next, process the message, bit by bit.
+        final StringTokenizer tokenizer = new StringTokenizer( message, " \n\t", true );
+        while ( tokenizer.hasMoreTokens() )
+        {
+            String textFound = tokenizer.nextToken();
+
+            if ( ( textFound.startsWith( "http://" ) || textFound.startsWith( "ftp://" ) || textFound.startsWith( "https://" ) || textFound.startsWith( "www." ) || textFound.startsWith( "file:/" ) ) && textFound.indexOf( "." ) > 1 )
+            {
+                insertLink( doc, textFound );
+            }
+            else if ( textFound.startsWith( "\\\\" ) || ( textFound.indexOf( "://" ) > 0 && textFound.indexOf( "." ) < 1 ) )
+            {
+                insertAddress( doc, textFound );
+            }
+            else if ( !insertImage( chatArea, textFound ) )
+            {
+                doc.insertString( doc.getLength(), textFound, messageStyle );
+            }
+        }
+
+        doc.insertString( doc.getLength(), "\n", messageStyle );
+        chatArea.setCaretPosition( doc.getLength() );
+    }
+
+    /**
+     * Inserts a link into the current document.
+     *
+     * @param link - the link to insert( ex. http://www.javasoft.com )
+     * @throws BadLocationException if the location is not available for insertion.
+     */
+    public void insertLink( Document doc, String link ) throws BadLocationException
+    {
+        // Create a new style, based on the style used for generic text, for the link.
+        final MutableAttributeSet linkStyle = new SimpleAttributeSet( getMessageStyle().copyAttributes() );
+        StyleConstants.setForeground( linkStyle, (Color) UIManager.get( "Link.foreground" ) );
+        StyleConstants.setUnderline( linkStyle, true );
+        linkStyle.addAttribute( "link", link );
+
+        doc.insertString( doc.getLength(), link, linkStyle );
+    }
+
+    /**
+     * Inserts a network address into the current document.
+     *
+     * @param address - the address to insert( ex. \superpc\etc\file\ OR http://localhost/ )
+     * @throws BadLocationException if the location is not available for insertion.
+     */
+    public void insertAddress( Document doc, String address ) throws BadLocationException
+    {
+        // Create a new style, based on the style used for generic text, for the address.
+        final MutableAttributeSet addressStyle = new SimpleAttributeSet( getMessageStyle().copyAttributes() );
+        StyleConstants.setForeground( addressStyle, (Color) UIManager.get( "Address.foreground" ) );
+        StyleConstants.setUnderline( addressStyle, true );
+        addressStyle.addAttribute( "link", address );
+
+        doc.insertString( doc.getLength(), address, addressStyle );
+    }
+
+    /**
+     * Inserts an emotion icon into the current document.
+     *
+     * @param imageKey - the smiley representation of the image.( ex. :) )
+     * @return true if the image was found, otherwise false.
+     */
+    public boolean insertImage( ChatArea chatArea, String imageKey )
+    {
+        if ( !chatArea.getForceEmoticons() && !SettingsManager.getLocalPreferences().areEmoticonsEnabled() || !chatArea.emoticonsAvailable )
+        {
+            return false;
+        }
+
+        final Icon emotion = EmoticonManager.getInstance().getEmoticonImage( imageKey.toLowerCase() );
+        if ( emotion == null )
+        {
+            return false;
+        }
+
+        final Document doc = chatArea.getDocument();
+        chatArea.select( doc.getLength(), doc.getLength() );
+
+        chatArea.insertIcon( emotion );
+        return true;
+    }
+}

--- a/core/src/main/java/org/jivesoftware/spark/ui/StartOfDayEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/StartOfDayEntry.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.spark.ui;
+
+import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
+
+import javax.swing.text.*;
+import java.awt.*;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * A text entry that denotes the start of a (new) day.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class StartOfDayEntry extends TranscriptWindowEntry
+{
+    private static final MutableAttributeSet STYLE;
+
+    private static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern( "EEEE, dd MMMM yyyy" );
+
+    static
+    {
+        STYLE = new SimpleAttributeSet();
+        StyleConstants.setFontFamily( STYLE, "Dialog" );
+        StyleConstants.setFontSize( STYLE, SettingsManager.getLocalPreferences().getChatRoomFontSize() );
+        StyleConstants.setBold( STYLE, true );
+        StyleConstants.setUnderline( STYLE, true );
+        StyleConstants.setForeground( STYLE, Color.BLACK );
+    }
+
+    protected StartOfDayEntry( ZonedDateTime timestamp )
+    {
+        super( timestamp );
+    }
+
+    @Override
+    protected void addTo( ChatArea chatArea ) throws BadLocationException
+    {
+        // Get the instant that represents the start of the day in the local time-zone.
+        final LocalDateTime startOfDay = getTimestamp().withZoneSameInstant( ZoneId.systemDefault() ).toLocalDate().atStartOfDay();
+
+        final String startOfDayMessage = FORMAT.format( startOfDay );
+
+        final Document doc = chatArea.getDocument();
+        doc.insertString(doc.getLength(), startOfDayMessage + '\n', STYLE );
+        chatArea.setCaretPosition(doc.getLength());
+    }
+}

--- a/core/src/main/java/org/jivesoftware/spark/ui/TimeStampedEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/TimeStampedEntry.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.spark.ui;
+
+import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * An entry that is prefixed with a time stamp.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public abstract class TimeStampedEntry extends TranscriptWindowEntry
+{
+    private final DateTimeFormatter format;
+
+    protected TimeStampedEntry( ZonedDateTime timestamp )
+    {
+        super( timestamp );
+        format = DateTimeFormatter.ofPattern( SettingsManager.getLocalPreferences().getTimeFormat() );
+    }
+
+    protected String getFormattedTimestamp()
+    {
+        // Convert the zoned timestamp to a timestamp in the local zone.
+        final LocalDateTime localDateTime = getTimestamp().withZoneSameInstant( ZoneId.systemDefault() ).toLocalDateTime();
+
+        // Use the local timestamp to format a message that will be displayed to the end-user.
+        return "(" + format.format( localDateTime ) + ") ";
+    }
+}

--- a/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2004-2011 Jive Software. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,6 @@
  */
 package org.jivesoftware.spark.ui;
 
-import org.jdesktop.swingx.calendar.DateUtils;
 import org.jivesoftware.Spark;
 import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
@@ -29,6 +28,7 @@ import org.jivesoftware.spark.plugin.ContextMenuListener;
 import org.jivesoftware.spark.ui.history.HistoryWindow;
 import org.jivesoftware.spark.util.ModelUtil;
 import org.jivesoftware.spark.util.log.Log;
+import org.jivesoftware.sparkimpl.plugin.emoticons.EmoticonManager;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.util.XmppStringUtils;
@@ -43,112 +43,189 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Iterator;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.*;
 import java.util.List;
 
 /**
- * The <CODE>TranscriptWindow</CODE> class. Provides a default implementation
- * of a Chat Window. In general, extensions could override this class
- * to offer more support within the chat, but should not be necessary.
+ * Provides a window in which a chat is presented to the end user, by listing all chat messages in order. This
+ * implementation is usable for both one-on-one chats, as well as multi-user chats.
+ *
+ * The class primary responsibility is to maintain an (time-based) ordered list of entries, and provides various methods
+ * to add new entries. Responsibility for the visual representation of each entry is delegated to the implementation of
+ * that entry.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
  */
-public class TranscriptWindow extends ChatArea implements ContextMenuListener {
-
-	private static final long serialVersionUID = -2168845249388070573L;
-	private final SimpleDateFormat notificationDateFormatter;
-
-    //code from SPARK-905 patch; it brakes message receiving when there is no old message in the window
-    //also related code on 181-186 lines   
-    //private SimpleDateFormat myDateFormat = new SimpleDateFormat("dd.MM.yyyy");
-    
-    private Date lastUpdated;
-
+public class TranscriptWindow extends ChatArea implements ContextMenuListener
+{
     /**
-     * The default font used in the chat window for all messages.
+     * Unless specifically documented otherwise, content is stored in an in-memory cache of {@link TranscriptWindowEntry}s.
+     * This cache is used to recompose the UI when needed (which typically occurs when entries are added out-of-order).
      */
-    private Font defaultFont;
-
-    private Date lastPost;
+    private final LinkedList<TranscriptWindowEntry> entries = new LinkedList<>();
 
     /**
      * Creates a default instance of <code>TranscriptWindow</code>.
      */
-    public TranscriptWindow() {
-        setEditable(false);
+    public TranscriptWindow()
+    {
+        setEditable( false );
 
-        // Set Default Font
-        final LocalPreferences pref = SettingsManager.getLocalPreferences();
-        int fontSize = pref.getChatRoomFontSize();
-        defaultFont = new Font("Dialog", Font.PLAIN, fontSize);
+        Collection<String> emoticonPacks;
+        emoticonPacks = EmoticonManager.getInstance().getEmoticonPacks();
 
+        if ( emoticonPacks == null )
+        {
+            emoticonsAvailable = false;
+        }
 
-        addMouseListener(this);
-        addMouseMotionListener(this);
-        setDragEnabled(true);
-        addContextMenuListener(this);
+        addMouseListener( this );
+        addMouseMotionListener( this );
+        setDragEnabled( true );
+        addContextMenuListener( this );
 
         // Make sure ctrl-c works
-        getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("Ctrl c"), "copy");
+        getInputMap( JComponent.WHEN_IN_FOCUSED_WINDOW ).put( KeyStroke.getKeyStroke( "Ctrl c" ), "copy" );
 
-        getActionMap().put("copy", new AbstractAction("copy") {
-			private static final long serialVersionUID = 1797491846835591379L;
+        getActionMap().put( "copy", new AbstractAction( "copy" )
+        {
+            private static final long serialVersionUID = 1797491846835591379L;
 
-			public void actionPerformed(ActionEvent evt) {
-                StringSelection stringSelection = new StringSelection(getSelectedText());
-                Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
+            public void actionPerformed( ActionEvent evt )
+            {
+                StringSelection stringSelection = new StringSelection( getSelectedText() );
+                Toolkit.getDefaultToolkit().getSystemClipboard().setContents( stringSelection, null );
             }
-        });
+        } );
 
-        String notificationDateFormat = ( (SimpleDateFormat) SimpleDateFormat.getDateInstance( SimpleDateFormat.FULL ) ).toPattern();
-        notificationDateFormatter = new SimpleDateFormat( notificationDateFormat );
     }
+
+    protected synchronized void add( TranscriptWindowEntry entry )
+    {
+        final TranscriptWindow transcriptWindow = this;
+        //boolean reorderEverything = false;
+        if ( !entries.isEmpty() )
+        {
+            if ( entry.getTimestamp().isBefore( entries.getLast().getTimestamp() ) )
+            {
+                Log.warning( "A chat entry appears to have been delivered out of order. The transcript window must be reordered!" );
+                //reorderEverything = true;
+
+                // This is an alternative approach to the 'reorderEverything boolean + routine. The idea behind using the
+                // SwingUtilities is to schedule redrawing after all currently queued messages (loads of which are
+                // probably also out of order), are processed, which should reduce the amount of redraws.
+                SwingUtilities.invokeLater( () ->
+                                            {
+                                                // Clear and refill the UI component.
+                                                try
+                                                {
+                                                    entries.sort( Comparator.comparing( TranscriptWindowEntry::getTimestamp ) );
+                                                    clear();
+                                                    for ( TranscriptWindowEntry e : entries )
+                                                    {
+                                                        e.addTo( transcriptWindow );
+                                                    }
+                                                }
+                                                catch ( BadLocationException ex )
+                                                {
+                                                    Log.error( "An exception prevented chat content to be redrawn in the user interface!", ex );
+                                                }
+                                            } );
+            }
+            else if ( !entry.getTimestamp().withZoneSameInstant( ZoneId.systemDefault() ).toLocalDate().isEqual( entries.getLast().getTimestamp().withZoneSameInstant( ZoneId.systemDefault() ).toLocalDate() ) )
+            {
+                // The date appeared to have rolled over, since the last entry. Add a 'start-of-day' entry before we add
+                // the new entry, unless we're already in the process of adding exactly that 'start-of-day' entry.
+                final StartOfDayEntry startOfDayEntry = new StartOfDayEntry( entry.getTimestamp() );
+                if ( !entry.equals( startOfDayEntry ) )
+                {
+                    add( startOfDayEntry );
+                }
+            }
+        }
+
+        entries.add( entry );
+
+        try
+        {
+//            if ( reorderEverything )
+//            {
+//                // Clear and refill the UI component.
+//                entries.sort( Comparator.comparing( TranscriptWindowEntry::getTimestamp ) );
+//                clear();
+//                for ( TranscriptWindowEntry e : entries )
+//                {
+//                    e.addTo( this );
+//                }
+//            }
+//            else
+            {
+                entry.addTo( this );
+            }
+        }
+        catch ( BadLocationException ex )
+        {
+            Log.error( "An exception prevented chat content to be displayed in the user interface!", ex );
+        }
+    }
+
 
     /**
      * Inserts a component into the transcript window.
      *
      * @param component the component to insert.
      */
-    public void addComponent(Component component) {
-        final StyledDocument doc = (StyledDocument)getDocument();
+    public void addComponent( Component component )
+    {
+        final StyledDocument doc = (StyledDocument) getDocument();
 
         // The image must first be wrapped in a style
-        Style style = doc.addStyle("StyleName", null);
+        Style style = doc.addStyle( "StyleName", null );
 
 
-        StyleConstants.setComponent(style, component);
+        StyleConstants.setComponent( style, component );
 
         // Insert the image at the end of the text
-        try {
-            doc.insertString(doc.getLength(), "ignored text", style);
-            doc.insertString(doc.getLength(), "\n", null);
+        try
+        {
+            doc.insertString( doc.getLength(), "ignored text", style );
+            doc.insertString( doc.getLength(), "\n", null );
         }
-        catch (BadLocationException e) {
-            Log.error(e);
+        catch ( BadLocationException e )
+        {
+            Log.error( e );
         }
-    }
-
-   /**
-    * Create and insert a message from the current user.
-    *
-    * @param nickname   the nickname of the current user.
-    * @param message    the message to insert.
-    * @param foreground the color to use for the message foreground.
-    */
-    public void insertMessage(String nickname, Message message, Color foreground) {
-        insertMessage(nickname, message, foreground, Color.white);
     }
 
     /**
-     * Create and insert a message from the current user.
+     * Adds a text message this transcript window.
      *
-     * @param nickname   the nickname of the current user.
+     * Unless the provided message defines a timestamp (for instance, when a 'delay' extension is present), the message
+     * timestamp is assumed to be 'now'.
+     *
+     * @param nickname   the nickname of the author of the message.
      * @param message    the message to insert.
-     * @param foreground the color to use for the message foreground.
-     * @param background the color to use for the message background.
+     * @param foreground the color to use for the nickname (excluding the message text) foreground.
      */
-    public void insertMessage(String nickname, Message message, Color foreground, Color background) {
-        // Check interceptors.
-        for (TranscriptWindowInterceptor interceptor : SparkManager.getChatManager().getTranscriptWindowInterceptors())
+    public void insertMessage( String nickname, Message message, Color foreground )
+    {
+        insertMessage( nickname, message, foreground, null );
+    }
+
+    /**
+     * Adds a text message this transcript window.
+     *
+     * @param nickname   the nickname of the author of the message.
+     * @param message    the message to insert.
+     * @param foreground the color to use for the nickname (excluding the message text) foreground.
+     * @param background the color to use for the entire background (eg, to highlight).
+     */
+    public void insertMessage( String nickname, Message message, Color foreground, Color background )
+    {
+        for ( TranscriptWindowInterceptor interceptor : SparkManager.getChatManager().getTranscriptWindowInterceptors() )
         {
             try
             {
@@ -167,252 +244,119 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener {
 
         String body = message.getBody();
 
-        //code from SPARK-905 patch; it brakes message receiving when there is no old message in the window
-        //also related code on 80 line
-        /*Date dateToday = new Date();
-        if(myDateFormat.format(lastPost).compareTo(myDateFormat.format(dateToday)) != 0)
+        // Verify the timestamp of this message. Determine if it is a 'live' message, or one that was sent earlier.
+        final DelayInformation inf = message.getExtension( "delay", "urn:xmpp:delay" );
+        final ZonedDateTime sentDate;
+        if ( inf != null )
         {
-        insertCustomText(notificationDateFormatter.format(dateToday), true, true, Color.BLACK);
-        lastPost = dateToday;
-        }*/
-        
-        try {
-            DelayInformation inf = message.getExtension("delay", "urn:xmpp:delay");
-            Date sentDate;
-            if (inf != null) {
-                sentDate = inf.getStamp();
-
-                body = "(" + Res.getString("offline") + ") " + body;
-            }
-            else {
-                sentDate = new Date();
-            }
-
-            String date = getDate(sentDate);
-
-            // Agent color is always blue
-            StyleConstants.setBold(styles, false);
-            StyleConstants.setForeground(styles, foreground);
-            StyleConstants.setBackground(styles, background);
-            final Document doc = getDocument();
-            styles.removeAttribute("link");
-
-            StyleConstants.setFontSize(styles, defaultFont.getSize());
-            doc.insertString(doc.getLength(), date + nickname + ": ", styles);
-
-            // Reset Styles for message
-            StyleConstants.setBold(styles, false);
-
-            StyleConstants.setForeground(styles, getMessageColor());
-            setText(body);
-            insertText("\n");
+            sentDate = inf.getStamp().toInstant().atZone( ZoneOffset.UTC );
+            body = "(" + Res.getString( "offline" ) + ") " + body;
         }
-        catch (BadLocationException e) {
-            Log.error("Error message.", e);
+        else
+        {
+            sentDate = ZonedDateTime.now();
         }
+
+        add( new MessageEntry( sentDate, nickname, foreground, body, (Color) UIManager.get( "Message.foreground" ), background ) );
     }
 
+
     /**
-     * Inserts a full line using a prefix and message.
+     * Adds a notification message this transcript window. A notification message generally is a presence update, but
+     * can be used for most anything related to the room.
      *
-     * @param prefix     the prefix to use. If null is used, then only the message will be inserted.
-     * @param message    the message to insert.
-     * @param foreground the foreground color for the message.
-     */
-    public void insertPrefixAndMessage(String prefix, String message, Color foreground) {
-        try {
-            // Agent color is always blue
-            StyleConstants.setBold(styles, false);
-            StyleConstants.setForeground(styles, foreground);
-            final Document doc = getDocument();
-            styles.removeAttribute("link");
-
-            StyleConstants.setFontSize(styles, defaultFont.getSize());
-            if (prefix != null) {
-                doc.insertString(doc.getLength(), prefix + ": ", styles);
-            }
-
-            // Reset Styles for message
-            StyleConstants.setBold(styles, false);
-
-            StyleConstants.setForeground(styles, getMessageColor());
-            setText(message);
-            insertText("\n");
-        }
-        catch (BadLocationException e) {
-            Log.error("Error message.", e);
-        }
-    }
-
-    protected Color getMessageColor() {
-        return Color.BLACK;
-    }
-
-
-    /**
-     * Create and insert a notification message. A notification message generally is a
-     * presence update, but can be used for most anything related to the room.
+     * The message timestamp is assumed to be 'now'.
      *
      * @param message         the information message to insert.
      * @param foregroundColor the foreground color to use.
      */
-    public synchronized void insertNotificationMessage(String message, Color foregroundColor) {
-        try {
-            // Agent color is always blue
-            StyleConstants.setBold(styles, false);
-            StyleConstants.setForeground(styles, foregroundColor);
-            final Document doc = getDocument();
-            styles.removeAttribute("link");
-
-            StyleConstants.setFontSize(styles, defaultFont.getSize());
-            doc.insertString(doc.getLength(), "", styles);
-
-            // Reset Styles for message
-            StyleConstants.setBackground(styles, new Color(0,0,0,0));
-            StyleConstants.setBold(styles, false);
-            StyleConstants.setForeground(styles, foregroundColor);
-            setText(message);
-            insertText("\n");
-
-            // Default back to black
-            StyleConstants.setForeground(styles, Color.black);
-        }
-        catch (BadLocationException ex) {
-            Log.error("Error message.", ex);
-        }
+    public synchronized void insertNotificationMessage( String message, Color foregroundColor )
+    {
+        add( new CustomTextEntry( ZonedDateTime.now(), message, foregroundColor ) );
     }
 
     /**
-     * Create and insert a notification message. A notification message generally is a
-     * presence update, but can be used for most anything related to the room.
+     * Adds a custom text message this transcript window.
+     *
+     * The message timestamp is assumed to be 'now'.
      *
      * @param text       the text to insert.
      * @param bold       true to use bold text.
      * @param underline  true to have text underlined.
      * @param foreground the foreground color.
      */
-    public synchronized void insertCustomText(String text, boolean bold, boolean underline, Color foreground) {
-        try {
-            // Agent color is always blue
-            StyleConstants.setBold(styles, true);
-            StyleConstants.setForeground(styles, foreground);
-            final Document doc = getDocument();
-            styles.removeAttribute("link");
-
-            StyleConstants.setFontSize(styles, defaultFont.getSize());
-            doc.insertString(doc.getLength(), "", styles);
-
-            // Reset Styles for message
-            StyleConstants.setBold(styles, bold);
-            StyleConstants.setUnderline(styles, underline);
-            StyleConstants.setForeground(styles, foreground);
-            setText(text);
-            insertText("\n");
-            StyleConstants.setUnderline(styles, false);
-            StyleConstants.setForeground(styles, Color.black);
-        }
-        catch (BadLocationException ex) {
-            Log.error("Error message.", ex);
-        }
+    public synchronized void insertCustomText( String text, boolean bold, boolean underline, Color foreground )
+    {
+        add( new CustomTextEntry( ZonedDateTime.now(), text, foreground, bold, false, underline, false ) );
     }
 
-
     /**
-     * Returns the formatted date.
+     * Adds a custom text message this transcript window.
      *
-     * @param insertDate the date to format.
-     * @return the formatted date.
-     */
-    private String getDate(Date insertDate) {
-        final LocalPreferences pref = SettingsManager.getLocalPreferences();
-
-        if (insertDate == null) {
-            insertDate = new Date();
-        }
-
-        StyleConstants.setFontFamily(styles, defaultFont.getFontName());
-        StyleConstants.setFontSize(styles, defaultFont.getSize());
-
-        if (pref.isTimeDisplayedInChat()) {
-
-            final SimpleDateFormat formatter = new SimpleDateFormat(pref.getTimeFormat());
-            final String date = formatter.format(insertDate);
-
-            return "(" + date + ") ";
-        }
-        lastUpdated = insertDate;
-        return "";
-    }
-
-
-    /**
-     * Return the last time the <code>TranscriptWindow</code> was updated.
+     * The message timestamp is assumed to be 'now'.
      *
-     * @return the last time the <code>TranscriptWindow</code> was updated.
+     * @param text          the text to insert.
+     * @param bold          true to use bold text.
+     * @param italic        true to use italic text.
+     * @param underline     true to have text underlined.
+     * @param strikeThrough true to have text strike through.
+     * @param foreground    the foreground color.
      */
-    public Date getLastUpdated() {
-        return lastUpdated;
+    public synchronized void insertCustomText( String text, boolean bold, boolean italic, boolean underline, boolean strikeThrough, Color foreground )
+    {
+        add( new CustomTextEntry( ZonedDateTime.now(), text, foreground, bold, italic, underline, strikeThrough ) );
     }
 
     /**
-     * Inserts a history message.
+     * Return the timestamp of the last entry that was added to this transcript window.
+     *
+     * If there is no entries in this window, the 'epoch' date, January 1, 1970, 00:00:00 GMT, is returned.
+     *
+     * @return the timestamp of the last entry in this window, or 'epoch' when there are no entries.
+     */
+    public Date getLastUpdated()
+    {
+        if ( entries.isEmpty() )
+        {
+            new Date( 0 );
+        }
+        return Date.from( entries.getLast().getTimestamp().toInstant() );
+    }
+
+    /**
+     * Adds a historic text message to this transcript window. These typically are messages that were added to a chat
+     * before the local user joined the chat.
      *
      * @param userid  the userid of the sender.
      * @param message the message to insert.
-     * @param date    the Date object created when the message was delivered.
+     * @param date    the timestamp of the message.
      */
-    public void insertHistoryMessage(String userid, String message, Date date) {
-        try {
-            String value;
+    public void insertHistoryMessage( String userid, String message, Date date )
+    {
+        final ZonedDateTime sentDate = date.toInstant().atZone( ZoneOffset.UTC );
+        final Color historyColor = (Color) UIManager.get( "History.foreground" );
 
-            long lastPostTime = lastPost != null ? lastPost.getTime() : 0;
-            long lastPostStartOfDay = DateUtils.startOfDayInMillis(lastPostTime);
-            long newPostStartOfDay = DateUtils.startOfDayInMillis(date.getTime());
+        add( new MessageEntry( sentDate, userid, historyColor, message, historyColor ) );
+    }
 
-            int diff = DateUtils.getDaysDiff(lastPostStartOfDay, newPostStartOfDay);
-            if (diff != 0) {
-                insertCustomText(notificationDateFormatter.format(date), true, true, Color.BLACK);
-            }
-
-            value = getDate(date);
-            value = value + userid + ": ";
-
-
-            lastPost = date;
-
-            // Agent color is always blue
-            StyleConstants.setBold(styles, false);
-            StyleConstants.setForeground(styles, Color.BLACK);
-            final Document doc = getDocument();
-            styles.removeAttribute("link");
-
-            StyleConstants.setFontSize(styles, defaultFont.getSize());
-            doc.insertString(doc.getLength(), value, styles);
-
-            // Reset Styles for message
-            StyleConstants.setBold(styles, false);
-            StyleConstants.setForeground(styles, (Color)UIManager.get("History.foreground"));
-            setText(message);
-            StyleConstants.setForeground(styles, Color.BLACK);
-            insertText("\n");
-        }
-        catch (BadLocationException ex) {
-            Log.error("Error message.", ex);
-        }
+    public void insertHorizontalLine()
+    {
+        add( new HorizontalLineEntry() );
     }
 
     /**
      * Disable the entire <code>TranscriptWindow</code> and visually represent
      * it as disabled.
      */
-    public void showWindowDisabled() {
+    public void showWindowDisabled()
+    {
         final Document document = getDocument();
         final SimpleAttributeSet attrs = new SimpleAttributeSet();
-        StyleConstants.setForeground(attrs, Color.LIGHT_GRAY);
+        StyleConstants.setForeground( attrs, Color.LIGHT_GRAY );
 
         final int length = document.getLength();
         StyledDocument styledDocument = getStyledDocument();
-        styledDocument.setCharacterAttributes(0, length, attrs, false);
+        styledDocument.setCharacterAttributes( 0, length, attrs, false );
     }
 
     /**
@@ -423,97 +367,99 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener {
      * @param headerData the string to prepend to the transcript.
      * @see ChatRoom#getTranscripts()
      */
-    public void saveTranscript(String fileName, List<Message> transcript, String headerData) {
+    public void saveTranscript( String fileName, List<Message> transcript, String headerData )
+    {
         final LocalPreferences pref = SettingsManager.getLocalPreferences();
 
-        try {
+        try
+        {
             SimpleDateFormat formatter;
 
-            File defaultSaveFile = new File(Spark.getSparkUserHome() + "/" + fileName);
-            final JFileChooser fileChooser = new JFileChooser(defaultSaveFile);
-            fileChooser.setSelectedFile(defaultSaveFile);
+            File defaultSaveFile = new File( Spark.getSparkUserHome() + "/" + fileName );
+            final JFileChooser fileChooser = new JFileChooser( defaultSaveFile );
+            fileChooser.setSelectedFile( defaultSaveFile );
 
             // Show save dialog; this method does not return until the dialog is closed
-            int result = fileChooser.showSaveDialog(this);
+            int result = fileChooser.showSaveDialog( this );
             final File selFile = fileChooser.getSelectedFile();
 
-            if (selFile != null && result == JFileChooser.APPROVE_OPTION) {
+            if ( selFile != null && result == JFileChooser.APPROVE_OPTION )
+            {
                 final StringBuilder buf = new StringBuilder();
                 final Iterator<Message> transcripts = transcript.iterator();
-                buf.append("<html><body>");
-                if (headerData != null) {
-                    buf.append(headerData);
+                buf.append( "<html><body>" );
+                if ( headerData != null )
+                {
+                    buf.append( headerData );
                 }
 
-                buf.append("<table width=600>");
-                while (transcripts.hasNext()) {
+                buf.append( "<table width=600>" );
+                while ( transcripts.hasNext() )
+                {
                     final Message message = transcripts.next();
                     String from = message.getFrom();
-                    if (from == null) {
+                    if ( from == null )
+                    {
                         from = pref.getNickname();
                     }
 
-                    if (Message.Type.groupchat == message.getType()) {
-                        if (ModelUtil.hasLength( XmppStringUtils.parseResource(from))) {
-                            from = XmppStringUtils.parseResource(from);
+                    if ( Message.Type.groupchat == message.getType() )
+                    {
+                        if ( ModelUtil.hasLength( XmppStringUtils.parseResource( from ) ) )
+                        {
+                            from = XmppStringUtils.parseResource( from );
                         }
                     }
 
                     final String body = message.getBody();
 
-                    final JivePropertiesExtension extension = ((JivePropertiesExtension) message.getExtension( JivePropertiesExtension.NAMESPACE ));
+                    final JivePropertiesExtension extension = ( (JivePropertiesExtension) message.getExtension( JivePropertiesExtension.NAMESPACE ) );
                     Date insertionDate = null;
-                    if ( extension != null ) {
+                    if ( extension != null )
+                    {
                         insertionDate = (Date) extension.getProperty( "insertionDate" );
                     }
 
-                    formatter = new SimpleDateFormat("hh:mm:ss");
+                    formatter = new SimpleDateFormat( "hh:mm:ss" );
 
                     String value = "";
-                    if (insertionDate != null) {
-                        value = "(" + formatter.format(insertionDate) + ") ";
+                    if ( insertionDate != null )
+                    {
+                        value = "(" + formatter.format( insertionDate ) + ") ";
                     }
-                    buf.append("<tr><td nowrap><font size=2>").append(value).append("<strong>").append(from).append(":</strong>&nbsp;").append(body).append("</font></td></tr>");
+                    buf.append( "<tr><td nowrap><font size=2>" ).append( value ).append( "<strong>" ).append( from ).append( ":</strong>&nbsp;" ).append( body ).append( "</font></td></tr>" );
 
                 }
-                buf.append("</table></body></html>");
-                final BufferedWriter writer = new BufferedWriter(new FileWriter(selFile));
-                writer.write(buf.toString());
+                buf.append( "</table></body></html>" );
+                final BufferedWriter writer = new BufferedWriter( new FileWriter( selFile ) );
+                writer.write( buf.toString() );
                 writer.close();
-                UIManager.put("OptionPane.okButtonText", Res.getString("ok"));
-                JOptionPane.showMessageDialog(SparkManager.getMainWindow(), "Chat transcript has been saved.",
-                        "Chat Transcript Saved", JOptionPane.INFORMATION_MESSAGE);
+                UIManager.put( "OptionPane.okButtonText", Res.getString( "ok" ) );
+                JOptionPane.showMessageDialog( SparkManager.getMainWindow(), "Chat transcript has been saved.",
+                                               "Chat Transcript Saved", JOptionPane.INFORMATION_MESSAGE );
             }
         }
-        catch (Exception ex) {
-            Log.error("Unable to save chat transcript.", ex);
-            UIManager.put("OptionPane.okButtonText", Res.getString("ok"));
-            JOptionPane.showMessageDialog(SparkManager.getMainWindow(), "Could not save transcript.", "Error", JOptionPane.ERROR_MESSAGE);
+        catch ( Exception ex )
+        {
+            Log.error( "Unable to save chat transcript.", ex );
+            UIManager.put( "OptionPane.okButtonText", Res.getString( "ok" ) );
+            JOptionPane.showMessageDialog( SparkManager.getMainWindow(), "Could not save transcript.", "Error", JOptionPane.ERROR_MESSAGE );
         }
 
     }
 
-    public void cleanup() {
+    public void cleanup()
+    {
         super.releaseResources();
 
         clear();
 
-        removeMouseListener(this);
-        removeMouseMotionListener(this);
+        removeMouseListener( this );
+        removeMouseMotionListener( this );
 
-        removeContextMenuListener(this);
-        getActionMap().remove("copy");
+        removeContextMenuListener( this );
+        getActionMap().remove( "copy" );
     }
-
-
-    public void setFont(Font font) {
-        this.defaultFont = font;
-    }
-
-    public Font getFont() {
-        return defaultFont;
-    }
-
 
     /**
      * Adds Print and Clear actions.
@@ -521,110 +467,82 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener {
      * @param object the TransferWindow
      * @param popup  the popup menu to add to.
      */
-    public void poppingUp(final Object object, JPopupMenu popup) {
-        Action printAction = new AbstractAction() {
-			private static final long serialVersionUID = -244227593637660347L;
+    public void poppingUp( final Object object, JPopupMenu popup )
+    {
+        popup.addSeparator();
 
-			public void actionPerformed(ActionEvent actionEvent) {
-                SparkManager.printChatTranscript((TranscriptWindow)object);
+        popup.add( new AbstractAction( Res.getString( "action.print" ), SparkRes.getImageIcon( SparkRes.PRINTER_IMAGE_16x16 ) )
+        {
+            public void actionPerformed( ActionEvent actionEvent )
+            {
+                SparkManager.printChatTranscript( (TranscriptWindow) object );
             }
-        };
+        } );
 
+        if ( !Default.getBoolean( "HIDE_HISTORY_SETTINGS" ) )
+        {
+            popup.add( new AbstractAction( Res.getString( "action.clear" ), SparkRes.getImageIcon( SparkRes.ERASER_IMAGE ) )
+            {
+                public void actionPerformed( ActionEvent actionEvent )
+                {
+                    String user = null;
+                    try
+                    {
+                        ChatManager manager = SparkManager.getChatManager();
+                        ChatRoom room = manager.getChatContainer().getActiveChatRoom();
+                        user = room.getRoomname();
 
-        Action clearAction = new AbstractAction() {
-			private static final long serialVersionUID = -5664307353522844588L;
-
-			public void actionPerformed(ActionEvent actionEvent) {
-
-            	String user = null;
-            	try {
-            		ChatManager manager = SparkManager.getChatManager();
-            		ChatRoom room = manager.getChatContainer().getActiveChatRoom();
-            		user = room.getRoomname();
-
-				} catch (ChatRoomNotFoundException e) {
-					e.printStackTrace();
-				}
-
-                int ok = JOptionPane.showConfirmDialog((TranscriptWindow)object,
-                    Res.getString("delete.permanently"), Res.getString("delete.log.permanently"),
-                    JOptionPane.YES_NO_OPTION,
-                    JOptionPane.QUESTION_MESSAGE);
-                if (ok == JOptionPane.YES_OPTION) {
-                	if(user != null){
-                        // This actions must be move into Transcript Plugin!
-	                    File transcriptDir = new File(SparkManager.getUserDirectory(), "transcripts");
-	                    File transcriptFile = new File(transcriptDir ,user + ".xml");
-	                    transcriptFile.delete();
-	                    transcriptFile = new File(transcriptDir,user + "_current.xml");
-	                    transcriptFile.delete();
-	                    clear();
+                        int ok = JOptionPane.showConfirmDialog( (TranscriptWindow) object,
+                                                                Res.getString( "delete.permanently" ),
+                                                                Res.getString( "delete.log.permanently" ),
+                                                                JOptionPane.YES_NO_OPTION,
+                                                                JOptionPane.QUESTION_MESSAGE );
+                        if ( ok == JOptionPane.YES_OPTION )
+                        {
+                            // This actions must be move into Transcript Plugin!
+                            File transcriptDir = new File( SparkManager.getUserDirectory(), "transcripts" );
+                            File transcriptFile = new File( transcriptDir, user + ".xml" );
+                            transcriptFile.delete();
+                            transcriptFile = new File( transcriptDir, user + "_current.xml" );
+                            transcriptFile.delete();
+                            clear();
+                        }
+                    }
+                    catch ( Exception ex )
+                    {
+                        Log.error( "An exception occurred while trying to clear history for a chat room " + user, ex );
                     }
                 }
-            }
-        };
-
-
-        printAction.putValue(Action.NAME, Res.getString("action.print"));
-        printAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.PRINTER_IMAGE_16x16));
-
-        clearAction.putValue(Action.NAME, Res.getString("action.clear"));
-        clearAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.ERASER_IMAGE));
-        popup.addSeparator();
-        popup.add(printAction);
-
-        if (!Default.getBoolean("HIDE_HISTORY_SETTINGS")) {
-        popup.add(clearAction);
+            } );
         }
-        
-        //History window
-        Action viewLogAction = new AbstractAction() {
 
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public void actionPerformed(ActionEvent e) {
-
-				ChatManager manager = SparkManager.getChatManager();
-				ChatRoom room;
-				try {
-					room = manager.getChatContainer().getActiveChatRoom();
-					HistoryWindow hw = new HistoryWindow(SparkManager.getUserDirectory(), room.getRoomname());
-					hw.showWindow();
-					 
-				} catch (Exception e1) {
-					e1.printStackTrace();
-				}
-			}
-
-		};
-		viewLogAction.putValue(Action.NAME, Res.getString("action.viewlog"));
-		popup.add(viewLogAction);
+        // History window
+        popup.add( new AbstractAction( Res.getString( "action.viewlog" ) )
+        {
+            @Override
+            public void actionPerformed( ActionEvent e )
+            {
+                ChatRoom room = null;
+                try
+                {
+                    room = SparkManager.getChatManager().getChatContainer().getActiveChatRoom();
+                    HistoryWindow hw = new HistoryWindow( SparkManager.getUserDirectory(), room.getRoomname() );
+                    hw.showWindow();
+                }
+                catch ( Exception ex )
+                {
+                    Log.error( "An exception occurred while trying to open history window for room " + room, ex );
+                }
+            }
+        } );
     }
 
-    public void poppingDown(JPopupMenu popup) {
-
+    public void poppingDown( JPopupMenu popup )
+    {
     }
 
-    public boolean handleDefaultAction(MouseEvent e) {
+    public boolean handleDefaultAction( MouseEvent e )
+    {
         return false;
     }
-
-    protected SimpleDateFormat getNotificationDateFormatter() {
-        return notificationDateFormatter;
-    }
-
-    protected Date getLastPost() {
-        return lastPost;
-    }
-
-    protected void setLastPost(Date lastPost) {
-        this.lastPost = lastPost;
-    }
-
-    protected void setLastUpdated(Date lastUpdated) {
-        this.lastUpdated = lastUpdated;
-    }
-
-
 }

--- a/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindowEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindowEntry.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.spark.ui;
+
+import javax.swing.text.BadLocationException;
+import java.time.ZonedDateTime;
+
+/**
+ * One entry in a transcript window (typically a line of text).
+ *
+ * This class and its descendants represent an entry of content displayed in a transcript window, including its
+ * formatting.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com.
+ */
+public abstract class TranscriptWindowEntry
+{
+    private final ZonedDateTime timestamp;
+
+    /**
+     * Constructs a new entry.
+     *
+     * When displayed in context of a conversation, chat entries are ordered by time. This is why the time component
+     * of an entry is non-optional. Note that multiple entries can exist that have the same time component.
+     *
+     * @param timestamp The timestamp of the entry (cannot be null).
+     */
+    protected TranscriptWindowEntry( ZonedDateTime timestamp )
+    {
+        if ( timestamp == null )
+        {
+            throw new IllegalArgumentException( "Argument 'timestamp' cannot be null." );
+        }
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * The timestamp of the entry.
+     *
+     * @return A (zoned) timestamp (never null).
+     */
+    public ZonedDateTime getTimestamp()
+    {
+        return timestamp;
+    }
+
+    /**
+     * Adds this entry to the provided chat area.
+     *
+     * This method is intended to be overridden by subclasses, which allows each subclass to decorate its content
+     * appropriately.
+     *
+     * @param chatArea the ChatArea to which content is to be added (cannot be null).
+     */
+    protected abstract void addTo( ChatArea chatArea ) throws BadLocationException;
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        TranscriptWindowEntry that = (TranscriptWindowEntry) o;
+
+        return timestamp.toInstant().equals( that.timestamp.toInstant() );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return timestamp.toInstant().hashCode();
+    }
+}

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -70,8 +70,6 @@ public class ChatRoomImpl extends ChatRoom {
     private String participantJID;
     private String participantNickname;
 
-    private final Color TRANSPARENT_COLOR = new Color(0,0,0,0);
-
     private Presence presence;
 
     private boolean offlineSent;
@@ -246,7 +244,7 @@ public class ChatRoomImpl extends ChatRoom {
         message.setTo(participantJID);
         message.setFrom(SparkManager.getSessionManager().getJID());
         try {
-            getTranscriptWindow().insertMessage(getNickname(), message, ChatManager.TO_COLOR, TRANSPARENT_COLOR);
+            getTranscriptWindow().insertMessage(getNickname(), message, ChatManager.TO_COLOR);
             getChatInputEditor().selectAll();
 
             getTranscriptWindow().validate();
@@ -480,7 +478,7 @@ public class ChatRoomImpl extends ChatRoom {
             checkEvents(message.getFrom(), message.getStanzaId(), messageEvent);
         }
 
-        getTranscriptWindow().insertMessage(participantNickname, message, ChatManager.FROM_COLOR, TRANSPARENT_COLOR);
+        getTranscriptWindow().insertMessage(participantNickname, message, ChatManager.FROM_COLOR);
 
         // Set the participant jid to their full JID.
         participantJID = message.getFrom();

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -265,7 +265,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
         String from = message.getFrom() != null ? message.getFrom() : "";
 
         final TranscriptWindow window = new TranscriptWindow();
-        window.insertPrefixAndMessage(null, buf.toString(), ChatManager.TO_COLOR);
+        window.insertNotificationMessage(buf.toString(), ChatManager.TO_COLOR);
 
         JPanel p = new JPanel();
         p.setLayout(new BorderLayout());
@@ -334,7 +334,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
 	//m.setFrom(name +" "+broadcasttype);
         m.setFrom(nickname+" - "+broadcasttype);
 
-	chatRoom.getTranscriptWindow().insertMessage(m.getFrom(), message, ChatManager.FROM_COLOR, new Color(0,0,0,0));
+	chatRoom.getTranscriptWindow().insertMessage(m.getFrom(), message, ChatManager.FROM_COLOR);
 	chatRoom.addToTranscript(m,true);
 	chatRoom.increaseUnreadMessageCount();
 	broadcastRooms.add(chatRoom);

--- a/core/src/main/resources/default.properties
+++ b/core/src/main/resources/default.properties
@@ -316,6 +316,7 @@ MenuItem.selectionForeground = 0,0,0,255
 Table.foreground = 0,0,0,255
 Table.background = 255,255,255,255
 ## ChatWindow Colors: ##
+Message.foreground = 0,0,0,255
 Address.foreground = 212,160,0,255
 User.foreground = 0,0,255,255
 OtherUser.foreground = 255,0,0,255


### PR DESCRIPTION
This commit started off as a fix for SPARK-1757, but ended up being somewhat of a rewrite of the
code that displays chat messages in the UI (the 'chat transcript window').

The original problem defines that chat messages are sometimes displayed out of order. The direct cause
of this is unknown (I suspect threading/timing issues). To work around the issue, this commit now
adds the capability to recompose the entire transcript window from memory.

A drawback of this is that a(nother) copy of the chat is now kept in memory (the 'entries' list that
is now added to TranscriptWindow). This might make Spark use more memory.

I've opted for a rewrite, as in the course of applying fixes to the existing code, I repreatedly got
lost in the jungle of reuse of styling, particularly. This commit adds new classes for all types of
entries in the Transcript Window (typically, a chat message), and makes each class responsible for
creating a UI representation of that type of entry. This removed quite a bit of boiler plate code.

As each entry now contains the original message, it's make-up as well as timestamp, the transcript
window is easily redrawn when messages start to arrive out of order. That bit is now implemented as
a responsibility of the TranscriptWindow class.

Various smaller changes were made:
- ctrl-space nickname completion in a MUC now no longer considers users on your roster (but not in the MUC)
- ctrl-space nickname completion now works for users that have no VCard (uses node-part of the JID instead)
- message color is now configurable (but still defaults to black).