### PR TITLE
SPARK-2110: Fix nicknames & add missing '@' in result of unescaping JIDs

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ChatManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/ChatManager.java
@@ -927,13 +927,8 @@ public class ChatManager {
 
 	    UserManager userManager = SparkManager.getUserManager();
 	    String nickname = userManager.getUserNicknameFromJID(jid);
-	    if (nickname == null) {
-		nickname = jid.toString();
-	    }
-
 	    ChatManager chatManager = SparkManager.getChatManager();
-	    ChatRoom chatRoom = chatManager.createChatRoom(jid, nickname,
-		    nickname);
+	    ChatRoom chatRoom = chatManager.createChatRoom(jid, nickname, nickname);
 	    chatManager.getChatContainer().activateChatRoom(chatRoom);
 	} else if (query.startsWith(UriManager.uritypes.message.getXML())) {
 	    try {

--- a/core/src/main/java/org/jivesoftware/spark/UserManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/UserManager.java
@@ -345,7 +345,7 @@ public class UserManager {
     }
 
     /**
-     * Unescapes a complete JID by examing the node itself and unescaping when necessary.
+     * Unescapes a complete JID by examining the node itself and unescaping when necessary.
      *
      * @param jid the users jid.
      * @return the unescaped JID.
@@ -360,6 +360,7 @@ public class UserManager {
         Domainpart restOfJID = jid.getDomain();
         if (node != null) {
             builder.append(XmppStringUtils.unescapeLocalpart(node.toString()));
+            builder.append('@');
         }
         builder.append(restOfJID);
         return builder.toString();

--- a/core/src/main/java/org/jivesoftware/spark/ui/VCardPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/VCardPanel.java
@@ -222,7 +222,7 @@ public class VCardPanel extends JPanel {
         }
         else {
             String nickname = SparkManager.getUserManager().getUserNicknameFromJID(jid);
-            usernameLabel.setText(UserManager.unescapeJID(nickname));
+            usernameLabel.setText(nickname);
         }
 
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/VCardViewer.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/VCardViewer.java
@@ -152,7 +152,7 @@ public class VCardViewer extends JPanel {
         }
         else {
             String nickname = SparkManager.getUserManager().getUserNicknameFromJID(jid);
-            usernameLabel.setText(UserManager.unescapeJID(nickname));
+            usernameLabel.setText(nickname);
         }
 
 

--- a/core/src/main/java/org/jivesoftware/spark/uri/UriManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/uri/UriManager.java
@@ -85,10 +85,6 @@ public class UriManager {
 
 	UserManager userManager = SparkManager.getUserManager();
 	String nickname = userManager.getUserNicknameFromJID(jid.asBareJid());
-	if (nickname == null) {
-	    nickname = jid.toString();
-	}
-
 	ChatManager chatManager = SparkManager.getChatManager();
 	ChatRoom chatRoom = chatManager.createChatRoom(jid.asEntityJidOrThrow(), nickname, nickname);
 	if (body != null) {


### PR DESCRIPTION
The implementation that unescapes JIDs unintentionally removes the '@' character (separating node- and domain-part). This commit restores that character.