### PR TITLE
Fileupload plugin: change uploadrequest parsing function

### DIFF
--- a/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/UploadRequest.java
+++ b/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/UploadRequest.java
@@ -77,11 +77,11 @@ public class UploadRequest extends IQ
                 {
                     if ( parser.getName().equals( "put" ) )
                     {
-                        uploadRequest.getUrl = parser.nextText();
+                        uploadRequest.putUrl = parser.getAttributeValue(null, "url");
                     }
                     else if ( parser.getName().equals( "get" ) )
                     {
-                        uploadRequest.putUrl = parser.nextText();
+                        uploadRequest.getUrl = parser.getAttributeValue(null, "url");
                     }
                 }
 


### PR DESCRIPTION
#### Quick explanation:

[Http file upload plugin] in Openfire was updated from 1.1.2 to 1.1.3 in 2/19.
The problem is that it changed the response format in compliance to XEP-format ([commit link]):

```java
slotElement.addElement( "put" ).setText( url.toExternalForm() );
slotElement.addElement( "get" ).setText( url.toExternalForm() );
```
to
```java
if ( isPre030Style )
{
	slotElement.addElement( "put" ).setText( url.toExternalForm() );
	slotElement.addElement( "get" ).setText( url.toExternalForm() );
}
else
{
	slotElement.addElement( "put" ).addAttribute( "url", url.toExternalForm() );
	slotElement.addElement( "get" ).addAttribute( "url", url.toExternalForm() );
}
```

So this causes parsing error in the fileupload plugin in Spark.
This PR will conflict with previous 1.1.2 version of Openfire plugin, so one should update it to 1.1.3 as soon as possible.

I also fixed code mismatch with "put" and "get" conditionals.

[Http file upload plugin]: https://github.com/guusdk/httpfileuploadcomponent
[commit link]: https://github.com/guusdk/httpfileuploadcomponent/commit/50d37567521e30bd96aeda9a624d2853433f9c9a