### PR TITLE
Disable meet plugin by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <module>plugins/flashing</module>
         <module>plugins/growl</module>
         <!--<module>plugins/jingle</module>-->
-        <module>plugins/meet</module>
+        <!--<module>plugins/meet</module>-->
         <!--<module>plugins/otr</module>-->
         <module>plugins/reversi</module>
         <module>plugins/roar</module>


### PR DESCRIPTION
This PR is to address SPARK-1987 by disabling the auto build of meet plugin. Not sure how the plugin inflates the installer as it uses a standard plugin pom file and includes Java classes from Spark Core. The change is to eliminate it from the issue.