### PR TITLE
SPARK-2092: Fix Fastpath plugin

### DIFF
--- a/plugins/fastpath/pom.xml
+++ b/plugins/fastpath/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>fastpath</artifactId>
-    <version>3.3.0</version>
+    <version>3.4.0</version>
 
     <name>Fastpath</name>
     <description>Provides FastPath Agent functionality.</description>

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/WorkgroupInitializer.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/WorkgroupInitializer.java
@@ -19,8 +19,8 @@ public class WorkgroupInitializer extends UrlInitializer
     {
     }
 
-    protected String getProvidersUrl()
-    {
+    @Override
+    protected String getProvidersUri() {
         return "classpath:org.jivesoftware.smack.legacy/workgroup.providers";
     }
 }


### PR DESCRIPTION
A API change in Smack went unnoticed, and caused the FastPath plugin to not load correctly. This commit fixes that, and increases the version number of the plugin.