### PR TITLE
SPARK-2132: No more JxBrowser

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -179,27 +179,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.teamdev.jxbrowser</groupId>
-            <artifactId>jxbrowser-win</artifactId>
-            <version>6.20</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.teamdev.jxbrowser</groupId>
-            <artifactId>jxbrowser-linux32</artifactId>
-            <version>6.14.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.teamdev.jxbrowser</groupId>
-            <artifactId>jxbrowser-linux64</artifactId>
-            <version>6.23.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.teamdev.jxbrowser</groupId>
-            <artifactId>jxbrowser-mac</artifactId>
-            <version>6.23.1</version>
+            <groupId>org.lobobrowser</groupId>
+            <artifactId>LoboBrowser</artifactId>
+            <version>1.0.0</version>
         </dependency>
 
         <dependency>
@@ -256,10 +238,6 @@
         <repository>
             <id>ej-technologies</id>
             <url>https://maven.ej-technologies.com/repository/</url>
-        </repository>
-        <repository>
-            <id>com.teamdev</id>
-            <url>https://maven.teamdev.com/repository/products</url>
         </repository>
     </repositories>
 

--- a/core/src/main/java/org/jivesoftware/spark/PluginManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/PluginManager.java
@@ -114,6 +114,7 @@ public class PluginManager implements MainWindowListener
         {
             PLUGINS_DIRECTORY.mkdirs();
         }
+        System.out.println( "Loading plugins from: " + PLUGINS_DIRECTORY.getAbsolutePath() );
 
         _blacklistPlugins = Default.getPluginBlacklist();
     }
@@ -327,9 +328,9 @@ public class PluginManager implements MainWindowListener
 
             try
             {
-                name = plugin.selectSingleNode( "name" ).getText().trim();
-                clazz = plugin.selectSingleNode( "class" ).getText().trim();
-                version = plugin.selectSingleNode( "version" ).getText().trim();
+                name = plugin.selectSingleNode( "name" ) != null ? plugin.selectSingleNode( "name" ).getText().trim() : null;
+                clazz = plugin.selectSingleNode( "class" ) != null ? plugin.selectSingleNode( "class" ).getText().trim() : null;
+                version = plugin.selectSingleNode( "version" ) != null ? plugin.selectSingleNode( "version" ).getText().trim() : null;
 
                 try
                 {
@@ -356,7 +357,7 @@ public class PluginManager implements MainWindowListener
                 // Check for minimum Spark version
                 try
                 {
-                    minVersion = plugin.selectSingleNode( "minSparkVersion" ).getText();
+                    minVersion = plugin.selectSingleNode( "minSparkVersion" ) != null ? plugin.selectSingleNode( "minSparkVersion" ).getText().trim() : "";
 
                     String buildNumber = JiveInfo.getVersion();
                     boolean ok = buildNumber.compareTo( minVersion ) >= 0;
@@ -375,7 +376,7 @@ public class PluginManager implements MainWindowListener
                 // Check for minimum Java version
                 try
                 {
-                    final String pluginMinVersion = plugin.selectSingleNode( "java" ).getText();
+                    final String pluginMinVersion = plugin.selectSingleNode( "java" ) != null ? plugin.selectSingleNode( "java" ).getText().trim() : "";
                     final int jv = StringUtils.getJavaMajorVersion( pluginMinVersion == null || pluginMinVersion.trim().isEmpty() ? "0" : pluginMinVersion.trim() );
                     final int mv = StringUtils.getJavaMajorVersion( System.getProperty( "java.version" ) );
 
@@ -427,16 +428,16 @@ public class PluginManager implements MainWindowListener
                 {
                     publicPlugin.setVersion( version );
 
-                    String author = plugin.selectSingleNode( "author" ).getText();
+                    String author = plugin.selectSingleNode( "author" ) != null ? plugin.selectSingleNode( "author" ).getText() : null;
                     publicPlugin.setAuthor( author );
 
-                    String email = plugin.selectSingleNode( "email" ).getText();
+                    String email = plugin.selectSingleNode( "email" ) != null ? plugin.selectSingleNode( "email" ).getText() : null;
                     publicPlugin.setEmail( email );
 
-                    String description = plugin.selectSingleNode( "description" ).getText();
+                    String description = plugin.selectSingleNode( "description" ) != null ? plugin.selectSingleNode( "description" ).getText() : null;
                     publicPlugin.setDescription( description );
 
-                    String homePage = plugin.selectSingleNode( "homePage" ).getText();
+                    String homePage = plugin.selectSingleNode( "homePage" ) != null ? plugin.selectSingleNode( "homePage" ).getText() : null;
                     publicPlugin.setHomePage( homePage );
                 }
                 catch ( Exception e )

--- a/core/src/main/java/org/jivesoftware/spark/component/browser/EmbeddedBrowserViewer.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/browser/EmbeddedBrowserViewer.java
@@ -16,71 +16,86 @@
 package org.jivesoftware.spark.component.browser;
 
 import java.awt.BorderLayout;
+import java.net.MalformedURLException;
+
 import javax.swing.JFrame;
+import javax.swing.LookAndFeel;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
-import com.teamdev.jxbrowser.chromium.*;
-import com.teamdev.jxbrowser.chromium.swing.BrowserView;
+import org.lobobrowser.gui.ContentEvent;
+import org.lobobrowser.gui.ContentListener;
+import org.lobobrowser.gui.FramePanel;
 
-public class EmbeddedBrowserViewer extends BrowserViewer {
+public class EmbeddedBrowserViewer extends BrowserViewer implements ContentListener {
 
-	private static final long serialVersionUID = -8055149462713514766L;
-	private Browser browser;
-	
-	/**
-	 * Constructs a new LobobrowserViewer
-	 */
-	public EmbeddedBrowserViewer() {
-		browser = new Browser();
-	 }
-	
-	/**
-	 * Implementation of "Back"-button
-	 */
-	@Override
-	public void goBack() {
-		browser.goBack();
-	}
+    private static final long serialVersionUID = -8055149462713514766L;
+    private FramePanel browser;
 
-	/**
-	 * Initialization of the BrowserViewer
-	 */
-	@Override
-	public void initializeBrowser() {
-		this.setLayout(new BorderLayout());
+    /**
+     * Constructs a new LobobrowserViewer
+     */
+    public EmbeddedBrowserViewer() {
+        LookAndFeel laf = UIManager.getLookAndFeel();
 
-		final BrowserView view = new BrowserView( browser );
-		this.add(view, BorderLayout.CENTER);
-	}
+        browser = new FramePanel();
+        //substance look and feel
+        try {
+            UIManager.setLookAndFeel(laf);
+        }
+        catch (UnsupportedLookAndFeelException e) {
+            e.printStackTrace();
+        }
+        browser.addContentListener(this);
+    }
 
-	/**
-	 * Load the given URL
-	 */
-	@Override
-	public void loadURL(String url) {
-		browser.loadURL( url );
-	}
+    /**
+     * Implementation of "Back"-button
+     */
+    public void goBack() {
+        browser.back();
+    }
 
-//	/**
-//	 * React to an event by updating the address bar
-//	 */
-//	public void contentSet(ContentEvent event) {
-//		if (browser == null || browser.getCurrentNavigationEntry() == null) {
-//            return;
-//        }
-//        String url = browser.getCurrentNavigationEntry().getUrl().toExternalForm();
-//        documentLoaded(url);
-//	}
-	
-	public static void main(String[] args) {
-		EmbeddedBrowserViewer  viewer = new EmbeddedBrowserViewer();
-		viewer.initializeBrowser();
-		JFrame frame = new JFrame("Test");
+    /**
+     * Initialization of the BrowserViewer
+     */
+    public void initializeBrowser() {
+        this.setLayout(new BorderLayout());
+        this.add(browser, BorderLayout.CENTER);
+    }
+
+    /**
+     * Load the given URL
+     */
+    public void loadURL(String url) {
+        try {
+            browser.navigate(url);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * React to an event by updating the address bar
+     */
+    public void contentSet(ContentEvent event) {
+        if (browser == null || browser.getCurrentNavigationEntry() == null) {
+            return;
+        }
+        String url = browser.getCurrentNavigationEntry().getUrl().toExternalForm();
+        documentLoaded(url);
+    }
+
+    public static void main(String[] args) {
+        EmbeddedBrowserViewer  viewer = new EmbeddedBrowserViewer();
+        viewer.initializeBrowser();
+        JFrame frame = new JFrame("Test");
 
         frame.getContentPane().setLayout(new BorderLayout());
         frame.getContentPane().add(viewer, BorderLayout.CENTER);
-		frame.setVisible(true);
-	    frame.pack();
+        frame.setVisible(true);
+        frame.pack();
         frame.setSize(600, 400);
-		viewer.loadURL("http://igniterealtime.org");
-	}
+        viewer.loadURL("http://igniterealtime.org");
+    }
 }

--- a/distribution/src/installer/spark.install4j
+++ b/distribution/src/installer/spark.install4j
@@ -576,12 +576,9 @@
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
-        <entry location="lib/jxbrowser-linux32-6.14.2.jar" fileType="regular" />
         <entry location="lib/linux64" fileType="regular" />
-        <entry location="lib/jxbrowser-mac-6.23.1.jar" fileType="regular" />
         <entry location="lib/linux" fileType="regular" />
         <entry location="lib/mac" fileType="regular" />
-        <entry location="lib/jxbrowser-linux64-6.23.1.jar" fileType="regular" />
         <entry location="plugins/apple.jar" fileType="regular" />
         <entry location="plugins/growl.jar" fileType="regular" />
         <entry location="bin/startup.bat" fileType="regular" />
@@ -599,10 +596,8 @@
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
-        <entry location="lib/jxbrowser-win-6.20.jar" fileType="regular" />
         <entry location="lib/windows" fileType="regular" />
         <entry location="lib/windows64" fileType="regular" />
-        <entry location="lib/jxbrowser-mac-6.23.1.jar" fileType="regular" />
         <entry location="lib/mac" fileType="regular" />
         <entry location="plugins/apple.jar" fileType="regular" />
         <entry location="plugins/growl.jar" fileType="regular" />
@@ -621,13 +616,10 @@
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
-        <entry location="lib/jxbrowser-win-6.20.jar" fileType="regular" />
-        <entry location="lib/jxbrowser-linux32-6.14.2.jar" fileType="regular" />
         <entry location="lib/linux64" fileType="regular" />
         <entry location="lib/windows" fileType="regular" />
         <entry location="lib/windows64" fileType="regular" />
         <entry location="lib/linux" fileType="regular" />
-        <entry location="lib/jxbrowser-linux64-6.23.1.jar" fileType="regular" />
         <entry location="plugins/flashing.jar" fileType="regular" />
         <entry location="bin/startup.bat" fileType="regular" />
       </exclude>
@@ -645,10 +637,8 @@
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
-        <entry location="lib/jxbrowser-win-6.20.jar" fileType="regular" />
         <entry location="lib/windows" fileType="regular" />
         <entry location="lib/windows64" fileType="regular" />
-        <entry location="lib/jxbrowser-mac-6.23.1.jar" fileType="regular" />
         <entry location="lib/mac" fileType="regular" />
         <entry location="plugins/apple.jar" fileType="regular" />
         <entry location="plugins/growl.jar" fileType="regular" />
@@ -671,10 +661,8 @@
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
-        <entry location="lib/jxbrowser-win-6.20.jar" fileType="regular" />
         <entry location="lib/windows" fileType="regular" />
         <entry location="lib/windows64" fileType="regular" />
-        <entry location="lib/jxbrowser-mac-6.23.1.jar" fileType="regular" />
         <entry location="lib/mac" fileType="regular" />
         <entry location="plugins/apple.jar" fileType="regular" />
         <entry location="plugins/growl.jar" fileType="regular" />
@@ -706,10 +694,8 @@
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
-        <entry location="lib/jxbrowser-win-6.120.jar" fileType="regular" />
         <entry location="lib/windows" fileType="regular" />
         <entry location="lib/windows64" fileType="regular" />
-        <entry location="lib/jxbrowser-mac-6.23.1.jar" fileType="regular" />
         <entry location="lib/mac" fileType="regular" />
         <entry location="plugins/apple.jar" fileType="regular" />
         <entry location="plugins/growl.jar" fileType="regular" />
@@ -740,13 +726,10 @@
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
-        <entry location="lib/jxbrowser-win-6.20.jar" fileType="regular" />
-        <entry location="lib/jxbrowser-linux32-6.14.2.jar" fileType="regular" />
         <entry location="lib/linux64" fileType="regular" />
         <entry location="lib/windows" fileType="regular" />
         <entry location="lib/windows64" fileType="regular" />
         <entry location="lib/linux" fileType="regular" />
-        <entry location="lib/jxbrowser-linux64-6.23.1.jar" fileType="regular" />
         <entry location="plugins/flashing.jar" fileType="regular" />
         <entry location="bin/startup.bat" fileType="regular" />
       </exclude>
@@ -764,12 +747,9 @@
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
       <exclude>
-        <entry location="lib/jxbrowser-linux32-6.14.2.jar" fileType="regular" />
         <entry location="lib/linux64" fileType="regular" />
-        <entry location="lib/jxbrowser-mac-6.23.1.jar" fileType="regular" />
         <entry location="lib/linux" fileType="regular" />
         <entry location="lib/mac" fileType="regular" />
-        <entry location="lib/jxbrowser-linux64-6.23.1.jar" fileType="regular" />
         <entry location="plugins/apple.jar" fileType="regular" />
         <entry location="plugins/growl.jar" fileType="regular" />
         <entry location="bin/startup.bat" fileType="regular" />

--- a/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
+++ b/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
@@ -17,8 +17,6 @@
 
 package org.jivesoftware.spark.plugin.ofmeet;
 
-import com.teamdev.jxbrowser.chromium.Browser;
-import com.teamdev.jxbrowser.chromium.swing.BrowserView;
 import org.jivesoftware.Spark;
 import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.spark.SparkManager;

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <module>plugins/flashing</module>
         <module>plugins/growl</module>
         <!--<module>plugins/jingle</module>-->
-        <module>plugins/meet</module>
+        <!--<module>plugins/meet</module>-->
         <!--<module>plugins/otr</module>-->
         <module>plugins/reversi</module>
         <module>plugins/roar</module>


### PR DESCRIPTION
This re-introduces the (likely broken) LoboBrowser, in favor of JxBrowser (for which we can't obtain a license). Using Lobobrowser is far from ideal (we'd ideally go with something more modern), but with moving out JxBrowser, we at least remove a release blocker.