### PR TITLE
SPARK-2116: Make maximum value for 'current' transcript size configurable

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
@@ -20,6 +20,7 @@ import org.jivesoftware.spark.SparkManager;
 import org.jivesoftware.spark.util.StringUtils;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.plugin.manager.Enterprise;
+import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
@@ -81,7 +82,8 @@ public final class ChatTranscripts {
     		for (HistoryMessage message : transcript.getMessages()) {
     			tempTranscript.addHistoryMessage(message);
     		}
-    		writeToFile(currentHistoryFile, tempTranscript.getNumberOfEntries(20), false);
+            int max = SettingsManager.getLocalPreferences().getMaxCurrentHistorySize();
+            writeToFile(currentHistoryFile, tempTranscript.getNumberOfEntries(max), false);
     	}
     }
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
@@ -1494,5 +1494,11 @@ public class LocalPreferences {
         return getBoolean("fileTransferIbbOnly", Default.getBoolean(Default.FILE_TRANSFER_IBB_ONLY));
     }
 
+    public void setMaxCurrentHistorySize( int value ) {
+        setInt( "currentHistoryMaxSize", value );
+    }
 
+    public int getMaxCurrentHistorySize() {
+        return getInt( "currentHistoryMaxSize", 20 );
+    }
 }


### PR DESCRIPTION


Configurable by adding/changing an integer value for 'currentHistoryMaxSize' in spark.settings. I've not added a visual config thingy yet.