### PR TITLE
Fileupload plugin: fix invalid port bug

### DIFF
--- a/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/ChatRoomDecorator.java
+++ b/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/ChatRoomDecorator.java
@@ -184,9 +184,13 @@ public class ChatRoomDecorator
 
         try {
             PutMethod put = new PutMethod(response.putUrl);
-            Protocol.registerProtocol( "https", new Protocol( "https", new EasySSLProtocolSocketFactory(), put.getURI().getPort() ) );
+            int port = put.getURI().getPort();
+            if (port > 0)
+            {
+                Protocol.registerProtocol( "https", new Protocol( "https", new EasySSLProtocolSocketFactory(), port ) );
+            }
+            
             HttpClient client = new HttpClient();
-
             RequestEntity entity = new FileRequestEntity(file, "application/binary");
             put.setRequestEntity(entity);
             put.setRequestHeader("User-Agent", "Spark HttpFileUpload");


### PR DESCRIPTION
Fileupload plugin can upload file only once, and the next upload fails because of this bug.
`Putmethod.getURI()` seems to omit port number if the port of `Protocol` matches with that of the instance.
So I assumed that if `URI.getPort()` returns -1, the protocol need not be changed. 