### PR TITLE
SPARK-2000 Default Settings and lacking resource for mutual.auth

### DIFF
--- a/core/src/main/java/org/jivesoftware/resource/Default.java
+++ b/core/src/main/java/org/jivesoftware/resource/Default.java
@@ -97,8 +97,31 @@ public class Default {
     public static final String HIDE_SAVE_PASSWORD_AND_AUTOLOGIN = "HIDE_SAVE_PASSWORD_AND_AUTOLOGIN";
     public static final String HIDE_LOGIN_AS_INVISIBLE = "HIDE_LOGIN_AS_INVISIBLE"; 
     public static final String MAINT_FILESPEC = "MAINT_FILESPEC";
-    public static final String HIDE_START_A_CHAT = "HIDE_START_A_CHAT";
-
+    public static final String HIDE_START_A_CHAT = "HIDE_START_A_CHAT";    
+    public static final String ACCEPT_ALL = "ACCEPT_ALL";
+    public static final String ACCEPT_EXPIRED = "ACCEPT_EXPIRED";
+    public static final String ACCEPT_NOT_VALID_YET = "ACCEPT_NOT_VALID_YET";
+    public static final String ACCEPT_SELF_SIGNED = "ACCEPT_SELF_SIGNED";
+    public static final String ACCEPT_REVOKED = "ACCEPT_REVOKED";
+    public static final String CHECK_CRL = "CHECK_CRL"; 
+    public static final String CHECK_OCSP = "CHECK_OCSP";
+    public static final String ALLOW_SOFT_FAIL = "ALLOW_SOFT_FAIL";
+    public static final String ALLOW_CLIENT_SIDE_AUTH = "ALLOW_CLIENT_SIDE_AUTH";
+    public static final String DISABLE_HOSTNAME_VERIFICATION = "DISABLE_HOSTNAME_VERIFICATION";
+    public static final String SECURITY_MODE = "SECURITY_MODE";
+    public static final String HOST_AND_PORT_CONFIGURED = "HOST_AND_PORT_CONFIGURED";
+    public static final String XMPP_PORT = "XMPP_PORT";
+    public static final String USE_HOSTNAME_AS_RESOURCE = "USE_HOSTNAME_AS_RESOURCE";
+    public static final String USE_VERSION_AS_RESOURCE = "USE_VERSION_AS_RESOURCE";
+    public static final String TIME_OUT = "TIME_OUT";
+    public static final String COMPRESSION_ENABLED = "COMPRESSION_ENABLED";
+    public static final String DEBUGGER_ENABLED = "DEBUGGER_ENABLED";
+    public static final String USE_SSO = "USE_SSO";
+    public static final String USE_SASL_GSS_API_SMACK_3_COMPATIBLE = "USE_SASL_GSS_API_SMACK_3_COMPATIBLE";
+    public static final String SSO_METHOD = "SSO_METHOD";
+    public static final String PROXY_ENABLED = "PROXY_ENABLED";
+    public static final String OLD_SSL_ENABLED = "OLD_SSL_ENABLED";
+    
     static ClassLoader cl = SparkRes.class.getClassLoader();
 
     static {

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/CertificatesManagerSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/CertificatesManagerSettingsPanel.java
@@ -36,6 +36,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableModel;
 
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.spark.util.ResourceUtils;
 import org.jivesoftware.spark.util.log.Log;
@@ -331,7 +332,27 @@ public class CertificatesManagerSettingsPanel extends JPanel implements ActionLi
 		return certTable;
 	}
 
-	
+	public void useDefault() {
+
+	    acceptAll.setSelected(Default.getBoolean(Default.ACCEPT_ALL));
+	    acceptExpired.setSelected(Default.getBoolean(Default.ACCEPT_EXPIRED));
+        acceptNotValidYet.setSelected(Default.getBoolean(Default.ACCEPT_NOT_VALID_YET));
+        acceptSelfSigned.setSelected(Default.getBoolean(Default.ACCEPT_SELF_SIGNED));
+        acceptRevoked.setSelected(Default.getBoolean(Default.ACCEPT_REVOKED));
+        checkCRL.setSelected(Default.getBoolean(Default.CHECK_CRL));
+        checkOCSP.setSelected(Default.getBoolean(Default.CHECK_OCSP));
+        allowSoftFail.setSelected(Default.getBoolean(Default.ALLOW_SOFT_FAIL));
+        
+        acceptAll.setEnabled(true);
+        acceptExpired.setEnabled(true);
+        acceptNotValidYet.setEnabled(true);
+        acceptSelfSigned.setEnabled(true);
+        acceptRevoked.setEnabled(true);
+        checkCRL.setEnabled(true);
+        checkOCSP.setEnabled(true);
+        allowSoftFail.setEnabled(true);
+    
+	}
 	
     public void saveSettings() {
         localPreferences.setAcceptExpired(acceptExpired.isSelected());

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/GeneralLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/GeneralLoginSettingsPanel.java
@@ -225,6 +225,17 @@ class GeneralLoginSettingsPanel extends JPanel implements ActionListener
         return valid;
     }
 
+    public void useDefault(){
+        autoDiscoverBox.setSelected(!Default.getBoolean(Default.HOST_AND_PORT_CONFIGURED));
+        useHostnameAsResourceBox.setSelected(Default.getBoolean(Default.USE_HOSTNAME_AS_RESOURCE));
+        useVersionAsResourceBox.setSelected(Default.getBoolean(Default.USE_VERSION_AS_RESOURCE));
+        compressionBox.setSelected(Default.getBoolean(Default.COMPRESSION_ENABLED));
+        debuggerBox.setSelected(Default.getBoolean(Default.DEBUGGER_ENABLED));
+        portField.setText(Default.getString(Default.XMPP_PORT));
+        resourceField.setText(Default.getString(Default.SHORT_NAME));
+        timeOutField.setText(Default.getString(Default.TIME_OUT));
+    }
+    
     public void saveSettings()
     {
         localPreferences.setTimeOut( Integer.parseInt( timeOutField.getText() ) );

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/LoginSettingDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/LoginSettingDialog.java
@@ -39,12 +39,14 @@ public class LoginSettingDialog implements PropertyChangeListener
     private JDialog optionsDialog;
     private JOptionPane optionPane;
 
+    private JTabbedPane tabbedPane = new JTabbedPane();
+    
     private GeneralLoginSettingsPanel generalPanel;
     private SecurityLoginSettingsPanel securityPanel;
     private ProxyLoginSettingsPanel proxyPanel;
     private PkiLoginSettingsPanel pkiPanel;
     private SsoLoginSettingsPanel ssoPanel;
-	private CertificatesManagerSettingsPanel certManager;
+	private CertificatesManagerSettingsPanel certManagerPanel;
 	private MutualAuthenticationSettingsPanel mutAuthPanel;
 
     /**
@@ -58,7 +60,7 @@ public class LoginSettingDialog implements PropertyChangeListener
         securityPanel = new SecurityLoginSettingsPanel( localPreferences, optionsDialog );
         ssoPanel = new SsoLoginSettingsPanel( localPreferences, optionsDialog );
         pkiPanel = new PkiLoginSettingsPanel( localPreferences, optionsDialog );
-        certManager = new CertificatesManagerSettingsPanel(localPreferences, optionsDialog);
+        certManagerPanel = new CertificatesManagerSettingsPanel(localPreferences, optionsDialog);
         mutAuthPanel = new MutualAuthenticationSettingsPanel(localPreferences, optionsDialog);
     }
 
@@ -71,7 +73,6 @@ public class LoginSettingDialog implements PropertyChangeListener
      */
     public boolean invoke( JFrame owner )
     {
-        JTabbedPane tabbedPane = new JTabbedPane();
         TitlePanel titlePanel;
 
         // Create the title panel for this dialog
@@ -92,10 +93,10 @@ public class LoginSettingDialog implements PropertyChangeListener
         }
         if ( !Default.getBoolean(Default.CERTIFICATES_MANAGER_DISABLED))
         {
-        	tabbedPane.addTab( Res.getString( "tab.certificates" ), certManager );
+        	tabbedPane.addTab( Res.getString( "tab.certificates" ), certManagerPanel );
         }
         if ( !Default.getBoolean( Default.MUTUAL_AUTH_DISABLED)){
-            tabbedPane.addTab("Mutual auth", mutAuthPanel);
+            tabbedPane.addTab( Res.getString("tab.mutual.auth"), mutAuthPanel);
         }
         // Construct main panel w/ layout.
         final JPanel mainPanel = new JPanel();
@@ -153,7 +154,7 @@ public class LoginSettingDialog implements PropertyChangeListener
                 proxyPanel.saveSettings();
                 ssoPanel.saveSettings();
                 pkiPanel.saveSettings();
-                certManager.saveSettings();
+                certManagerPanel.saveSettings();
                 mutAuthPanel.saveSettings();
                 SettingsManager.saveSettings();
                 optionsDialog.setVisible( false );
@@ -164,9 +165,24 @@ public class LoginSettingDialog implements PropertyChangeListener
                 optionPane.setValue( JOptionPane.UNINITIALIZED_VALUE );
                 optionPane.addPropertyChangeListener( this );
             }
-        }
-        else
-        {
+        } else if (Res.getString("use.default") == value) {
+            if (tabbedPane.getSelectedComponent().equals(generalPanel)) {
+                generalPanel.useDefault();
+            } else if (tabbedPane.getSelectedComponent().equals(securityPanel)) {
+                securityPanel.useDefault();
+            } else if (tabbedPane.getSelectedComponent().equals(proxyPanel)) {
+                proxyPanel.useDefault();
+            } else if (tabbedPane.getSelectedComponent().equals(ssoPanel)) {
+                ssoPanel.useDefault();
+            } else if (tabbedPane.getSelectedComponent().equals(certManagerPanel)) {
+                certManagerPanel.useDefault();
+            }  
+                
+                optionPane.removePropertyChangeListener( this );
+                optionPane.setValue( JOptionPane.UNINITIALIZED_VALUE );
+                optionPane.addPropertyChangeListener( this );
+            
+        } else {
             // Some unknown operation happened
             optionPane.setValue( JOptionPane.UNINITIALIZED_VALUE );
         }

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/ProxyLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/ProxyLoginSettingsPanel.java
@@ -221,6 +221,11 @@ class ProxyLoginSettingsPanel extends JPanel
         return valid;
     }
 
+    public void useDefault() {
+        useProxyBox.setSelected(Default.getBoolean(Default.PROXY_ENABLED));
+        enableFields(useProxyBox.isSelected());
+    }
+    
     /**
      * Persist the proxy settings to local preferences.
      */

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/SecurityLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/SecurityLoginSettingsPanel.java
@@ -16,6 +16,7 @@
 
 package org.jivesoftware.spark.ui.login;
 
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.smack.ConnectionConfiguration;
 import org.jivesoftware.spark.util.ResourceUtils;
@@ -120,6 +121,15 @@ public class SecurityLoginSettingsPanel extends JPanel
         return true;
     }
 
+    public void useDefault() {
+        modeRequiredRadio.setSelected(Default.getString(Default.SECURITY_MODE).equals("required"));
+        modeIfPossibleRadio.setSelected(Default.getString(Default.SECURITY_MODE).equals("ifpossible"));
+        modeDisabledRadio.setSelected(Default.getString(Default.SECURITY_MODE).equals("disabled"));
+        disableHostnameVerificationBox.setSelected(Default.getBoolean(Default.DISABLE_HOSTNAME_VERIFICATION));
+        allowClientSideAuthentication.setSelected(Default.getBoolean(Default.ALLOW_CLIENT_SIDE_AUTH));
+        useSSLBox.setSelected(Default.getBoolean(Default.OLD_SSL_ENABLED));
+    }
+    
     public void saveSettings()
     {
         if ( modeRequiredRadio.isSelected() )

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/SsoLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/SsoLoginSettingsPanel.java
@@ -1,5 +1,6 @@
 package org.jivesoftware.spark.ui.login;
 
+import org.jivesoftware.resource.Default;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.spark.component.WrappedLabel;
 import org.jivesoftware.spark.util.ModelUtil;
@@ -232,6 +233,17 @@ class SsoLoginSettingsPanel extends JPanel implements ActionListener
         return valid;
     }
 
+    public void useDefault(){
+        useSSOBox.setSelected(Default.getBoolean(Default.USE_SSO));
+        methodFileRadio.setSelected(Default.getString(Default.SSO_METHOD).equals("file"));
+        methodDNSRadio.setSelected(Default.getString(Default.SSO_METHOD).equals("dns"));
+        methodManualRadio.setSelected(Default.getString(Default.SSO_METHOD).equals("manual"));
+        setFormEnabled(useSSOBox.isSelected());
+        useSaslGssapiSmack3compatBox.setSelected(Default.getBoolean(Default.USE_SASL_GSS_API_SMACK_3_COMPATIBLE));
+
+    
+    }
+    
     public void saveSettings()
     {
         localPreferences.setSSOEnabled( useSSOBox.isSelected() );

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
@@ -59,7 +59,7 @@ public class LocalPreferences {
 	 * @return the XMPP Port to communicate on. Default is 5222.
 	 */
 	public int getXmppPort() {
-		return Integer.parseInt(props.getProperty("xmppPort", "5222"));
+		return Integer.parseInt(props.getProperty("xmppPort", Default.getString(Default.XMPP_PORT)));
 	}
 
 	/**
@@ -101,7 +101,7 @@ public class LocalPreferences {
 	 * @return the smack timeout for requests.
 	 */
 	public int getTimeOut() {
-		return Integer.parseInt(props.getProperty("timeout", "10"));
+		return Integer.parseInt(props.getProperty("timeout", Default.getString(Default.TIME_OUT)));
 	}
 
 	/**
@@ -421,7 +421,7 @@ public class LocalPreferences {
     {
         try
         {
-            final String securityMode = props.getProperty( "securityMode", ConnectionConfiguration.SecurityMode.ifpossible.toString() );
+            final String securityMode = props.getProperty( "securityMode", Default.getString(Default.SECURITY_MODE) );
             return ConnectionConfiguration.SecurityMode.valueOf( securityMode );
         }
         catch ( Exception e )
@@ -452,7 +452,7 @@ public class LocalPreferences {
 	 * @return true if we should connect via 'old-style' SSL (otherwise, STARTTLS might be used).
 	 */
 	public boolean isSSL() {
-		return Boolean.parseBoolean(props.getProperty("sslEnabled", "false"));
+		return getBoolean("sslEnabled", Default.getBoolean(Default.OLD_SSL_ENABLED));
 	}
 
 	/**
@@ -511,7 +511,7 @@ public class LocalPreferences {
 	}
 
 	public boolean isProxyEnabled() {
-		return getBoolean("proxyEnabled", false);
+		return getBoolean("proxyEnabled", Default.getBoolean(Default.PROXY_ENABLED));
 	}
 
 	public void setProxyEnabled(boolean proxyEnabled) {
@@ -595,7 +595,7 @@ public class LocalPreferences {
 	}
 
 	public boolean isHostAndPortConfigured() {
-		return getBoolean("hostAndPort", false);
+		return getBoolean("hostAndPort", Default.getBoolean(Default.HOST_AND_PORT_CONFIGURED));
 	}
 
 	public void setHostAndPortConfigured(boolean configured) {
@@ -796,7 +796,7 @@ public class LocalPreferences {
 	}
 
 	public boolean isCompressionEnabled() {
-		return getBoolean("compressionOn", false);
+		return getBoolean("compressionOn", Default.getBoolean(Default.COMPRESSION_ENABLED));
 	}
 
 	public void setTheme(String theme) {
@@ -977,11 +977,11 @@ public class LocalPreferences {
 	}
 
 	public boolean isSSOEnabled() {
-		return getBoolean("ssoEnabled", false);
+		return getBoolean("ssoEnabled", Default.getBoolean(Default.USE_SSO));
 	}
 
 	public boolean isSaslGssapiSmack3Compatible() {
-		return getBoolean("saslGssapiSmack3compat", false);
+		return getBoolean("saslGssapiSmack3compat", Default.getBoolean(Default.USE_SASL_GSS_API_SMACK_3_COMPATIBLE));
 	}
 
 	public void setSaslGssapiSmack3Compatible( boolean b) {
@@ -1072,7 +1072,7 @@ public class LocalPreferences {
 	}
 
 	public boolean isDebuggerEnabled() {
-		return getBoolean("debuggerEnabled", false);
+		return getBoolean("debuggerEnabled", Default.getBoolean(Default.DEBUGGER_ENABLED));
 	}
 
 	public void setContactListFontSize(int fontSize) {
@@ -1231,7 +1231,7 @@ public class LocalPreferences {
 	}
 
 	public boolean isAcceptAllCertificates() {
-		return getBoolean("AcceptAllCertificates", false);
+		return getBoolean("AcceptAllCertificates", Default.getBoolean(Default.ACCEPT_ALL));
 	}
 
 	public void setDisableHostnameVerification(boolean accept) {
@@ -1239,7 +1239,7 @@ public class LocalPreferences {
 	}
 
 	public boolean isDisableHostnameVerification() {
-		return getBoolean("DisableHostnameVerification", false);
+		return getBoolean("DisableHostnameVerification", Default.getBoolean(Default.DISABLE_HOSTNAME_VERIFICATION));
 	}
 
 	private boolean getBoolean(String property, boolean defaultValue) {
@@ -1357,7 +1357,7 @@ public class LocalPreferences {
     }
 
     public boolean isUseHostnameAsResource() {
-	return getBoolean("useHostnameAsResource", false);
+	return getBoolean("useHostnameAsResource", Default.getBoolean(Default.USE_HOSTNAME_AS_RESOURCE));
     }
 
     public void setUseHostnameAsResource(boolean useHostnameAsResource) {
@@ -1365,7 +1365,7 @@ public class LocalPreferences {
     }
     
     public boolean isUseVersionAsResource() {
-	return getBoolean("useVersionAsResource", false);
+	return getBoolean("useVersionAsResource", Default.getBoolean(Default.USE_VERSION_AS_RESOURCE));
     }
 
     public void setUseVersionAsResource(boolean useVersionAsResource) {
@@ -1422,7 +1422,7 @@ public class LocalPreferences {
     }
     
     public boolean isAcceptSelfSigned() {
-        return Boolean.parseBoolean(props.getProperty("acceptSelfSigned", "false"));
+        return getBoolean("acceptSelfSigned", Default.getBoolean(Default.ACCEPT_SELF_SIGNED));
     }
 
     public void setAcceptSelfSigned(boolean acceptSelfSigned) {
@@ -1430,7 +1430,7 @@ public class LocalPreferences {
     }
 
     public boolean isAcceptRevoked() {
-        return Boolean.parseBoolean(props.getProperty("acceptRevoked", "false"));
+        return getBoolean("acceptRevoked", Default.getBoolean(Default.ACCEPT_REVOKED));
     }
 
     public void setAcceptRevoked(boolean acceptRevoked) {
@@ -1438,7 +1438,8 @@ public class LocalPreferences {
     }
 
     public boolean isAcceptExpired() {
-        return Boolean.parseBoolean(props.getProperty("acceptExpired", "false"));
+        
+        return getBoolean("acceptExpired", Default.getBoolean(Default.ACCEPT_EXPIRED));
     }
 
     public void setAcceptExpired(boolean acceptExpired) {
@@ -1446,7 +1447,7 @@ public class LocalPreferences {
     }
 
     public boolean isAcceptNotValidYet() {
-        return Boolean.parseBoolean(props.getProperty("acceptNotValidYet", "false"));
+        return getBoolean("acceptNotValidYet", Default.getBoolean(Default.ACCEPT_NOT_VALID_YET));
     }
     
     public void setAcceptNotValidYet(boolean acceptNotValidYet) {
@@ -1454,7 +1455,7 @@ public class LocalPreferences {
     }
     
     public boolean isCheckCRL() {
-        return Boolean.parseBoolean(props.getProperty("checkCRL", "true"));
+        return getBoolean("checkCRL", Default.getBoolean(Default.CHECK_CRL));
     }
 
     public void setCheckCRL(boolean checkCRL) {
@@ -1462,7 +1463,7 @@ public class LocalPreferences {
     }
 
     public boolean isCheckOCSP() {
-        return Boolean.parseBoolean(props.getProperty("checkOCSP", "true"));
+        return getBoolean("checkOCSP", Default.getBoolean(Default.CHECK_OCSP));
     }
 
     public void setCheckOCSP(boolean checkOCSP) {
@@ -1470,7 +1471,7 @@ public class LocalPreferences {
     }
 
     public boolean isAllowSoftFail() {
-        return Boolean.parseBoolean(props.getProperty("allowSoftFail", "true"));
+        return getBoolean("allowSoftFail", Default.getBoolean(Default.ALLOW_SOFT_FAIL));
     }
 
     public void setAllowSoftFail(boolean allowSoftFail) {
@@ -1478,7 +1479,7 @@ public class LocalPreferences {
     }
     
     public boolean isAllowClientSideAuthentication() {
-        return Boolean.parseBoolean(props.getProperty("allowClientSideAuthentication", "false"));
+        return getBoolean("allowClientSideAuthentication", Default.getBoolean(Default.ALLOW_CLIENT_SIDE_AUTH));
     }
 
     public void setAllowClientSideAuthentication(boolean allowClientSideAuthentication) {

--- a/core/src/main/resources/default.properties
+++ b/core/src/main/resources/default.properties
@@ -56,6 +56,38 @@ CERTIFICATES_MANAGER_DISABLED = false
 #Removes Mutual Authentication Tab
 MUTUAL_AUTH_DISABLED = false
 
+#
+# This are default settings in LoginSettingsDialog tabs
+# General
+HOST_AND_PORT_CONFIGURED = false
+XMPP_PORT = 5222
+USE_HOSTNAME_AS_RESOURCE = false
+USE_VERSION_AS_RESOURCE = false
+TIME_OUT = 10
+COMPRESSION_ENABLED = false
+DEBUGGER_ENABLED = false
+#Security tab
+DISABLE_HOSTNAME_VERIFICATION = false
+ALLOW_CLIENT_SIDE_AUTH = false
+SECURITY_MODE = ifpossible
+OLD_SSL_ENABLED = false
+#PROXY
+PROXY_ENABLED = false
+#SSO
+USE_SSO = false
+USE_SASL_GSS_API_SMACK_3_COMPATIBLE = false
+SSO_METHOD = file
+# Certificate ManagerSettingsPanel
+ACCEPT_ALL = false
+ACCEPT_EXPIRED = false
+ACCEPT_NOT_VALID_YET = false
+ACCEPT_SELF_SIGNED = false
+ACCEPT_REVOKED = false
+CHECK_CRL = true
+CHECK_OCSP = true
+ALLOW_SOFT_FAIL = true
+
+
 # Show Password Reset Button on LoginDialog. 
 # !!!! This will repleace the "register new user" button, please set ACCOUNT_DISABLED = true !!!!
 PASSWORD_RESET_ENABLED = false

--- a/core/src/main/resources/i18n/spark_i18n.properties
+++ b/core/src/main/resources/i18n/spark_i18n.properties
@@ -963,6 +963,7 @@ tab.proxy = Proxy
 tab.sso = SSO
 tab.pki = PKI
 tab.certificates = Certificates
+tab.mutual.auth = Mutual auth
 title.about = About
 title.advanced.connection.preferences = Advanced connection preferences
 title.account.create.registration = Account registration


### PR DESCRIPTION
At first I was intending to add default settings only to Certificate Manager but as UseDefault button wasn't working for other tabs so I fixed them too. I added default settings to Default class and default.proporties and used it in tabs.