### PR TITLE
SPARK-2030: Add basic Message Styling support

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/MessageEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/MessageEntry.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.spark.ui;
 
+import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.plugin.emoticons.EmoticonManager;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 
@@ -22,7 +23,10 @@ import javax.swing.*;
 import javax.swing.text.*;
 import java.awt.*;
 import java.time.ZonedDateTime;
-import java.util.StringTokenizer;
+import java.util.*;
+import java.util.List;
+
+import static javax.swing.text.StyleConstants.Foreground;
 
 /**
  * An entry that represents a single (chat) message.
@@ -34,6 +38,7 @@ import java.util.StringTokenizer;
  */
 public class MessageEntry extends TimeStampedEntry
 {
+    public static final List<Character> DIRECTIVE_CHARS = Arrays.asList( '*', '_', '~', '`' );
     private final String prefix;
     private final Color prefixColor;
     private final String message;
@@ -106,7 +111,7 @@ public class MessageEntry extends TimeStampedEntry
         this.backgroundColor = backgroundColor != null ? backgroundColor : new Color( 255, 255, 255, 0);
     }
 
-    protected AttributeSet getPrefixStyle()
+    protected MutableAttributeSet getPrefixStyle()
     {
         final MutableAttributeSet style = new SimpleAttributeSet();
         StyleConstants.setFontFamily( style, "Dialog" );
@@ -116,7 +121,7 @@ public class MessageEntry extends TimeStampedEntry
         return style;
     }
 
-    protected AttributeSet getMessageStyle()
+    protected MutableAttributeSet getMessageStyle()
     {
         final MutableAttributeSet style = new SimpleAttributeSet();
         StyleConstants.setFontFamily( style, "Dialog" );
@@ -129,35 +134,221 @@ public class MessageEntry extends TimeStampedEntry
     @Override
     protected void addTo( ChatArea chatArea ) throws BadLocationException
     {
-        final AttributeSet prefixStyle = getPrefixStyle();
-        final AttributeSet messageStyle = getMessageStyle();
+        final MutableAttributeSet prefixStyle = getPrefixStyle();
+        final MutableAttributeSet messageStyle = getMessageStyle();
 
         // First, add the message prefix.
         final Document doc = chatArea.getDocument();
         doc.insertString( doc.getLength(), getFormattedTimestamp() + prefix + ": ", prefixStyle );
 
-        // Next, process the message, bit by bit.
-        final StringTokenizer tokenizer = new StringTokenizer( message, " \n\t", true );
-        while ( tokenizer.hasMoreTokens() )
-        {
-            String textFound = tokenizer.nextToken();
+        final MutableAttributeSet directiveStyle = applyMessageStyle( 'K', messageStyle ); // Special style used on the directives themselves.
 
-            if ( ( textFound.startsWith( "http://" ) || textFound.startsWith( "ftp://" ) || textFound.startsWith( "https://" ) || textFound.startsWith( "www." ) || textFound.startsWith( "file:/" ) ) && textFound.indexOf( "." ) > 1 )
+        // Next, process the message, bit by bit.
+        for ( final Block block : asBlocks( message ) )
+        {
+            if ( block.isPreformattedCodeBlock() )
             {
-                insertLink( doc, textFound );
+                final MutableAttributeSet style = applyMessageStyle( '`', messageStyle );
+                for ( final String line : block.lines )
+                {
+                    doc.insertString( doc.getLength(), line + "\n", line.trim().startsWith( "```" ) ? directiveStyle : style );
+                }
             }
-            else if ( textFound.startsWith( "\\\\" ) || ( textFound.indexOf( "://" ) > 0 && textFound.indexOf( "." ) < 1 ) )
+            else
             {
-                insertAddress( doc, textFound );
-            }
-            else if ( !insertImage( chatArea, textFound ) )
-            {
-                doc.insertString( doc.getLength(), textFound, messageStyle );
+                // for now, we'll not visually differentiate between quotes and non-quotes.
+                for ( final String line : block.lines)
+                {
+                    int i = 0;
+                    while ( i < line.length() - 1 )
+                    {
+                        // Skip through prepending whitespace.
+                        if ( Character.isWhitespace( line.charAt( i ) ) )
+                        {
+                            doc.insertString( doc.getLength(), line.substring( i, i+1 ), messageStyle );
+                            i++;
+                        }
+
+                        // Find the next whitespace or line-ending (used for links, addresses, images, but not style)
+                        int end = line.indexOf( ' ', i+1 );
+                        if ( end == -1 ) end = line.indexOf(  '\t', i+1 );
+                        if ( end == -1 ) end = line.length();
+                        final String textFound = line.substring( i, end );
+                        if ( ( textFound.startsWith( "http://" ) || textFound.startsWith( "ftp://" ) || textFound.startsWith( "https://" ) || textFound.startsWith( "www." ) || textFound.startsWith( "file:/" ) ) && textFound.indexOf( "." ) > 1 )
+                        {
+                            insertLink( doc, textFound );
+                            i = end;
+                            continue;
+                        }
+
+                        if ( textFound.startsWith( "\\\\" ) || ( textFound.indexOf( "://" ) > 0 && textFound.indexOf( "." ) < 1 ) )
+                        {
+                            insertAddress( doc, textFound );
+                            i = end;
+                            continue;
+                        }
+
+                        if ( insertImage( chatArea, textFound ) )
+                        {
+                            i = end;
+                            continue;
+                        }
+
+                        // Opening directive (must be preceeded by a whitespace-character, or be the first character of the line)
+                        if ( (i == 0 || Character.isWhitespace( line.charAt( i-1 ) ) ) && DIRECTIVE_CHARS.contains( line.charAt( i ) ) )
+                        {
+                            final char directive = line.charAt( i );
+                            final int closing = line.indexOf( directive, i + 1 );
+
+                            // Closing directive must not be preceeded by a whitespace character.
+                            if ( closing != -1 && !Character.isWhitespace( line.charAt( closing-1 ) ) )
+                            {
+                                final MutableAttributeSet applied = applyMessageStyle( directive, messageStyle );
+                                doc.insertString( doc.getLength(), line.substring( i, i+1 ), directiveStyle ); // Opening directive
+                                doc.insertString( doc.getLength(), line.substring( i+1, closing ), applied ); // Styled text
+                                doc.insertString( doc.getLength(), line.substring( closing, closing+1 ), directiveStyle ); // Closing directive
+                                i = closing + 1;
+                                continue;
+                            }
+                        }
+
+                        doc.insertString( doc.getLength(), textFound, messageStyle );
+                        i = end;
+                    }
+
+                    doc.insertString( doc.getLength(), "\n", messageStyle );
+                }
             }
         }
 
-        doc.insertString( doc.getLength(), "\n", messageStyle );
         chatArea.setCaretPosition( doc.getLength() );
+    }
+
+    /**
+     * Splits the provided text into a sequence of blocks.
+     *
+     * @param text The text to be parsed
+     * @return the
+     */
+    protected java.util.List<Block> asBlocks( String text )
+    {
+        final java.util.List<Block> result = new ArrayList<>();
+
+        // Process the text line-by-line
+        final StringTokenizer tokenizer = new StringTokenizer( text, "\n", false );
+        Block block = null;
+        while ( tokenizer.hasMoreTokens() )
+        {
+            final String line = tokenizer.nextToken();
+
+            if ( block == null )
+            {
+                block = new Block( line );
+            }
+            else if ( !block.tryAppend( line ) )
+            {
+                // If this line does not belong to the block that's already being constructed, then that block is
+                // done. Add it to the resul    t, and create a new one.
+                result.add( block );
+                block = new Block( line );
+            }
+        }
+
+        if (block != null)
+        {
+            result.add( block );
+        }
+
+        return result;
+    }
+
+    /**
+     * A block is any chunk of text that can be parsed unambiguously in one pass.
+     *
+     * <ul>
+     * <li>A single line of text comprising one or more spans</li>
+     * <li>A block quotation</li>
+     * <li>A preformatted code block</li>
+     * </ul>
+     */
+    class Block
+    {
+        java.util.Deque<String> lines = new ArrayDeque<>();
+
+        Block( String line )
+        {
+            lines.add( line );
+        }
+
+        boolean isBlockQuotation() {
+            return !lines.isEmpty() && lines.getFirst().startsWith( ">" );
+        }
+
+        boolean isPreformattedCodeBlock() {
+            return !lines.isEmpty() && lines.getFirst().startsWith( "```" );
+        }
+
+        boolean tryAppend( String line )
+        {
+            if ( isBlockQuotation() && line.startsWith( ">" ) )
+            {
+                // Only add when this is a new line in the same block quote.
+                if ( !line.startsWith( ">" ) )
+                {
+                    return false;
+                }
+
+                lines.add( line );
+                return true;
+            }
+
+            if ( isPreformattedCodeBlock() )
+            {
+                // Only add if the code block was not already closed.
+                if ( lines.size() > 1 && lines.getLast().trim().endsWith( "```" ) )
+                {
+                    return false;
+                }
+
+                lines.add( line );
+                return true;
+            }
+
+            if ( line.startsWith( ">" ) || line.startsWith( "```" ))
+            {
+                // Start a new block!
+                return false;
+            }
+            lines.add( line );
+            return true;
+        }
+    }
+
+    public MutableAttributeSet applyMessageStyle( char directive, MutableAttributeSet messageStyle )
+    {
+        final MutableAttributeSet style = new SimpleAttributeSet( messageStyle.copyAttributes() );
+        switch ( directive )
+        {
+            case '*':
+                StyleConstants.setBold( style, true );
+                break;
+            case '_':
+                StyleConstants.setItalic( style, true );
+                break;
+            case '~':
+                StyleConstants.setStrikeThrough( style, true );
+                break;
+            case '`':
+                StyleConstants.setFontFamily( style, "Monospaced" );
+                break;
+            case 'K': // Keyword
+                StyleConstants.setForeground( style, ((Color) messageStyle.getAttribute( Foreground )).brighter().brighter().brighter() );
+                break;
+
+            default:
+                Log.warning( "Cannot apply message style for unrecognized directive: " + directive );
+        }
+        return style;
     }
 
     /**


### PR DESCRIPTION
This is a quick and dirty implementation that can (and perhaps should) be improved upon.

It adds basic support, but does not work with nested styles.