### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Bug Reporting
 Only a few users have access for for filling bugs in the tracker. New
 users should:
 
-1. Create a forums account (only e-mail is a requirement, you can skip all the other fields).
-2. Login to a forum account
-3. Press New in your toolbar and choose Discussion
-4. Choose the [Spark Dev forum](http://community.igniterealtime.org/community/developers/spark_dev) of Ignite Realtime and add the tag 'bug_report' to your new post
+1. Create a Discourse account
+2. Login to a Discourse account
+3. Click on the New Topic button.
+4. Choose the [Spark Dev category](https://discourse.igniterealtime.org/c/spark/spark-dev) of Ignite Realtime and provide a detailed description of the bug.
 
 Please search for your issues in the bug tracker before reporting.
 
@@ -33,6 +33,7 @@ Resources
 ---------
 
 - Documentation: http://www.igniterealtime.org/projects/spark/documentation.jsp
+- Community: https://discourse.igniterealtime.org/c/spark
 - Bug Tracker: http://issues.igniterealtime.org/browse/SPARK
 - Nightly Builds: http://www.igniterealtime.org/downloads/nightly_spark.jsp
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,28 @@ Combined with the [Openfire] server, [Spark] is the easiest and best alternative
 
 [![Build Status](https://travis-ci.org/igniterealtime/Spark.svg?branch=master)](https://travis-ci.org/igniterealtime/Spark)
 
--------
+Bug Reporting
+-------------
+
+Only a few users have access for for filling bugs in the tracker. New
+users should:
+
+1. Create a forums account (only e-mail is a requirement, you can skip all the other fields).
+2. Login to a forum account
+3. Press New in your toolbar and choose Discussion
+4. Choose the [Spark Dev forum](http://community.igniterealtime.org/community/developers/spark_dev) of Ignite Realtime and add the tag 'bug_report' to your new post
+
+Please search for your issues in the bug tracker before reporting.
+
+Resources
+---------
+
+- Documentation: http://www.igniterealtime.org/projects/spark/documentation.jsp
+- Bug Tracker: http://issues.igniterealtime.org/browse/SPARK
+- Nightly Builds: http://www.igniterealtime.org/downloads/nightly_spark.jsp
+
+Ignite Realtime
+===============
 
 [Ignite Realtime] is an Open Source community composed of end-users and developers around the world who 
 are interested in applying innovative, open-standards-based Real Time Collaboration to their businesses and organizations. 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ users should:
 
 1. Create a Discourse account
 2. Login to a Discourse account
-3. Click on the New Topic button.
-4. Choose the [Spark Dev category](https://discourse.igniterealtime.org/c/spark/spark-dev) of Ignite Realtime and provide a detailed description of the bug.
+3. Click on the New Topic button
+4. Choose the [Spark Dev category](https://discourse.igniterealtime.org/c/spark/spark-dev) and provide a detailed description of the bug.
 
 Please search for your issues in the bug tracker before reporting.
 


### PR DESCRIPTION
The Spark README seemed a bit lacking in comparison to OpenFire's, so I copied the same format from OpenFire, but switched all the links to match Spark. I also edited the community info to mention Discourse instead of the old Community.