### PR TITLE
SPARK-1995, SPARK-1996, SPARK-1997 and lack of resources in one text.

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/login/MutualAuthenticationSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/MutualAuthenticationSettingsPanel.java
@@ -266,7 +266,7 @@ public class MutualAuthenticationSettingsPanel extends JPanel implements ActionL
             } catch (InvalidKeySpecException | NoSuchAlgorithmException | KeyStoreException | InvalidNameException
                     | IOException e) {
 
-                JOptionPane.showMessageDialog(null, "dialog.cannot.upload.certificate");
+                JOptionPane.showMessageDialog(null, Res.getString("dialog.cannot.upload.certificate"));
                 Log.error("Cannot upload certificate file", e);
             }
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateController.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateController.java
@@ -44,7 +44,7 @@ public class CertificateController extends CertManager {
      * TRUSTED contain user's trusted certificates 
      * EXCEPTIONS contain user's certificates that are added to exceptions (their's validity isn't checked) 
      * CACERTS contain only JRE default certificates, data is only read from it, never saved to this file 
-     * BLACKLIST used for revoked certificates 
+     * BLACKLIST used for revoked certificates, part of super class CertManager 
      * DISTRUSTED_CACERTS when user remove JRE certificate then really copy of this is created in this KeyStore 
      * CACERTS_EXCEPTIONS used for JRE certificates that are added to exceptions (their's validity isn;t checked)
      * DISPLAYED_CACERTS isn't used de facto as file as it is never saved but this object helps in keystore management. 
@@ -52,7 +52,6 @@ public class CertificateController extends CertManager {
      * 
      */
     public final static File TRUSTED =              new File(Spark.getSparkUserHome() + File.separator + "security" + File.separator + "truststore");
-    public final static File BLACKLIST =            new File(Spark.getSparkUserHome() + File.separator + "security" + File.separator + "blacklist");
     public final static File EXCEPTIONS =           new File(Spark.getSparkUserHome() + File.separator + "security" + File.separator + "exceptions");
     public final static File DISTRUSTED_CACERTS =   new File(Spark.getSparkUserHome() + File.separator + "security" + File.separator + "distrusted_cacerts");
     public final static File CACERTS_EXCEPTIONS =   new File(Spark.getSparkUserHome() + File.separator + "security" + File.separator + "cacerts_exceptions");
@@ -61,11 +60,10 @@ public class CertificateController extends CertManager {
     public final static File CACERTS =              new File(System.getProperty("java.home") + File.separator + "lib"
             + File.separator + "security" + File.separator + "cacerts");
 
-	private KeyStore trustStore, blackListStore, exceptionsStore, displayCaStore, distrustedCaStore, exceptionsCaStore;
+	private KeyStore trustStore, exceptionsStore, displayCaStore, distrustedCaStore, exceptionsCaStore;
 	
 	private List<CertificateModel> trustedCertificates = new LinkedList<>(); // contain certificates which aren't revoked or exempted
 	private List<CertificateModel> exemptedCertificates = new LinkedList<>(); // contain only certificates from exempted list
-	private List<CertificateModel> blackListedCertificates = new LinkedList<>(); //contain only revoked certificates
 	private List<CertificateModel> exemptedCacerts = new LinkedList<>(); // contain only exempted cacerts certificates
 	private List<CertificateModel> displayCaCertificates = new LinkedList<>(); // contain cacerts displayed certificates that aren't exempted
 	
@@ -85,16 +83,16 @@ public class CertificateController extends CertManager {
      */
     @Override
     public void loadKeyStores() {
+
+        blackListStore =    openKeyStore(BLACKLIST); 
         trustStore =        openKeyStore(TRUSTED);
         exceptionsStore =   openKeyStore(EXCEPTIONS);
-        blackListStore =    openKeyStore(BLACKLIST); 
         distrustedCaStore = openKeyStore(DISTRUSTED_CACERTS);
         exceptionsCaStore = openKeyStore(CACERTS_EXCEPTIONS);
         displayCaStore =    openCacertsKeyStore();
         
         trustedCertificates =       fillTableListWithKeyStoreContent(trustStore, trustedCertificates);
         exemptedCertificates =      fillTableListWithKeyStoreContent(exceptionsStore, exemptedCertificates);
-        blackListedCertificates =   fillTableListWithKeyStoreContent(blackListStore, blackListedCertificates);
         displayCaCertificates =     fillTableListWithKeyStoreContent(displayCaStore, displayCaCertificates);
         exemptedCacerts =           fillTableListWithKeyStoreContent(exceptionsCaStore, exemptedCacerts);
         
@@ -172,7 +170,6 @@ public class CertificateController extends CertManager {
 		Object[] certEntry = new Object[NUMBER_OF_COLUMNS];
 		addRowsToTableModel(trustedCertificates, certEntry);
 		addRowsToTableModel(exemptedCertificates, certEntry);
-		addRowsToTableModel(blackListedCertificates, certEntry);
 		addRowsToTableModel(displayCaCertificates, certEntry);
 		addRowsToTableModel(exemptedCacerts, certEntry);
     }
@@ -445,17 +442,7 @@ public class CertificateController extends CertManager {
 			moveCertificate(source, target, alias);
 
 	}
-	/**
-	 * This method transfer certificate with given alias to certificate blackList
-	 * @param alias
-	 * @throws KeyStoreException
-	 * @throws NoSuchAlgorithmException
-	 * @throws CertificateException
-	 * @throws IOException
-	 */
-	public void moveCertificateToBlackList(String alias) throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException{
-		moveCertificate(getAliasKeyStorePath(alias), BLACKLIST, alias);
-	}
+	
 	
 	/**
      * This method transfer certificate from source KeyStore to target KeyStore.

--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateModel.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateModel.java
@@ -322,7 +322,7 @@ public class CertificateModel {
 	}
 
 	public String getValidityStatus() {
-		if (checkRevoked()) {
+		if (isRevoked()) {
 			return Res.getString("cert.revoked");
 			
 		} else if (isAfterNotAfter() == true) {
@@ -338,7 +338,7 @@ public class CertificateModel {
 	
 	public String getCertStatusAll() {
 		String status = "";
-		if (checkRevoked()) {
+		if (isRevoked()) {
 			status += Res.getString("cert.revoked") + "\n";
 		}
 		if (isAfterNotAfter()) {
@@ -347,7 +347,7 @@ public class CertificateModel {
 		if (isBeforeNotBefore()) {
 			status += Res.getString("cert.not.valid.yet") + "\n";
 		}
-		if (!checkRevoked() && !isAfterNotAfter() && !isBeforeNotBefore()) {
+		if (!isRevoked() && !isAfterNotAfter() && !isBeforeNotBefore()) {
 			status += Res.getString("cert.valid") + "\n";
 		}
 		if (isSelfSigned()) {
@@ -369,16 +369,11 @@ public class CertificateModel {
 	 * @return True if certificate isn't expired, isn't not valid yet and isn't revoked.
 	 */
 	private boolean checkValidity() {
-		if (!isAfterNotAfter() && !isBeforeNotBefore() && !checkRevoked()) {
+		if (!isAfterNotAfter() && !isBeforeNotBefore() && !isRevoked()) {
 			return true;
 		} else {
 			return false;
 		}
-	}
-
-	private boolean checkRevoked() {
-		// TO-DO
-		return false;
 	}
 
 	private boolean isBeforeNotBefore() {
@@ -465,6 +460,10 @@ public class CertificateModel {
 
 	public boolean isRevoked() {
 		return revoked;
+	}
+	
+	public void setRevoked(boolean revoked) {
+	    this.revoked = revoked;
 	}
 
 	public boolean isNotValidYet() {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/IdentityController.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/IdentityController.java
@@ -49,7 +49,6 @@ import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.jivesoftware.Spark;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.spark.ui.login.CertificateDialog;
-import org.jivesoftware.spark.ui.login.CertificatesManagerSettingsPanel;
 import org.jivesoftware.spark.ui.login.MutualAuthenticationSettingsPanel;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 
@@ -87,6 +86,8 @@ public class IdentityController extends CertManager {
     public void loadKeyStores() {
 
         idStore = openKeyStore(IDENTITY);
+        blackListStore = openKeyStore(BLACKLIST);
+        
         fillTableListWithKeyStoreContent(idStore, null);
            
     }
@@ -233,7 +234,7 @@ public class IdentityController extends CertManager {
 
             @Override
             public void run() {
-                CertificatesManagerSettingsPanel.getCertTable().setModel(tableModel);
+                MutualAuthenticationSettingsPanel.getIdTable().setModel(tableModel);
                 tableModel.fireTableDataChanged();
             }
         });

--- a/core/src/main/resources/i18n/spark_i18n.properties
+++ b/core/src/main/resources/i18n/spark_i18n.properties
@@ -1196,8 +1196,8 @@ dialog.certificate.sure.to.delete = Are you sure that you want to delete this ce
 dialog.certificate.has.been.deleted = Certificate has been successfully deleted.
 dialog.self.signed.certificate.has.been.created = Self signed certificate and private key has been created in directory: \n
 dialog.certificate.request.has.been.created = Certificate Sign Request and private key has been created in directory: \n
-dialog.cannot.upload.certificate.might.be.ill.formated = "Cannot upload certificate file: Certificate might me ill formated"
-dialog.cannot.upload.certificate = "Cannot upload certificate file"
+dialog.cannot.upload.certificate.might.be.ill.formated = Cannot upload certificate file: Certificate might me ill formated
+dialog.cannot.upload.certificate = Cannot upload certificate file
 
 cert.valid = Valid
 cert.revoked = Revoked


### PR DESCRIPTION
Refreshing certificate table works. Blacklist is now used for adding status to the Certificate Model, not as separate List in table. Also now button for checking revocation in certificate dialog works.