### PR TITLE
SPARK-1784: Do not surpress ROAR popup when chat container is inactiv…

### DIFF
--- a/plugins/roar/src/main/java/org/jivesoftware/spark/roar/RoarMessageListener.java
+++ b/plugins/roar/src/main/java/org/jivesoftware/spark/roar/RoarMessageListener.java
@@ -55,8 +55,10 @@ public class RoarMessageListener implements GlobalMessageListener {
 
             int framestate = SparkManager.getChatManager().getChatContainer().getChatFrame().getState();
 
+            final boolean chatContainerHasFocus = SparkManager.getChatManager().getChatContainer().isFocusOwner();
+
             // If the message is for a chat that's currently active and showing, do not popup.
-            if (framestate == JFrame.NORMAL && activeroom.equals(room) && room.isShowing()
+            if (!chatContainerHasFocus && framestate == JFrame.NORMAL && activeroom.equals(room) && room.isShowing()
                     && (isOldGroupChat(room) || isMessageFromRoom(room, message))) {
                 Log.debug( "Surpressing popup: chat is currently active and showing.");
                 return;


### PR DESCRIPTION
…e/has no focus

Prior to this change, popups where surpressed when the chat container was not explicitly closed.