### PR TITLE
SPARK-2008 Fix for exempted cacerts certificates removal

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateController.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateController.java
@@ -119,13 +119,12 @@ public class CertificateController extends CertManager {
                     // if getCertificateAlias return null then entry doesn't exist in distrustedCaStore (Java's default).
                     if (distrustedCaStore.getCertificateAlias(certificate) == null && exceptionsCaStore.getCertificateAlias(certificate) == null) {
 
-                        displayCerts.setCertificateEntry(useCommonNameAsAlias(certificate), certificate);                        
+                        displayCerts.setCertificateEntry(alias, certificate);                        
                     }
 
                 }
             }
-        } catch (KeyStoreException | HeadlessException | InvalidNameException | NoSuchAlgorithmException
-                | CertificateException | IOException e) {
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
             Log.error("Cannot read KeyStore", e);
 
         }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateController.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateController.java
@@ -369,7 +369,7 @@ public class CertificateController extends CertManager {
         if (dialogValue == JOptionPane.YES_OPTION) {
             KeyStore store = getAliasKeyStore(alias);
             
-            if(store.equals(displayCaStore)){
+            if(store.equals(displayCaStore) || store.equals(exceptionsCaStore)){
                 // adds entry do distrusted store so it will be not displayed next time
                 distrustedCaStore.setCertificateEntry(alias, store.getCertificate(alias));
             }
@@ -385,6 +385,7 @@ public class CertificateController extends CertManager {
             trustedCertificates.remove(model);
             blackListedCertificates.remove(model);
             displayCaCertificates.remove(model);
+            exemptedCacerts.remove(model);
              
             allCertificates.remove(model);
         }


### PR DESCRIPTION
When you tried to remove certificate it was removed only from exemptedCacertsStore but it wasn't added to the distrusted entries. In effect certificate was displayed still but now as trusted JRE certificate.