### PR TITLE
SPARK-2012: Use bookmark name when listing rooms

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/BookmarksUI.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/BookmarksUI.java
@@ -614,7 +614,7 @@ public class BookmarksUI extends JPanel {
         for (BookmarkedConference bookmark : bookmarks) {
             DomainBareJid serviceName = bookmark.getJid().asDomainBareJid();
             EntityBareJid roomJID = bookmark.getJid();
-            Localpart roomName = roomJID.getLocalpart();
+            String roomName = bookmark.getName() != null && !bookmark.getName().isEmpty() ? bookmark.getName() : roomJID.getLocalpart().toString();
 
             if (bookmark.isAutoJoin()) {
                 ConferenceUtils.joinConferenceOnSeperateThread(roomName, bookmark.getJid(), bookmark.getPassword());
@@ -633,7 +633,7 @@ public class BookmarksUI extends JPanel {
                 serviceNode = (JiveTreeNode)path.getLastPathComponent();
             }
 
-            addBookmark(serviceNode, roomName.toString(), roomJID.toString());
+            addBookmark(serviceNode, roomName, roomJID.toString());
 
             tree.expandPath(path);
         }


### PR DESCRIPTION
The bookmark name should contain the name of the room. It's preferable to show the name of the room in the listing of bookmarked rooms, as opposed to the room ID.