### PR TITLE
SPARK-1979: Restore distribution archive directory for 'sounds'

### DIFF
--- a/core/src/assembly/installation-directory.xml
+++ b/core/src/assembly/installation-directory.xml
@@ -40,6 +40,10 @@
             </excludes>
         </fileSet>
 
+        <fileSet>
+            <directory>${project.basedir}/src/main/resources/sounds/</directory>
+            <outputDirectory>resources/sounds</outputDirectory>
+        </fileSet>
     </fileSets>
 
 
@@ -53,6 +57,30 @@
             <source>${project.basedir}/src/main/resources/startup.sh</source>
             <outputDirectory>bin</outputDirectory>
             <fileMode>0755</fileMode>
+        </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/Info.plist</source>
+            <outputDirectory>resources</outputDirectory>
+        </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/jniwrap.dll</source>
+            <outputDirectory>resources</outputDirectory>
+        </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/jniwrap.lic</source>
+            <outputDirectory>resources</outputDirectory>
+        </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/startup.bat</source>
+            <outputDirectory>resources</outputDirectory>
+        </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/startup.sh</source>
+            <outputDirectory>resources</outputDirectory>
+        </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/systeminfo.dll</source>
+            <outputDirectory>resources</outputDirectory>
         </file>
     </files>
 </assembly>

--- a/core/src/assembly/installation-directory.xml
+++ b/core/src/assembly/installation-directory.xml
@@ -44,6 +44,12 @@
             <directory>${project.basedir}/src/main/resources/sounds/</directory>
             <outputDirectory>resources/sounds</outputDirectory>
         </fileSet>
+
+        <fileSet>
+            <directory>${project.basedir}/src/documentation/</directory>
+            <outputDirectory>documentation</outputDirectory>
+        </fileSet>
+
     </fileSets>
 
 


### PR DESCRIPTION
The 'sounds' directory (and some other files) used to live outside of the spark.jar file in Spark 2.8.3. This commit mostly restores this.

I'm leaving out the emoticons, as I think that has been tackled in SPARK-2068.