### PR TITLE
Removing some dead code.

### DIFF
--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -33,7 +33,7 @@ import org.jivesoftware.spark.util.ResourceUtils;
 import org.jivesoftware.spark.util.SwingWorker;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.certificates.SparkSSLSocketFactory;
-import org.jivesoftware.sparkimpl.certificates.SparkSSLContext;
+import org.jivesoftware.sparkimpl.certificates.SparkSSLContextCreator;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.parts.Localpart;
@@ -356,7 +356,7 @@ public class AccountCreationWizard extends JPanel {
             // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
             // plain connections which is 5222.
             try {
-                SSLContext context = SparkSSLContext.setUpContext(SparkSSLContext.Options.ONLY_SERVER_SIDE);
+                SSLContext context = SparkSSLContextCreator.setUpContext(SparkSSLContextCreator.Options.ONLY_SERVER_SIDE);
                 builder.setCustomSSLContext(context);
                 builder.setSecurityMode( securityMode );
             } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
@@ -374,7 +374,7 @@ public class AccountCreationWizard extends JPanel {
                 builder.setHost( DNSUtil.resolveXMPPServiceDomain( serverNameDnsName, null, DnssecMode.disabled ).get( 0 ).getFQDN() );
                 builder.setPort( 5223 );
             }
-            builder.setSocketFactory( new SparkSSLSocketFactory(SparkSSLContext.Options.ONLY_SERVER_SIDE) );
+            builder.setSocketFactory( new SparkSSLSocketFactory(SparkSSLContextCreator.Options.ONLY_SERVER_SIDE) );
             // SMACK 4.1.9  does not recognize an 'old-style' SSL socket as being secure, which will cause a failure when
             // the 'required' Security Mode is defined. Here, we work around this by replacing that security mode with an
             // 'if-possible' setting.

--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -48,7 +48,7 @@ import org.jivesoftware.spark.util.SwingWorker;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.plugin.manager.Enterprise;
 import org.jivesoftware.sparkimpl.certificates.SparkSSLSocketFactory;
-import org.jivesoftware.sparkimpl.certificates.SparkSSLContext;
+import org.jivesoftware.sparkimpl.certificates.SparkSSLContextCreator;
 import org.jivesoftware.sparkimpl.plugin.layout.LayoutSettings;
 import org.jivesoftware.sparkimpl.plugin.layout.LayoutSettingsManager;
 import org.jivesoftware.sparkimpl.settings.JiveInfo;
@@ -290,14 +290,14 @@ public class LoginDialog {
         if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useOldSSL) {
             // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
             // plain connections which is 5222.
-            SparkSSLContext.Options options;
+            SparkSSLContextCreator.Options options;
             if(localPref.isAllowClientSideAuthentication()){
-            options = SparkSSLContext.Options.BOTH;
+            options = SparkSSLContextCreator.Options.BOTH;
             } else {
-                options = SparkSSLContext.Options.ONLY_SERVER_SIDE;
+                options = SparkSSLContextCreator.Options.ONLY_SERVER_SIDE;
             }
             try {               
-                SSLContext context = SparkSSLContext.setUpContext(options);
+                SSLContext context = SparkSSLContextCreator.setUpContext(options);
                 builder.setCustomSSLContext(context);
                 builder.setSecurityMode( securityMode );
             } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
@@ -314,11 +314,11 @@ public class LoginDialog {
                 builder.setHost( DNSUtil.resolveXMPPServiceDomain( serverNameDnsName, null, DnssecMode.disabled ).get( 0 ).getFQDN() );
                 builder.setPort( 5223 );
             }
-            SparkSSLContext.Options options;
+            SparkSSLContextCreator.Options options;
             if(localPref.isAllowClientSideAuthentication()){
-            options = SparkSSLContext.Options.BOTH;
+            options = SparkSSLContextCreator.Options.BOTH;
             } else {
-                options = SparkSSLContext.Options.ONLY_SERVER_SIDE;
+                options = SparkSSLContextCreator.Options.ONLY_SERVER_SIDE;
             }
             builder.setSocketFactory( new SparkSSLSocketFactory(options) );
             // SMACK 4.1.9  does not recognize an 'old-style' SSL socket as being secure, which will cause a failure when

--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/SparkSSLContextCreator.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/SparkSSLContextCreator.java
@@ -13,45 +13,38 @@ import javax.net.ssl.SSLContextSpi;
 
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 
-public class SparkSSLContext extends SSLContext {
+public class SparkSSLContextCreator {
 
     /**
-     * 
      * ClientSide is authentication by
      */
     public enum Options {
         BOTH, ONLY_CLIENT_SIDE, ONLY_SERVER_SIDE;
-
-    }
-
-    protected SparkSSLContext(SSLContextSpi contextSpi, Provider provider, String protocol) {
-        super(contextSpi, provider, protocol);
-        // TODO Auto-generated constructor stub
     }
 
     /**
      * Create SSLContext and initialize it
      * 
-     * @return initialized SSL context with BouncyCastleProvider
+     * @return initialized SSL context
      * @throws KeyManagementException
      * @throws NoSuchAlgorithmException
-     * @throws KeyStoreException 
-     * @throws UnrecoverableKeyException 
+     * @throws KeyStoreException
+     * @throws UnrecoverableKeyException
      * @throws NoSuchProviderException
      */
-    public static SSLContext setUpContext(Options options) throws KeyManagementException, NoSuchAlgorithmException, UnrecoverableKeyException, KeyStoreException, NoSuchProviderException {
-        SSLContext context = SparkSSLContext.getInstance("TLS");
-        if (options == options.ONLY_SERVER_SIDE) {
+    public static SSLContext setUpContext(Options options)
+            throws KeyManagementException, NoSuchAlgorithmException, UnrecoverableKeyException, KeyStoreException, NoSuchProviderException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        if (options == Options.ONLY_SERVER_SIDE) {
             context.init(null, SparkTrustManager.getTrustManagerList(), new SecureRandom());
-        } else if (options == options.BOTH) {
-
+        } else if (options == Options.BOTH) {
             IdentityController identityController = new IdentityController(SettingsManager.getLocalPreferences());
             context.init(identityController.initKeyManagerFactory().getKeyManagers(), SparkTrustManager.getTrustManagerList(), new SecureRandom());
-  
-        } else if (options == options.ONLY_CLIENT_SIDE){
+
+        } else if (options == Options.ONLY_CLIENT_SIDE) {
             IdentityController identityController = new IdentityController(SettingsManager.getLocalPreferences());
             context.init(identityController.initKeyManagerFactory().getKeyManagers(), null, new SecureRandom());
-            
+
         }
         return context;
     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/SparkSSLSocketFactory.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/SparkSSLSocketFactory.java
@@ -28,7 +28,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.jivesoftware.spark.util.log.Log;
-import org.jivesoftware.sparkimpl.certificates.SparkSSLContext.Options;
+import org.jivesoftware.sparkimpl.certificates.SparkSSLContextCreator.Options;
 
 /**
  * An SSL socket factory that will let any certifacte past, even if it's expired or not singed by a root CA.
@@ -41,7 +41,7 @@ public class SparkSSLSocketFactory extends SSLSocketFactory {
 
         SSLContext sslcontent;
         try {
-            sslcontent = SparkSSLContext.setUpContext(options);
+            sslcontent = SparkSSLContextCreator.setUpContext(options);
             factory = sslcontent.getSocketFactory();
         } catch (KeyManagementException | UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException
                 | NoSuchProviderException e) {


### PR DESCRIPTION
It's more a cleanup PR as it doesn't bring any functional changes. I am removing here some dead code, as class SparkSSLContext inherit SSLContext without reason because SSLContext is created by it's static method.