### PR TITLE
SPARK-2107: restore popup when user search results are empty.

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/search/users/SearchForm.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/search/users/SearchForm.java
@@ -143,7 +143,7 @@ public class SearchForm extends JPanel {
 
             @Override
 			public void finished() {
-                if (data != null) {
+                if (data != null && !data.getRows().isEmpty() ) {
                     searchResults.showUsersFound(data);
                     searchResults.invalidate();
                     searchResults.validate();


### PR DESCRIPTION
When a search for users results in no hits, a popup used to be shown, but is no longer. This commit restores the functionality.