### PR TITLE
SPARK-1976: Better error messages

### DIFF
--- a/core/src/main/resources/i18n/spark_i18n.properties
+++ b/core/src/main/resources/i18n/spark_i18n.properties
@@ -243,6 +243,7 @@ available = Available
 broadcast = Broadcast
 cancel = Cancel
 delete = Delete
+details = Details
 close = Close
 create = Create
 date = Date


### PR DESCRIPTION
This commit:
- reworks the login method to remove some redundant code;
- applies the MessageDialog-provided error dialog generator to the login method;
- refactored the MessageDialog error dialog generator (to allow for toggling of the large stacktrace pane).

In all, this should improve the error messages during login. The same technique could be re-used elsewhere.