### PR TITLE
SPARK-2154: Do not parse nicknames using Jid implementation

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/Workspace.java
+++ b/core/src/main/java/org/jivesoftware/spark/Workspace.java
@@ -403,9 +403,9 @@ public class Workspace extends JPanel implements StanzaListener {
             return;
         }
         ContactItem contact = contactList.getContactItemByJID(bareJID);
-        Localpart nickname = bareJID.getLocalpartOrNull();
+        String nickname = bareJID.getLocalpartOrNull() == null ? null : bareJID.getLocalpartOrNull().toString();
         if (contact != null) {
-            nickname = Localpart.fromOrThrowUnchecked(contact.getDisplayName());
+            nickname = contact.getDisplayName();
         }
 
         // Create the room if it does not exist.


### PR DESCRIPTION
Nicknames aren't necessarily components of a Jid (they are in context of MUC, but they're pretty much free form text on the roster). By attempting to use the Jid implementation to parse nicknames, exceptions occur. In this instance, such an exception prevents an offline message being displayed if it is sent by someone that is on the recipients roster using in nickname that contains a space.