### PR TITLE
Add OWASP dependency check to build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -263,4 +263,29 @@
         </repository>
     </repositories>
 
+    <profiles>
+        <profile>
+        <id>owasp-check</id>
+        <build>
+            <plugins>
+	            <plugin>
+    	            <groupId>org.owasp</groupId>
+        	        <artifactId>dependency-check-maven</artifactId>
+        	        <version>4.0.2</version>
+            	    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                      	    </goals>
+                 	    </execution>
+              	    </executions>
+                </plugin>
+        	</plugins>
+        </build>
+        <activation>
+          <activeByDefault>false</activeByDefault>
+        </activation>
+      </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
The check is currenty optional and placed
inside the profile 'owasp-check'.
One can directly invoke the plugin via
 `mvn org.owasp:dependency-check-maven:check`
An attempt at resolving SPARK-2113.