### PR TITLE
SPARK-2149: Prevent notification from popping up on every presence change

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/preference/notifications/NotificationPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/preference/notifications/NotificationPlugin.java
@@ -106,7 +106,7 @@ public class NotificationPlugin implements Plugin, StanzaListener {
         }
 
         BareJid bareJid = jid.asBareJid();
-        boolean isOnline = onlineUsers.contains(jid);
+        boolean isOnline = onlineUsers.contains(bareJid);
 
         if (presence.isAvailable()) {
             if (preferences.isOnlineNotificationsOn()) {


### PR DESCRIPTION
Notifications (when enabled) should online occur when a user that was previously online goes offline, or the other way around.