### PR TITLE
SPARK-2085: No-history transcript window bugfix.

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
@@ -322,7 +322,7 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener
     {
         if ( entries.isEmpty() )
         {
-            new Date( 0 );
+            return new Date( 0 );
         }
         return Date.from( entries.getLast().getTimestamp().toInstant() );
     }


### PR DESCRIPTION
Without this, an error occurs when trying to add messages to a window that has no history.