### PR TITLE
SPARK-2110: Stop using deprecated VCard API

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/RosterDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/RosterDialog.java
@@ -57,6 +57,7 @@ import org.jivesoftware.smack.roster.Roster;
 import org.jivesoftware.smack.roster.RosterEntry;
 import org.jivesoftware.smack.roster.RosterGroup;
 import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smackx.vcardtemp.VCardManager;
 import org.jivesoftware.smackx.xdata.Form;
 import org.jivesoftware.smackx.search.ReportedData;
 import org.jivesoftware.smackx.vcardtemp.packet.VCard;
@@ -645,13 +646,12 @@ public class RosterDialog implements ActionListener {
 
 	if (!ModelUtil.hasLength(nickname) && ModelUtil.hasLength(contact)) {
 	    // Try to load nickname from VCard
-	    VCard vcard = new VCard();
 	    try {
 			EntityBareJid contactJid = JidCreate.entityBareFrom(contact);
-			vcard.load(SparkManager.getConnection(), contactJid);
-		nickname = vcard.getNickName();
+            final VCard vcard = VCardManager.getInstanceFor(SparkManager.getConnection()).loadVCard(contactJid);
+		    nickname = vcard.getNickName();
 	    } catch (XMPPException | SmackException | XmppStringprepException | InterruptedException e1) {
-		Log.error(e1);
+		    Log.error(e1);
 	    }
 	    // If no nickname, use first name.
 	    if (!ModelUtil.hasLength(nickname)) {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
@@ -485,7 +485,8 @@ public class VCardEditor {
 	    final VCardManager vcardManager = SparkManager.getVCardManager();
 	    vcardManager.setPersonalVCard(vcard);
 
-	    vcard.save(SparkManager.getConnection());
+        org.jivesoftware.smackx.vcardtemp.VCardManager smackVCardManager = org.jivesoftware.smackx.vcardtemp.VCardManager.getInstanceFor( SparkManager.getConnection() );
+        smackVCardManager.saveVCard( vcard );
 
 	    // Notify users.
 	    if (avatarBytes != null) {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -258,7 +258,8 @@ public class VCardManager {
                 @Override
 				public Object construct() {
                     try {
-                        personalVCard.load(SparkManager.getConnection());
+                        final org.jivesoftware.smackx.vcardtemp.VCardManager smackVCardManager = org.jivesoftware.smackx.vcardtemp.VCardManager.getInstanceFor(SparkManager.getConnection());
+                        personalVCard = smackVCardManager.loadVCard();
                     }
                     catch (XMPPException | SmackException | InterruptedException e) {
                         Log.error("Error loading vcard information.", e);
@@ -383,7 +384,7 @@ public class VCardManager {
      */    
 	public void reloadPersonalVCard() {
 		try {
-			personalVCard.load(SparkManager.getConnection());
+            personalVCard = org.jivesoftware.smackx.vcardtemp.VCardManager.getInstanceFor(SparkManager.getConnection()).loadVCard();
             personalVCardAvatar = personalVCard.getAvatar();
             personalVCardHash = null; // reload lazy later, when need
 
@@ -520,8 +521,8 @@ public class VCardManager {
 		}
         VCard vcard = new VCard();
         try {
-        	vcard.setJabberId(jid.toString());
-            vcard.load(SparkManager.getConnection(), jid);
+            vcard = org.jivesoftware.smackx.vcardtemp.VCardManager.getInstanceFor(SparkManager.getConnection()).loadVCard( jid );
+            vcard.setJabberId(jid.toString());
             if (vcard.getNickName() != null && vcard.getNickName().length() > 0)
             {
             	// update nickname.


### PR DESCRIPTION
Smack has deprecated parts of the VCard API (primarily the 'load' and 'save' methods). As Spark still used this API at some points, some data doesn't get refereshed / loaded properly. By switching to the new API, these problems disappear.