### PR TITLE
SPARK-2114: Fix Java version string comparison.

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/PluginManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/PluginManager.java
@@ -357,19 +357,16 @@ public class PluginManager implements MainWindowListener
                 // Check for minimum Java version
                 try
                 {
-                    String javaversion = plugin.selectSingleNode( "java" ).getText().replaceAll( "[^0-9]", "" );
-                    javaversion = javaversion == null ? "0" : javaversion;
-                    int jv = Integer.parseInt( attachMissingZero( javaversion ) );
-
-                    String myversion = System.getProperty( "java.version" ).replaceAll( "[^0-9]", "" );
-                    int mv = Integer.parseInt( attachMissingZero( myversion ) );
+                    final String pluginMinVersion = plugin.selectSingleNode( "java" ).getText();
+                    final int jv = StringUtils.getJavaMajorVersion( pluginMinVersion == null || pluginMinVersion.trim().isEmpty() ? "0" : pluginMinVersion.trim() );
+                    final int mv = StringUtils.getJavaMajorVersion( System.getProperty( "java.version" ) );
 
                     boolean ok = ( mv >= jv );
 
                     if ( !ok )
                     {
                         Log.error( "Unable to load plugin " + name +" due to old JavaVersion.\n" +
-                                       "It Requires " + plugin.selectSingleNode( "java" ).getText() +
+                                       "It Requires " + pluginMinVersion +
                                        " you have " + System.getProperty( "java.version" ) );
                         return null;
                     }
@@ -451,15 +448,6 @@ public class PluginManager implements MainWindowListener
         }
 
         return pluginClass;
-    }
-
-    private String attachMissingZero( String value )
-    {
-        while ( value.length() < 5 )
-        {
-            value = value + "0";
-        }
-        return value;
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/spark/util/StringUtils.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/StringUtils.java
@@ -2034,4 +2034,27 @@ public class StringUtils {
 	}
 	return result;
     }
+
+    /**
+     * Returns the value of the major/feature element of the version number.
+     *
+     * @param version A java version String
+     * @return The major
+     */
+    public static int getJavaMajorVersion( String version ) {
+        if (version.startsWith("1.")) {
+            int dot = version.indexOf(".", 2);
+            if ( dot == -1 ) {
+                version = version.substring( 2 );
+            } else {
+                version = version.substring( 2, dot );
+            }
+        } else {
+            int dot = version.indexOf(".");
+            if (dot != -1) {
+                version = version.substring(0, dot);
+            }
+        }
+        return Integer.parseInt(version);
+    }
 }

--- a/core/src/test/java/org/jivesoftware/spark/util/JavaVersionTest.java
+++ b/core/src/test/java/org/jivesoftware/spark/util/JavaVersionTest.java
@@ -1,0 +1,49 @@
+package org.jivesoftware.spark.util;
+
+import org.jivesoftware.spark.util.StringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JavaVersionTest
+{
+    @Test
+    public void testJava7() throws Exception
+    {
+        // Setup fixture.
+        final String value = "1.7.0";
+
+        // Execute system under test.
+        final int result = StringUtils.getJavaMajorVersion( value );
+
+        // Verify results.
+        assertEquals( 7, result );
+    }
+
+
+    @Test
+    public void testJava9() throws Exception
+    {
+        // Setup fixture.
+        final String value = "9.0.0.15";
+
+        // Execute system under test.
+        final int result = StringUtils.getJavaMajorVersion( value );
+
+        // Verify results.
+        assertEquals( 9, result );
+    }
+
+    @Test
+    public void testJava11() throws Exception
+    {
+        // Setup fixture.
+        final String value = "11.0.1";
+
+        // Execute system under test.
+        final int result = StringUtils.getJavaMajorVersion( value );
+
+        // Verify results.
+        assertEquals( 11, result );
+    }
+}


### PR DESCRIPTION
Without this, plugins that define a minimum Java version of 9 or lower fail to load on Java 10 or higher.