### PR TITLE
SPARK-2006 Don't use common name as alias if alias already exist.

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateController.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateController.java
@@ -119,13 +119,12 @@ public class CertificateController extends CertManager {
                     // if getCertificateAlias return null then entry doesn't exist in distrustedCaStore (Java's default).
                     if (distrustedCaStore.getCertificateAlias(certificate) == null && exceptionsCaStore.getCertificateAlias(certificate) == null) {
 
-                        displayCerts.setCertificateEntry(useCommonNameAsAlias(certificate), certificate);                        
+                        displayCerts.setCertificateEntry(alias, certificate);                        
                     }
 
                 }
             }
-        } catch (KeyStoreException | HeadlessException | InvalidNameException | NoSuchAlgorithmException
-                | CertificateException | IOException e) {
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
             Log.error("Cannot read KeyStore", e);
 
         }


### PR DESCRIPTION
I probably introduced this bug with adding JRE certificates, but it is not related to random NullPointerExceptions. The problem which it generate is that not all certificates from JRE are displayed and that cause further problems at moving certificates to/from exceptions list.