### PR TITLE
SPARK-1915 -- Implement separate History settings in Client Control

### DIFF
--- a/core/src/main/java/org/jivesoftware/resource/Default.java
+++ b/core/src/main/java/org/jivesoftware/resource/Default.java
@@ -93,6 +93,7 @@ public class Default {
     public static final String HISTORY_DISABLED = "HISTORY_DISABLED";
     public static final String HIDE_HISTORY_SETTINGS = "HIDE_HISTORY_SETTINGS";
     public static final String HIDE_SAVE_PASSWORD_AND_AUTOLOGIN = "HIDE_SAVE_PASSWORD_AND_AUTOLOGIN";
+    public static final String HIDE_LOGIN_AS_INVISIBLE = "HIDE_LOGIN_AS_INVISIBLE"; 
     public static final String MAINT_FILESPEC = "MAINT_FILESPEC";
 
     static ClassLoader cl = SparkRes.class.getClassLoader();

--- a/core/src/main/java/org/jivesoftware/spark/PresenceManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/PresenceManager.java
@@ -16,12 +16,14 @@
 package org.jivesoftware.spark;
 
 import org.jivesoftware.resource.Res;
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.SparkRes;
 import org.jivesoftware.smack.packet.ExtensionElement;
 import org.jivesoftware.smack.roster.Roster;
 import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smackx.muc.packet.MUCUser;
 import org.jivesoftware.spark.util.log.Log;
+import org.jivesoftware.sparkimpl.plugin.manager.Enterprise;
 import org.jxmpp.util.XmppStringUtils;
 
 import javax.swing.Icon;
@@ -30,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.jivesoftware.smack.util.StringUtils.isEmpty;
 import static org.jivesoftware.smack.util.StringUtils.isNullOrEmpty;
 
 /**
@@ -51,7 +52,7 @@ public class PresenceManager {
         final Presence phonePresence = new Presence(Presence.Type.available, Res.getString("status.on.phone"), 0, Presence.Mode.away);
         final Presence dndPresence = new Presence(Presence.Type.available, Res.getString("status.do.not.disturb"), 0, Presence.Mode.dnd);
         final Presence extendedAway = new Presence(Presence.Type.available, Res.getString("status.extended.away"), 0, Presence.Mode.xa);
-	final Presence invisible = new Presence(Presence.Type.unavailable, Res.getString("status.invisible"), 0, Presence.Mode.available);
+        final Presence invisible = new Presence(Presence.Type.unavailable, Res.getString("status.invisible"), 0, Presence.Mode.available);
 
         PRESENCES.add(freeToChatPresence);
         PRESENCES.add(availablePresence);
@@ -59,7 +60,8 @@ public class PresenceManager {
         PRESENCES.add(extendedAway);
         PRESENCES.add(phonePresence);
         PRESENCES.add(dndPresence);
-	PRESENCES.add(invisible);
+
+        if (!Default.getBoolean("HIDE_LOGIN_AS_INVISIBLE") && Enterprise.containsFeature(Enterprise.INVISIBLE_LOGIN_FEATURE)) PRESENCES.add(invisible);        
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
@@ -28,6 +28,7 @@ import org.jivesoftware.spark.plugin.ContextMenuListener;
 import org.jivesoftware.spark.ui.history.HistoryWindow;
 import org.jivesoftware.spark.util.ModelUtil;
 import org.jivesoftware.spark.util.log.Log;
+import org.jivesoftware.sparkimpl.plugin.manager.Enterprise;
 import org.jivesoftware.sparkimpl.plugin.emoticons.EmoticonManager;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
@@ -479,8 +480,8 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener
             }
         } );
 
-        if ( !Default.getBoolean( "HIDE_HISTORY_SETTINGS" ) )
-        {
+        if (!Default.getBoolean("HIDE_HISTORY_SETTINGS") && Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE) 
+        		&& !Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
             popup.add( new AbstractAction( Res.getString( "action.clear" ), SparkRes.getImageIcon( SparkRes.ERASER_IMAGE ) )
             {
                 public void actionPerformed( ActionEvent actionEvent )
@@ -517,24 +518,26 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener
         }
 
         // History window
-        popup.add( new AbstractAction( Res.getString( "action.viewlog" ) )
-        {
-            @Override
-            public void actionPerformed( ActionEvent e )
-            {
-                ChatRoom room = null;
-                try
-                {
-                    room = SparkManager.getChatManager().getChatContainer().getActiveChatRoom();
-                    HistoryWindow hw = new HistoryWindow( SparkManager.getUserDirectory(), room.getRoomname() );
-                    hw.showWindow();
-                }
-                catch ( Exception ex )
-                {
-                    Log.error( "An exception occurred while trying to open history window for room " + room, ex );
-                }
-            }
-        } );
+        if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
+        	popup.add( new AbstractAction( Res.getString( "action.viewlog" ) )
+        	{
+        		@Override
+        		public void actionPerformed( ActionEvent e )
+        		{
+        			ChatRoom room = null;
+        			try
+        			{
+        				room = SparkManager.getChatManager().getChatContainer().getActiveChatRoom();
+        				HistoryWindow hw = new HistoryWindow( SparkManager.getUserDirectory(), room.getRoomname() );
+        				hw.showWindow();
+        			}
+        			catch ( Exception ex )
+        			{
+        				Log.error( "An exception occurred while trying to open history window for room " + room, ex );
+        			}
+        		}
+        	} );
+        }
     }
 
     public void poppingDown( JPopupMenu popup )

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -647,7 +647,7 @@ public class ChatRoomImpl extends ChatRoom {
     	vcardPanel = new VCardPanel(participantJID);
     	getToolBar().add(vcardPanel, new GridBagConstraints(0, 1, 1, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL, new Insets(0, 2, 0, 2), 0, 0));
 
-    	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE)) {
+       	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
     		final LocalPreferences localPreferences = SettingsManager.getLocalPreferences();
     		if (!localPreferences.isChatHistoryEnabled()) {
     			return;

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
@@ -128,15 +128,19 @@ public class ContactListAssistantPlugin implements Plugin {
                     });
 
                     int index = -1;
-                    for (int i = 0; i < popup.getComponentCount(); i++) {
-                        Object o = popup.getComponent(i);
-                        if (o instanceof JMenuItem && ((JMenuItem)o).getText().equals(Res.getString("menuitem.rename"))) {
-                            index = i;
-                            break;
-                        }
-                    }
+                    if (!Default.getBoolean("DISABLE_RENAMES") && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE)) {
+                    	for (int i = 0; i < popup.getComponentCount(); i++) {
+                    		Object o = popup.getComponent(i);
+                    		if (o instanceof JMenuItem && ((JMenuItem)o).getText().equals(Res.getString("menuitem.rename"))) {
+                    			index = i;
+                    			break;
+                    		}
+                    	}
+
+                    } else index = 3;
+
                     if (contactItems.size() == 1) {
-                        // Add right after the rename item.
+                        // Add MOVE/COPY options right after the RENAME option or in it's place if it doesn't exist.
                         if (index != -1) {
                         	// See if we should disable the "Move to" and "Copy to" menu options
                         	if (!Default.getBoolean("DISABLE_MOVE_AND_COPY") && Enterprise.containsFeature(Enterprise.MOVE_COPY_FEATURE)) {
@@ -151,7 +155,7 @@ public class ContactListAssistantPlugin implements Plugin {
                     		popup.addSeparator();
                     		popup.add(moveToMenu);
                     		popup.add(copyToMenu);
-                    	}                        
+                   	}                        
 
                         // Clean up the extra separator if "Broadcast" menu items are disabled
                         if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM") && Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) popup.addSeparator();                        

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/manager/Enterprise.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/manager/Enterprise.java
@@ -43,6 +43,7 @@ public class Enterprise {
     public static final String HELP_FORUMS_FEATURE = "help-forums";
     public static final String HELP_USERGUIDE_FEATURE = "help-userguide";
     public static final String HISTORY_SETTINGS_FEATURE = "history-settings";
+    public static final String HISTORY_TRANSCRIPTS_FEATURE = "history-transcripts";
     public static final String HOST_NAME_FEATURE = "host-name";
     public static final String INVISIBLE_LOGIN_FEATURE = "invisible-login";
     public static final String ANONYMOUS_LOGIN_FEATURE = "anonymous-login";

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscriptPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscriptPlugin.java
@@ -111,7 +111,7 @@ public class ChatTranscriptPlugin implements ChatRoomListener {
         contactList.addContextMenuListener(new ContextMenuListener() {
             public void poppingUp(Object object, JPopupMenu popup) {
                 if (object instanceof ContactItem) {
-                	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE)) popup.add(viewHistoryAction);
+                	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) popup.add(viewHistoryAction);
                	 	popup.add(showStatusMessageAction);
                 }
             }
@@ -335,7 +335,9 @@ public class ChatTranscriptPlugin implements ChatRoomListener {
                 return;
             }
             chatHistoryButton = UIComponentRegistry.getButtonFactory().createChatTranscriptButton();
-            if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE)) chatRoom.addChatRoomButton(chatHistoryButton);
+
+            if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) chatRoom.addChatRoomButton(chatHistoryButton);
+
             chatHistoryButton.setToolTipText(Res.getString("tooltip.view.history"));
             chatHistoryButton.addActionListener(this);
         }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
@@ -69,7 +69,7 @@ public final class ChatTranscripts {
     public static void appendToTranscript(String jid, ChatTranscript transcript) {
     	final File transcriptFile = getTranscriptFile(jid);
 
-    	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE)) {
+       	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
     		// Write Full Transcript, appending the messages.
     		writeToFile(transcriptFile, transcript.getMessages(), true);
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/preference/chat/ChatPreferencePanel.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/preference/chat/ChatPreferencePanel.java
@@ -131,7 +131,8 @@ public class ChatPreferencePanel extends JPanel implements ActionListener {
 
         chatWindowPanel.add(groupChatNotificationBox, new GridBagConstraints(0, 2, 2, 1, 1.0, 1.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
 
-        if (!Default.getBoolean("HISTORY_DISABLED") && !Default.getBoolean("HIDE_HISTORY_SETTINGS") && Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE)) {
+        if (!Default.getBoolean("HISTORY_DISABLED") && !Default.getBoolean("HIDE_HISTORY_SETTINGS")
+        		&& Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
         	chatWindowPanel.add(hideChatHistory, new GridBagConstraints(0, 3, 2, 1, 1.0, 1.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
         	chatWindowPanel.add(hidePrevChatHistory, new GridBagConstraints(0, 4, 2, 1, 1.0, 1.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
         }


### PR DESCRIPTION
Currently Client Control plugin's setting "History Settings" not just hides the history settings, but also disables the history in Spark. Which might not be desired. One might need to have history, but hide settings, so users won't be able to disable it from a GUI. This change will implement two separate history features in Client Control - "History Settings" and "History Transcripts". Now an admin can select to enable/disable the history controls as well as enable/disable the logging of the history into transcript files. **NOTE: Updated version 2.1.2 of the Client Control plug-in and minimum of Spark version 2.9.0 is required for proper functionality.**