### PR TITLE
SPARK-1972: New 'security' login settings panel.

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/login/GeneralLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/GeneralLoginSettingsPanel.java
@@ -32,11 +32,8 @@ class GeneralLoginSettingsPanel extends JPanel implements ActionListener
     private JTextField resourceField = new JTextField();
     private JCheckBox useHostnameAsResourceBox = new JCheckBox();
     private JCheckBox useVersionAsResourceBox = new JCheckBox();
-    private JCheckBox useSSLBox = new JCheckBox();
     private JCheckBox compressionBox = new JCheckBox();
     private JCheckBox debuggerBox = new JCheckBox();
-    private JCheckBox acceptAllCertificatesBox = new JCheckBox();
-    private JCheckBox disableHostnameVerificationBox = new JCheckBox();
 
     public GeneralLoginSettingsPanel( LocalPreferences localPreferences, JDialog optionsDialog )
     {
@@ -48,7 +45,6 @@ class GeneralLoginSettingsPanel extends JPanel implements ActionListener
         ResourceUtils.resLabel( timeOutLabel, timeOutField, Res.getString( "label.response.timeout" ) );
         JCheckBox autoLoginBox = new JCheckBox();
         ResourceUtils.resButton( autoLoginBox, Res.getString( "label.auto.login" ) );
-        ResourceUtils.resButton( useSSLBox, Res.getString( "label.old.ssl" ) );
         JLabel xmppHostLabel = new JLabel();
         ResourceUtils.resLabel( xmppHostLabel, xmppHostField, Res.getString( "label.host" ) );
         ResourceUtils.resButton( autoDiscoverBox, Res.getString( "checkbox.auto.discover.port" ) );
@@ -58,12 +54,9 @@ class GeneralLoginSettingsPanel extends JPanel implements ActionListener
         ResourceUtils.resButton( useVersionAsResourceBox, Res.getString( "checkbox.use.version.as.resource" ) );
         ResourceUtils.resButton( compressionBox, Res.getString( "checkbox.use.compression" ) );
         ResourceUtils.resButton( debuggerBox, Res.getString( "checkbox.use.debugger.on.startup" ) );
-        ResourceUtils.resButton( acceptAllCertificatesBox, Res.getString( "checkbox.accept.all.certificates" ) );
-        ResourceUtils.resButton( disableHostnameVerificationBox, Res.getString( "checkbox.disable.hostname.verification" ) );
         portField.setText( Integer.toString( localPreferences.getXmppPort() ) );
         timeOutField.setText( Integer.toString( localPreferences.getTimeOut() ) );
         autoLoginBox.setSelected( localPreferences.isAutoLogin() );
-        useSSLBox.setSelected( localPreferences.isSSL() );
         xmppHostField.setText( localPreferences.getXmppHost() );
         resourceField.setText( localPreferences.getResource() );
 
@@ -84,39 +77,32 @@ class GeneralLoginSettingsPanel extends JPanel implements ActionListener
 
         debuggerBox.setSelected( localPreferences.isDebuggerEnabled() );
 
-        acceptAllCertificatesBox.setSelected( localPreferences.isAcceptAllCertificates() );
-
-        disableHostnameVerificationBox.setSelected( localPreferences.isDisableHostnameVerification() );
-
         final JPanel connectionPanel = new JPanel();
         connectionPanel.setLayout( new GridBagLayout() );
         connectionPanel.setBorder( BorderFactory.createTitledBorder( Res.getString( "group.connection" ) ) );
 
         setLayout( new GridBagLayout() );
 
-        add( autoDiscoverBox, new GridBagConstraints( 0, 0, 2, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
+        add( autoDiscoverBox, new GridBagConstraints( 0, 0, 2, 1, 1.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
 
-        connectionPanel.add( xmppHostLabel, new GridBagConstraints( 0, 0, 2, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
-        connectionPanel.add( xmppHostField, new GridBagConstraints( 2, 0, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 200, 0 ) );
-        connectionPanel.add( portLabel,     new GridBagConstraints( 0, 1, 2, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
-        connectionPanel.add( portField,     new GridBagConstraints( 2, 1, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 50, 0 ) );
+        connectionPanel.add( xmppHostLabel, new GridBagConstraints( 0, 0, 1, 1, 0.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        connectionPanel.add( xmppHostField, new GridBagConstraints( 1, 0, 1, 1, 1.0, 0.0, WEST, NONE, DEFAULT_INSETS, 200, 0 ) );
+        connectionPanel.add( portLabel,     new GridBagConstraints( 0, 1, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
+        connectionPanel.add( portField,     new GridBagConstraints( 1, 1, 1, 1, 1.0, 0.0, WEST, NONE, DEFAULT_INSETS, 50, 0 ) );
 
-        add( connectionPanel, new GridBagConstraints( 0, 1, 3, 1, 1.0, 1.0, WEST, BOTH, DEFAULT_INSETS, 0, 0 ) );
+        add( connectionPanel, new GridBagConstraints( 0, 1, 3, 1, 1.0, 0.0, NORTHWEST, BOTH, DEFAULT_INSETS, 0, 0 ) );
 
         if ( Default.getBoolean( Default.HOSTNAME_AS_RESOURCE ) == Default.getBoolean( Default.VERSION_AS_RESOURCE ) )
         {
             add( resourceLabel,            new GridBagConstraints( 0, 2, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
             add( resourceField,            new GridBagConstraints( 1, 2, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 100, 0 ) );
-            add( useHostnameAsResourceBox, new GridBagConstraints( 0, 3, 2, 1, 0.0, 1.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
-            add( useVersionAsResourceBox,  new GridBagConstraints( 0, 4, 2, 1, 0.0, 1.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
+            add( useHostnameAsResourceBox, new GridBagConstraints( 0, 3, 2, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
+            add( useVersionAsResourceBox,  new GridBagConstraints( 0, 4, 2, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
         }
         add( timeOutLabel,             new GridBagConstraints( 0, 5, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
         add( timeOutField,             new GridBagConstraints( 1, 5, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 50, 0 ) );
-        add( useSSLBox,                new GridBagConstraints( 0, 6, 2, 1, 0.0, 1.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
-        add( compressionBox,           new GridBagConstraints( 0, 7, 2, 1, 0.0, 1.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
-        add( acceptAllCertificatesBox, new GridBagConstraints( 0, 8, 2, 1, 0.0, 1.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
-        add( disableHostnameVerificationBox, new GridBagConstraints( 0, 9, 2, 1, 0.0, 1.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
-        add( debuggerBox,              new GridBagConstraints( 0, 10, 2, 1, 0.0, 1.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        add( compressionBox,           new GridBagConstraints( 0, 6, 2, 1, 0.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        add( debuggerBox,              new GridBagConstraints( 0, 7, 2, 1, 0.0, 1.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
     }
 
     /**
@@ -243,15 +229,12 @@ class GeneralLoginSettingsPanel extends JPanel implements ActionListener
     {
         localPreferences.setTimeOut( Integer.parseInt( timeOutField.getText() ) );
         localPreferences.setXmppPort( Integer.parseInt( portField.getText() ) );
-        localPreferences.setSSL( useSSLBox.isSelected() );
         localPreferences.setXmppHost( xmppHostField.getText() );
         localPreferences.setCompressionEnabled( compressionBox.isSelected() );
         localPreferences.setDebuggerEnabled( debuggerBox.isSelected() );
         localPreferences.setResource( resourceField.getText() );
         localPreferences.setUseHostnameAsResource( useHostnameAsResourceBox.isSelected() );
         localPreferences.setUseVersionAsResource( useVersionAsResourceBox.isSelected() );
-        localPreferences.setAcceptAllCertificates( acceptAllCertificatesBox.isSelected() );
-        localPreferences.setDisableHostnameVerification( disableHostnameVerificationBox.isSelected() );
         SettingsManager.saveSettings();
     }
 }

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/LoginSettingDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/LoginSettingDialog.java
@@ -40,6 +40,7 @@ public class LoginSettingDialog implements PropertyChangeListener
     private JOptionPane optionPane;
 
     private GeneralLoginSettingsPanel generalPanel;
+    private SecurityLoginSettingsPanel securityPanel;
     private ProxyLoginSettingsPanel proxyPanel;
     private PkiLoginSettingsPanel pkiPanel;
     private SsoLoginSettingsPanel ssoPanel;
@@ -53,6 +54,7 @@ public class LoginSettingDialog implements PropertyChangeListener
         LocalPreferences localPreferences = SettingsManager.getLocalPreferences();
         generalPanel = new GeneralLoginSettingsPanel( localPreferences, optionsDialog );
         proxyPanel = new ProxyLoginSettingsPanel( localPreferences, optionsDialog );
+        securityPanel = new SecurityLoginSettingsPanel( localPreferences, optionsDialog );
         ssoPanel = new SsoLoginSettingsPanel( localPreferences, optionsDialog );
         pkiPanel = new PkiLoginSettingsPanel( localPreferences, optionsDialog );
         certManager = new CertificatesManagerSettingsPanel(localPreferences, optionsDialog);
@@ -73,6 +75,7 @@ public class LoginSettingDialog implements PropertyChangeListener
         // Create the title panel for this dialog
         titlePanel = new TitlePanel( Res.getString( "title.advanced.connection.preferences" ), "", SparkRes.getImageIcon( SparkRes.BLANK_24x24 ), true );
         tabbedPane.addTab( Res.getString( "tab.general" ), generalPanel );
+        tabbedPane.addTab( Res.getString( "tab.security" ), securityPanel );
         if ( !Default.getBoolean( Default.PROXY_DISABLED ) )
         {
             tabbedPane.addTab( Res.getString( "tab.proxy" ), proxyPanel );
@@ -133,6 +136,7 @@ public class LoginSettingDialog implements PropertyChangeListener
         {
 
             boolean valid = generalPanel.validate_settings();
+            valid = valid && securityPanel.validate_settings();
             valid = valid && proxyPanel.validate_settings();
             valid = valid && ssoPanel.validate_settings();
             valid = valid && pkiPanel.validate_settings();
@@ -140,6 +144,7 @@ public class LoginSettingDialog implements PropertyChangeListener
             if ( valid )
             {
                 generalPanel.saveSettings();
+                securityPanel.saveSettings();
                 proxyPanel.saveSettings();
                 ssoPanel.saveSettings();
                 pkiPanel.saveSettings();

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/PkiLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/PkiLoginSettingsPanel.java
@@ -145,7 +145,7 @@ class PkiLoginSettingsPanel extends JPanel implements ActionListener
         trustStorePanel.add( trustStorePasswordLabel, new GridBagConstraints( 0, 1, 1, 1, 0.0, 0.0, NORTHWEST, NONE, DEFAULT_INSETS, 0, 0 ) );
         trustStorePanel.add( trustStorePassword,      new GridBagConstraints( 1, 1, 1, 1, 0.0, 0.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 100, 0 ) );
 
-        add( trustStorePanel, new GridBagConstraints( 0, 3, 2, 1, 0.0, 0.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 150, 0 ) );
+        add( trustStorePanel, new GridBagConstraints( 0, 3, 2, 1, 0.0, 1.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 150, 0 ) );
 
         usePKIBox.addActionListener( this );
         pkiStore.addActionListener( this );

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/ProxyLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/ProxyLoginSettingsPanel.java
@@ -59,7 +59,7 @@ class ProxyLoginSettingsPanel extends JPanel
         add( usernameLabel, new GridBagConstraints( 0, 4, 1, 1, 0.0, 0.0, NORTHWEST, NONE,       DEFAULT_INSETS, 0, 0 ) );
         add( usernameField, new GridBagConstraints( 1, 4, 1, 1, 1.0, 0.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
         add( passwordLabel, new GridBagConstraints( 0, 5, 1, 1, 0.0, 0.0, NORTHWEST, NONE,       DEFAULT_INSETS, 0, 0 ) );
-        add( passwordField, new GridBagConstraints( 1, 5, 1, 1, 1.0, 0.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        add( passwordField, new GridBagConstraints( 1, 5, 1, 1, 1.0, 1.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
 
         useProxyBox.addActionListener( e -> enableFields( useProxyBox.isSelected() ) );
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/SecurityLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/SecurityLoginSettingsPanel.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jivesoftware.spark.ui.login;
+
+import org.jivesoftware.resource.Res;
+import org.jivesoftware.smack.ConnectionConfiguration;
+import org.jivesoftware.spark.util.ResourceUtils;
+import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
+import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import static java.awt.GridBagConstraints.*;
+
+/**
+ * Allows users to configure security-related settings.
+ *
+ * @author Guus der Kinderen, guus.der.kinderen@gmail.com
+ */
+public class SecurityLoginSettingsPanel extends JPanel
+{
+    private final static Insets DEFAULT_INSETS = new Insets( 5, 5, 5, 5 );
+
+    private final JDialog optionsDialog;
+    private final LocalPreferences localPreferences;
+
+    // Radio buttons that configure the 'mode' of encryption.
+    private final JRadioButton modeRequiredRadio;
+    private final JRadioButton modeIfPossibleRadio;
+    private final JRadioButton modeDisabledRadio;
+
+    // Checkbox that toggles between 'old' style SSL (socket encryption, typically on port 5223), or STARTTLS. A check indicates 'old' behavior.
+    private JCheckBox useSSLBox;
+
+    private JCheckBox acceptAllCertificatesBox;
+    private JCheckBox disableHostnameVerificationBox;
+
+    public SecurityLoginSettingsPanel( LocalPreferences localPreferences, JDialog optionsDialog )
+    {
+        this.localPreferences = localPreferences;
+        this.optionsDialog = optionsDialog;
+
+        setLayout( new GridBagLayout() );
+
+        // The titled-border panel labeled 'encryption mode'
+        final JPanel encryptionModePanel = new JPanel();
+        encryptionModePanel.setLayout( new GridBagLayout() );
+        encryptionModePanel.setBorder( BorderFactory.createTitledBorder( Res.getString( "group.encryption_mode" ) ) );
+
+        // The radio buttons that config the 'encryption mode'
+        modeRequiredRadio = new JRadioButton();
+        modeRequiredRadio.setToolTipText( Res.getString( "tooltip.encryptionmode.required" ) );
+        modeIfPossibleRadio = new JRadioButton();
+        modeIfPossibleRadio.setToolTipText( Res.getString( "tooltip.encryptionmode.ifpossible" ) );
+        modeDisabledRadio = new JRadioButton();
+        modeDisabledRadio.setToolTipText( Res.getString( "tooltip.encryptionmode.disabled" ) );
+
+        useSSLBox = new JCheckBox();
+        acceptAllCertificatesBox = new JCheckBox();
+        disableHostnameVerificationBox = new JCheckBox();
+
+        // .. Set labels/text for all the components.
+        ResourceUtils.resButton( modeRequiredRadio,              Res.getString( "radio.encryptionmode.required" ) );
+        ResourceUtils.resButton( modeIfPossibleRadio,            Res.getString( "radio.encryptionmode.ifpossible" ) );
+        ResourceUtils.resButton( modeDisabledRadio,              Res.getString( "radio.encryptionmode.disabled" ) );
+        ResourceUtils.resButton( useSSLBox,                      Res.getString( "label.old.ssl" ) );
+        ResourceUtils.resButton( acceptAllCertificatesBox,       Res.getString( "checkbox.accept.all.certificates" ) );
+        ResourceUtils.resButton( disableHostnameVerificationBox, Res.getString( "checkbox.disable.hostname.verification" ) );
+
+        // ... add the radio buttons to a group to make them interdependent.
+        final ButtonGroup modeGroup = new ButtonGroup();
+        modeGroup.add( modeRequiredRadio );
+        modeGroup.add( modeIfPossibleRadio );
+        modeGroup.add( modeDisabledRadio );
+
+        // ... add event handler that disables the UI of encryption-related config, when encryption itself is disabled.
+        modeDisabledRadio.addChangeListener( e -> {
+            final boolean encryptionPossible = !modeDisabledRadio.isSelected();
+            useSSLBox.setEnabled( encryptionPossible );
+            acceptAllCertificatesBox.setEnabled( encryptionPossible );
+            disableHostnameVerificationBox.setEnabled( encryptionPossible );
+        } );
+
+        // ... apply the correct state, either based on saves settings, or defaults.
+        modeRequiredRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.required );
+        modeIfPossibleRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.ifpossible );
+        modeDisabledRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.disabled );
+        useSSLBox.setSelected( localPreferences.isSSL() );
+        acceptAllCertificatesBox.setSelected( localPreferences.isAcceptAllCertificates() );
+        disableHostnameVerificationBox.setSelected( localPreferences.isDisableHostnameVerification() );
+
+        // ... place the components on the titled-border panel.
+        encryptionModePanel.add( modeRequiredRadio,   new GridBagConstraints( 0, 0, 1, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        encryptionModePanel.add( modeIfPossibleRadio, new GridBagConstraints( 0, 1, 1, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        encryptionModePanel.add( modeDisabledRadio,   new GridBagConstraints( 0, 2, 1, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        encryptionModePanel.add( useSSLBox,           new GridBagConstraints( 0, 3, 2, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+
+        // ... place the titled-border panel on the global panel.
+        add( encryptionModePanel,            new GridBagConstraints( 0, 0, 1, 1, 1.0, 0.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+
+        // ... place the other components under the titled-border panel.
+        add( acceptAllCertificatesBox,       new GridBagConstraints( 0, 1, 1, 1, 0.0, 0.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        add( disableHostnameVerificationBox, new GridBagConstraints( 0, 2, 1, 1, 0.0, 1.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+    }
+
+    public boolean validate_settings()
+    {
+        return true;
+    }
+
+    public void saveSettings()
+    {
+        if ( modeRequiredRadio.isSelected() )
+        {
+            localPreferences.setSecurityMode( ConnectionConfiguration.SecurityMode.required );
+        }
+        if ( modeIfPossibleRadio.isSelected() )
+        {
+            localPreferences.setSecurityMode( ConnectionConfiguration.SecurityMode.ifpossible );
+        }
+        if ( modeDisabledRadio.isSelected() )
+        {
+            localPreferences.setSecurityMode( ConnectionConfiguration.SecurityMode.disabled );
+        }
+        localPreferences.setSSL( useSSLBox.isSelected() );
+        localPreferences.setAcceptAllCertificates( acceptAllCertificatesBox.isSelected() );
+        localPreferences.setDisableHostnameVerification( disableHostnameVerificationBox.isSelected() );
+        SettingsManager.saveSettings();
+    }
+}

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/SsoLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/SsoLoginSettingsPanel.java
@@ -131,7 +131,7 @@ class SsoLoginSettingsPanel extends JPanel implements ActionListener
         add( realmField,                   new GridBagConstraints( 2, 5, 1, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
         add( kdcLabel,                     new GridBagConstraints( 1, 6, 1, 1, 0.0, 0.0, WEST, NONE,       DEFAULT_INSETS, 0, 0 ) );
         add( kdcField,                     new GridBagConstraints( 2, 6, 1, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
-        add( useSaslGssapiSmack3compatBox, new GridBagConstraints( 0, 7, 3, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        add( useSaslGssapiSmack3compatBox, new GridBagConstraints( 0, 7, 3, 1, 1.0, 1.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
 
         useSSOBox.setSelected( localPreferences.isSSOEnabled() );
         useSaslGssapiSmack3compatBox.setSelected( localPreferences.isSaslGssapiSmack3Compatible() );

--- a/core/src/main/java/org/jivesoftware/spark/util/DummySSLSocketFactory.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/DummySSLSocketFactory.java
@@ -83,6 +83,10 @@ public class DummySSLSocketFactory extends SSLSocketFactory {
         return factory.createSocket(s, i);
     }
 
+    public Socket createSocket() throws IOException {
+        return factory.createSocket();
+    }
+
     public String[] getDefaultCipherSuites() {
         return factory.getSupportedCipherSuites();
     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
@@ -19,6 +19,7 @@ package org.jivesoftware.sparkimpl.settings.local;
 import org.jivesoftware.Spark;
 import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
+import org.jivesoftware.smack.ConnectionConfiguration;
 import org.jivesoftware.spark.PluginRes;
 import org.jivesoftware.spark.SparkManager;
 import java.io.File;
@@ -410,20 +411,59 @@ public class LocalPreferences {
 		props.setProperty("newInstall", Boolean.toString(newInstall));
 	}
 
+    /**
+     * Return the desirability of encryption.
+     *
+     * @return The security mode.
+     * @see org.jivesoftware.smack.ConnectionConfiguration.SecurityMode
+     */
+	public ConnectionConfiguration.SecurityMode getSecurityMode()
+    {
+        try
+        {
+            final String securityMode = props.getProperty( "securityMode", ConnectionConfiguration.SecurityMode.ifpossible.toString() );
+            return ConnectionConfiguration.SecurityMode.valueOf( securityMode );
+        }
+        catch ( Exception e )
+        {
+            Log.warning( "Unable to parse 'securityMode' value. Using default instead.", e );
+            return ConnectionConfiguration.SecurityMode.ifpossible;
+        }
+    }
+
+    /**
+     * Sets the desirability of encryption.
+     *
+     * @return The security mode.
+     * @see org.jivesoftware.smack.ConnectionConfiguration.SecurityMode
+     */
+    public void setSecurityMode( ConnectionConfiguration.SecurityMode securityMode )
+    {
+        props.setProperty( "securityMode", securityMode.toString() );
+    }
+
 	/**
-	 * Returns true to use SSL.
+	 * Returns true to use 'old style' SSL.
+     *
+     * This type of encryption typically occurs on port 5223, and causes the socket to be SSL-encrypted immediately.
+     *
+     * When this options is <em>disabled</em>, but encryption is still to be used, STARTTLS will be used instead.
 	 *
-	 * @return true if we should connect via SSL.
+	 * @return true if we should connect via 'old-style' SSL (otherwise, STARTTLS might be used).
 	 */
 	public boolean isSSL() {
 		return Boolean.parseBoolean(props.getProperty("sslEnabled", "false"));
 	}
 
 	/**
-	 * Sets if the agent should use SSL for connecting.
+	 * Sets if the agent should use 'old style' SSL for connecting.
 	 *
+     * This type of encryption typically occurs on port 5223, and causes the socket to be SSL-encrypted immediately.
+     *
+     * When this options is <em>disabled</em>, but encryption is still to be used, STARTTLS will be used instead.
+     *
 	 * @param ssl
-	 *            true if we should be using SSL.
+	 *            true if we should be using SSL, false if STARTTLS is to be used for encryption.
 	 */
 	public void setSSL(boolean ssl) {
 		props.setProperty("sslEnabled", Boolean.toString(ssl));

--- a/core/src/main/resources/i18n/spark_i18n.properties
+++ b/core/src/main/resources/i18n/spark_i18n.properties
@@ -397,6 +397,9 @@ checkbox.accept.invalid = Accept invalid
 checkbox.check.crl = Check CRL
 checkbox.check.ocsp = Check OCSP
 checkbox.on.exception.list = On the exception list
+radio.encryptionmode.required = Required
+radio.encryptionmode.ifpossible = If possible
+radio.encryptionmode.disabled = Disabled
 
 delete.log.permanently = Permanently delete log
 delete.permanently = Permanently delete?
@@ -417,6 +420,7 @@ group.search.results = Search results
 group.chat.name.notification = Seen your name...
 group.chat.name.match = Your name has been said in group chat:
 group.send_config.error = An exception occurred while trying to save the updated form!
+group.encryption_mode = Encryption mode
 
 label.na = n/a
 label.home = Home
@@ -945,6 +949,7 @@ tab.conferences = Conferences
 tab.contacts = Contacts
 tab.deactivated.plugins = Deactivated plugins
 tab.general = General
+tab.security = Security
 tab.home = Home
 tab.installed.plugins = Installed plugins
 tab.personal = Personal
@@ -1104,6 +1109,9 @@ tooltip.start.chat = Start a conversation
 tooltip.view.changelog = View change log
 tooltip.view.history = View conversation history
 tooltip.view.readme = View readme
+tooltip.encryptionmode.required = Encryption is required in order to connect. If the server does not offer encryption, or if the encryption negotiaton fails, the connection to the server will fail.
+tooltip.encryptionmode.ifpossible = Encryption is used whenever it's available.
+tooltip.encryptionmode.disabled = Encryption is disabled and only non-encrypted connections will be used. If encryption is required by the server, the connection will fail.
 
 tree.conference.services = Conference services
 tree.users.in.room = Users in room
@@ -1277,7 +1285,7 @@ cert.extension.name.constraints.excluded.subtrees = Excluded subtrees
 2.5.29.68 = id-ce-attributeMappings 
 2.5.29.69 = id-ce-holderNameConstraints 
 
-2.16.840.1.113730.1.1 = 
+2.16.840.1.113730.1.1 =
 1.3.6.1.4.1.311.20.2 = szOID_ENROLL_CERTTYPE_EXTENSION
 1.3.6.1.4.1.311.21.1 = MS Certificate Services CA Version 
 1.2.840.113533.7.65.0 = Entrust version extension


### PR DESCRIPTION

![spark-security-login-panel](https://user-images.githubusercontent.com/4253898/28645169-c9d8eb64-725c-11e7-87d3-96b6d2a5222e.png)
This commit adds a new 'security' tab to the advanced login settings. Here, security-related
settings are made available.

Also, this commit makes slight modifications to the other tabs, by making the components be
oriented more to the top-left corner (instead of being centered - which looks pretty ugly).