### PR TITLE
OF-2079: Ensure settings are properly saved upon login

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/login/LoginSettingDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/LoginSettingDialog.java
@@ -128,6 +128,13 @@ public class LoginSettingDialog implements PropertyChangeListener
     @Override
 	public void propertyChange( PropertyChangeEvent e )
     {
+        // The event is fired to often - for example when disposing a dialog, after settings have already been saved.
+        // This causes settings to, again, be saved based on the configuration of the options dialog (which by this time
+        // are outdated). A work-around is provided below, to only process changes on events that were fired while the
+        // dialog was actually still visible. See SPARK-2079
+        if (!optionsDialog.isVisible()) {
+            return;
+        }
         String value = (String) optionPane.getValue();
         if ( Res.getString( "cancel" ).equals( value ) )
         {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/SettingsManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/SettingsManager.java
@@ -31,7 +31,7 @@ import java.util.Properties;
 
 
 /**
- * Responsbile for the loading and persisting of LocalSettings.
+ * Responsible for the loading and persisting of LocalSettings.
  */
 public class SettingsManager {
     private static LocalPreferences localPreferences;
@@ -56,7 +56,7 @@ public class SettingsManager {
      *
      * @return the LocalPreferences for this user.
      */
-    public static LocalPreferences getLocalPreferences() {
+    public synchronized static LocalPreferences getLocalPreferences() {
         if(localPreferences != null){
             return localPreferences;
         }

--- a/core/src/main/resources/i18n/spark_i18n.properties
+++ b/core/src/main/resources/i18n/spark_i18n.properties
@@ -985,6 +985,7 @@ dialog.certificate.show = <html>This is the certificate and private key you are 
 dialog.id.certificate.show = <html>This is the certificate you are trying to add to the IdentityStore <br><br> After adding this certificate Spark will be able to present this certificate to remote server during establishing connection in order to authenticate itself and encrypt that connection. <br><br> If you are sure that you want to add this certificate click the OK button.</html>
 dialog.certificate.add.from.connection = <html>This is the certificate provided by the server you are trying to connect to. <br> This certificate isn't in your TrustStore, which means it is not trusted<br> and you cannot connect to this server. <br><br> Do you want to trust it and add this certificate to your TrustStore?</html>
 dialog.certificate.unrecognized.server.certificate = <html>The server that you are connecting to identifies itself with a certificate that <br>is not recognized by Spark. Please review the details below.</html>
+dialog.certificate.ask.allow.self-signed = <html>The server that you are connecting to identifies itself with a certificate that is self-signed. <br>The current configuration of Spark disallows the use of self-signed certificates. Would you <br>like to change this configuration and try again?</html>
 dialog.certificate.subject.label = Subject:
 
 dialog.certificate.add.unrecognized.server.certificate = <html>Do you want to add this certificate to the set of certificates that is trusted by Spark?</html>

--- a/core/src/main/resources/i18n/spark_i18n_nl.properties
+++ b/core/src/main/resources/i18n/spark_i18n_nl.properties
@@ -677,3 +677,5 @@ tooltip.view.readme = Lees ReadMe
 
 tree.conference.services = Conferentie diensten
 tree.users.in.room = Gebruikers in ruimte
+dialog.certificate.unrecognized.server.certificate=<html>De server waarmee verbonden wordt identificeert zichzelf met een certificaat <br>dat niet wordt herkend door Spark. De details volgen hieronder.<html>
+dialog.certificate.add.unrecognized.server.certificate=<html>Wilt u dit certificaat toevoegen aan de collectie van certificaten die Spark accepteert?</html>


### PR DESCRIPTION
The way the 'advanced settings' dialog of the login screen works, causes it to save its configuration to file whenever 'an event' happens.

When saving the configuration, the state of the various UI elements (checkboxes, radiobuttons, etc) is used to update the configuration file.

Eligble events happen more often than expected, for example, when the dialog is disposed (which can occur much later after when it was closed). By that time, the settings of the UI elements can be outdated. This causes an issue where settings are unexpectedly 'reverted'.

This commit works around this problem by only allowing the settings to be updated while the screen is visible.