### PR TITLE
SPARK-2029: Don't check for voice

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
@@ -629,7 +629,7 @@ public class GroupChatRoom extends ChatRoom
 
                     final boolean isFromRoom = !message.getFrom().contains( "/" );
 
-                    if ( !SparkManager.getUserManager().hasVoice( this, from ) && !isFromRoom )
+                    if ( !isFromRoom && SparkManager.getUserManager().getOccupant( this, from ) == null )
                     {
                         return;
                     }


### PR DESCRIPTION
Upon receiving messages to be displayed in a chat room UI, don't explicity check if the
sender has voice (the server will have done this). This commit replaces the check with
a check to verify that the sender is a participant in the room (and I'm not even sure if
that's warranted).