### PR TITLE
Increase version number of all plugins

### DIFF
--- a/plugins/apple/pom.xml
+++ b/plugins/apple/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>apple</artifactId>
-    <version>3.0</version>
+    <version>4.0</version>
 
     <name>Apple Plugin</name>
     <description>Provides Mac OS X features for Spark.</description>

--- a/plugins/battleships/pom.xml
+++ b/plugins/battleships/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>battleships</artifactId>
-    <version>0.2</version>
+    <version>0.3</version>
 
     <name>Battleships</name>
     <description>An implementation of the classic Battleships guessing game.</description>

--- a/plugins/fastpath/pom.xml
+++ b/plugins/fastpath/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>fastpath</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
 
     <name>Fastpath</name>
     <description>Provides FastPath Agent functionality.</description>

--- a/plugins/fileupload/pom.xml
+++ b/plugins/fileupload/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>fileupload</artifactId>
-    <version>0.0.2</version>
+    <version>0.1</version>
 
     <name>Http File Upload Plugin</name>
     <description>Adds support for Openfire httpfileupload plugin to Spark</description>

--- a/plugins/flashing/pom.xml
+++ b/plugins/flashing/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>flashing</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
 
     <name>Window Flashing Plugin</name>
     <description>Flashes window on new messages (Microsoft Windows only).</description>

--- a/plugins/growl/pom.xml
+++ b/plugins/growl/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>growl</artifactId>
-    <version>2.3</version>
+    <version>2.4</version>
 
     <name>Growl</name>
     <description>Provides Growl notifications (see http://growl.info).</description>

--- a/plugins/jingle/pom.xml
+++ b/plugins/jingle/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>jingle</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
 
     <name>Jingle Client</name>
     <description>Allows for PC to PC calling.</description>

--- a/plugins/meet/pom.xml
+++ b/plugins/meet/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>meet</artifactId>
-    <version>0.0.5</version>
+    <version>0.1</version>
 
     <name>Meetings Plugin</name>
     <description>Adds support for Openfire Meetings to the Spark IM client.</description>

--- a/plugins/reversi/pom.xml
+++ b/plugins/reversi/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>reversi</artifactId>
-    <version>1.4</version>
+    <version>1.5</version>
 
     <name>Reversi</name>
     <description>Multiplayer game of Reversi.</description>

--- a/plugins/roar/pom.xml
+++ b/plugins/roar/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>roar</artifactId>
-    <version>0.5.0</version>
+    <version>0.6</version>
 
     <name>Roar!!!</name>
     <description>Provides customizable popup/notification functionality.</description>

--- a/plugins/sip/pom.xml
+++ b/plugins/sip/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>sip</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <name>Phone Client</name>
     <description>Adds SIP Softphone functionality to Spark.</description>

--- a/plugins/spelling/pom.xml
+++ b/plugins/spelling/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>spelling</artifactId>
-    <version>0.7</version>
+    <version>0.8</version>
 
     <name>Spellchecker Plugin</name>
     <description>Provides spellchecker functionality.</description>

--- a/plugins/systemtray/pom.xml
+++ b/plugins/systemtray/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>systemtray</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
 
     <name>SystemTray Plugin</name>
     <description>Notification and System Tray Plugin for Spark.</description>

--- a/plugins/tictactoe/pom.xml
+++ b/plugins/tictactoe/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>tictactoe</artifactId>
-    <version>0.2</version>
+    <version>0.3</version>
 
     <name>TicTacToe</name>
     <description>The most sophisticated TicTacToe Game ever created.</description>

--- a/plugins/transferguard/pom.xml
+++ b/plugins/transferguard/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>transferguard</artifactId>
-    <version>1.1.1</version>
+    <version>1.2</version>
 
     <name>Transfer Guard</name>
     <description>Adds the ability to automatically reject file transfers based on preference configuration.</description>

--- a/plugins/translator/pom.xml
+++ b/plugins/translator/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>translator</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
 
     <name>Translator Plugin</name>
     <description>Translates instant messages between users using Google Translation Service.</description>


### PR DESCRIPTION
Since the last release, major changes were applied to the project. To reflect this, I've increased the version number of all of the plugins.

Not all plugins might have had functional changes, but given that the project structure has changed a lot, some kind of increase (that will allow us to tell plugins before and after this release apart) could be helpful.