### PR TITLE
SPARK-2148: Fix displaying of own nickname in history

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -786,7 +786,7 @@ public class ChatRoomImpl extends ChatRoom {
     		for (HistoryMessage message : chatTranscript.getMessages()) {
     			String nickname = SparkManager.getUserManager().getUserNicknameFromJID(message.getFrom().asBareJid());
     			String messageBody = message.getBody();
-    			if (nickname.equals(message.getFrom().toString())) {
+    			if (nickname.equals(message.getFrom().toString()) || nickname.equals(message.getFrom().asBareJid().toString())) {
     				BareJid otherJID = message.getFrom().asBareJid();
     				EntityBareJid myJID = SparkManager.getSessionManager().getBareUserAddress();
 


### PR DESCRIPTION
When opening a chat window, the previously exchanged messages are displayed. In this history, your own nickname should be used, instead of your own JID.