### PR TITLE
SPARK-2151: Prevent IndexOutOfBoundsException in Reversi

### DIFF
--- a/plugins/reversi/pom.xml
+++ b/plugins/reversi/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>reversi</artifactId>
-    <version>1.5</version>
+    <version>1.6</version>
 
     <name>Reversi</name>
     <description>Multiplayer game of Reversi.</description>

--- a/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiModel.java
+++ b/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiModel.java
@@ -329,7 +329,7 @@ public class ReversiModel {
         }
         // Going down vertically.
         if (position < 48) {
-            for (int i=position+8; i <= 65; i+=8) {
+            for (int i=position+8; i <= 64; i+=8) {
                 if (board[i] == BLANK) {
                     break;
                 }


### PR DESCRIPTION
The old code attempts to iterate over 65 positions on a board that has 64. That's not going to work.

With this fix, I didn't get the exception that I had while previously playing this game. Unlike before, I can now successfully finish a game.