### PR TITLE
Re-enabling the meet plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <module>plugins/flashing</module>
         <module>plugins/growl</module>
         <!--<module>plugins/jingle</module>-->
-        <!--<module>plugins/meet</module>-->
+        <module>plugins/meet</module>
         <!--<module>plugins/otr</module>-->
         <module>plugins/reversi</module>
         <module>plugins/roar</module>


### PR DESCRIPTION
Now that the JxBrowser runtime file size issue is resolved, I am re-enabling meet plugin to be included by default with Spark