### PR TITLE
Added protection against NPE

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/SparkTrustManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/SparkTrustManager.java
@@ -133,7 +133,12 @@ public class SparkTrustManager implements X509TrustManager {
                 // check if certificate is in Keystore and check CRL, but do not validate path as certificate is Self
                 // Signed important reminder: hostname validation must be also turned off to accept self signed
                 // certificate
-                List<X509Certificate> certList = new ArrayList<>(Arrays.asList(getAcceptedIssuers()));
+                X509Certificate[] cert=getAcceptedIssuers();
+                if(cert == null)
+                {
+                    throw new CertificateException("Couldn't load trusted certificates");
+                }
+                List<X509Certificate> certList = new ArrayList<>(Arrays.asList(cert));
                 if (!certList.contains(chain[0])) {
                     throw new CertificateException("Certificate not in the TrustStore");
                 }
@@ -160,6 +165,7 @@ public class SparkTrustManager implements X509TrustManager {
         try {
             // See how many certificates are in the keystore.
             int numberOfEntry = trustStore.size();
+            System.out.println("numberOfEntry==="+numberOfEntry);
             if (acceptRevoked) {
                 numberOfEntry += blackStore.size();
             }


### PR DESCRIPTION
got NPE  in the Spark log :
 org.jivesoftware.smack.SmackException: javax.net.ssl.SSLException: java.lang.NullPointerException
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1029)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$300(XMPPTCPConnection.java:956)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:971)
	at java.lang.Thread.run(Thread.java:745)
Caused by: javax.net.ssl.SSLException: java.lang.NullPointerException
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:208)
	at sun.security.ssl.SSLSocketImpl.fatal(SSLSocketImpl.java:1949)
	at sun.security.ssl.SSLSocketImpl.fatal(SSLSocketImpl.java:1906)
	at sun.security.ssl.SSLSocketImpl.handleException(SSLSocketImpl.java:1889)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1410)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1387)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection.proceedTLSReceived(XMPPTCPConnection.java:768)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection.access$1000(XMPPTCPConnection.java:139)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:1022)
	... 3 more
Caused by: java.lang.NullPointerException
	at java.util.Objects.requireNonNull(Objects.java:203)
	at java.util.Arrays$ArrayList.<init>(Arrays.java:3813)
	at java.util.Arrays.asList(Arrays.java:3800)
	at org.jivesoftware.sparkimpl.certificates.SparkTrustManager.checkServerTrusted(SparkTrustManager.java:136)
	at sun.security.ssl.AbstractTrustManagerWrapper.checkServerTrusted(SSLContextImpl.java:922)
	at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1491)
	at sun.security.ssl.ClientHandshaker.processMessage(ClientHandshaker.java:216)
	at sun.security.ssl.Handshaker.processLoop(Handshaker.java:979)
	at sun.security.ssl.Handshaker.process_record(Handshaker.java:914)
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:1062)
	at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1375)
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1403)
	... 7 more
I have added protection for case when we return empty X509Certificate array
