### PR TITLE
SPARK-2141: Contacts should always be shown, even if they're not in a group

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/component/RosterTree.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/RosterTree.java
@@ -112,6 +112,7 @@ public final class RosterTree extends JPanel {
         });
 
 
+
         for (RosterGroup group : roster.getGroups()) {
             final JiveTreeNode groupNode = new JiveTreeNode(group.getName(), true);
             groupNode.setAllowsChildren(true);

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -133,6 +133,7 @@ public class ContactList extends JPanel implements ActionListener,
         localPreferences = SettingsManager.getLocalPreferences();
 
         offlineGroup = UIComponentRegistry.createContactGroup(Res.getString("group.offline"));
+        unfiledGroup = getUnfiledGroup();
 
         JToolBar toolbar = new JToolBar();
         toolbar.setFloatable(false);
@@ -194,7 +195,7 @@ public class ContactList extends JPanel implements ActionListener,
         }
 
         // Add ActionListener(s) to menus
-//        addContactGroup(unfiledGroup);
+        addContactGroup(unfiledGroup);
         addContactGroup(offlineGroup);
 
         showHideMenu.setSelected(false);


### PR DESCRIPTION
This commit restores functionality that already existed, but was ... disabled?

When a user is not in any group on the contact list, it is now displayed in a psuedo-group, called 'unfiled' (this is similar to the 'offline contacts' psuedo group).