### PR TITLE
SPARK-1956: Preference dialog should remember its size.

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/preference/PreferenceDialog.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/preference/PreferenceDialog.java
@@ -87,6 +87,7 @@ public class PreferenceDialog implements PropertyChangeListener
         mainPanel.add( pane, BorderLayout.CENTER );
         preferenceDialog.setContentPane( mainPanel );
 
+        preferenceDialog.pack();
         final Rectangle preferencesBounds = LayoutSettingsManager.getLayoutSettings().getPreferencesBounds();
         if ( preferencesBounds == null || preferencesBounds.width <= 0 || preferencesBounds.height <= 0 )
         {
@@ -101,7 +102,6 @@ public class PreferenceDialog implements PropertyChangeListener
 
         pane.addPropertyChangeListener( this );
 
-        preferenceDialog.pack();
         preferenceDialog.setVisible( true );
         preferenceDialog.toFront();
 


### PR DESCRIPTION
The recent fix for SPARK-945 already stored the preference dialog size and position, which fixed most of this bug. When that was implemented, a rogue invocation of .pack() was placed after the stored settings were applied. This resized the component again.