### PR TITLE
SPARK-2045 Make better use of PKIXRevocationChecker

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/login/CertificatesManagerSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/CertificatesManagerSettingsPanel.java
@@ -193,6 +193,7 @@ public class CertificatesManagerSettingsPanel extends JPanel implements ActionLi
             if (checkCRL.isSelected()) {
 
                 checkOCSP.setEnabled(true);
+                allowSoftFail.setEnabled(true);
             } else if (!checkCRL.isSelected()) {
 
                 checkOCSP.setSelected(false);
@@ -214,16 +215,8 @@ public class CertificatesManagerSettingsPanel extends JPanel implements ActionLi
             } else if (!acceptRevoked.isSelected()) {
                 checkCRL.setEnabled(true);
             }
-        } else if (e.getSource() == checkOCSP) {
-            if (checkOCSP.isSelected()) {
-
-                allowSoftFail.setEnabled(true);
-            } else if (!checkOCSP.isSelected()) {
-
-                allowSoftFail.setEnabled(false);
-                allowSoftFail.setSelected(false);
-            }
-        }
+        } 
+        
     }
 
     @Override


### PR DESCRIPTION
Use of PKIXRevocationChecker instead of custom code for downloading CRLs. This way checker's options are better used (and soft fail policy can be set with just CRL's). Also some comments were improved.