### PR TITLE
Add more consistency to default properties usage

### DIFF
--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -483,7 +483,7 @@ public class LoginDialog {
                 new GridBagConstraints(0, 5, 2, 1, 1.0, 0.0,
                     GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(5, 5, 5, 5), 0, 0));
 
-            if (!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTOLOGIN) && localPref.getPswdAutologin()) {
+            if (!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN) && localPref.getPswdAutologin()) {
                 add(savePasswordBox,
                     new GridBagConstraints(1, 5, 2, 1, 1.0, 0.0,
                         GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(5, 5, 0, 5), 0, 0));

--- a/core/src/main/java/org/jivesoftware/MainWindow.java
+++ b/core/src/main/java/org/jivesoftware/MainWindow.java
@@ -431,7 +431,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         File myMaintFile = new File(Default.getString(Default.MAINT_FILESPEC));
 
         final boolean maintMode = (myMaintFile.exists() && !myMaintFile.isDirectory());
-        final boolean prefsAllowed = (!Default.getBoolean("DISABLE_PREFERENCES_MENU_ITEM") && Enterprise.containsFeature(Enterprise.PREFERENCES_MENU_FEATURE));
+        final boolean prefsAllowed = (!Default.getBoolean(Default.DISABLE_PREFERENCES_MENU_ITEM) && Enterprise.containsFeature(Enterprise.PREFERENCES_MENU_FEATURE));
 
         if (maintMode || prefsAllowed) connectMenu.add(preferenceMenuItem);
 
@@ -448,9 +448,9 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         connectMenu.add(alwaysOnTopItem);
 
         // Set up the Logout and Exit menus...
-        if (!Default.getBoolean("DISABLE_EXIT") && Enterprise.containsFeature(Enterprise.LOGOUT_EXIT_FEATURE)) {
+        if (!Default.getBoolean(Default.DISABLE_EXIT) && Enterprise.containsFeature(Enterprise.LOGOUT_EXIT_FEATURE)) {
         	connectMenu.addSeparator();
-        	if(!Default.getBoolean("HIDE_SAVE_PASSWORD_AND_AUTOLOGIN") && SettingsManager.getLocalPreferences().getPswdAutologin()) {
+        	if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTOLOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
         		JMenuItem logoutMenuItem = new JMenuItem();
         		ResourceUtils.resButton(logoutMenuItem, Res.getString("menuitem.logout.no.status"));
         		logoutMenuItem.addActionListener( e -> logout(false) );
@@ -507,7 +507,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         };
 
 
-        if (!Default.getBoolean("HELP_USER_GUIDE_DISABLED") && Enterprise.containsFeature(Enterprise.HELP_USERGUIDE_FEATURE)) {
+        if (!Default.getBoolean(Default.HELP_USER_GUIDE_DISABLED) && Enterprise.containsFeature(Enterprise.HELP_USERGUIDE_FEATURE)) {
         	viewHelpGuideAction.putValue(Action.NAME,
         			Res.getString("menuitem.user.guide"));
         	viewHelpGuideAction.putValue(Action.SMALL_ICON,
@@ -515,10 +515,10 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         	helpMenu.add(viewHelpGuideAction);
         }
 
-        if (!Default.getBoolean("HELP_FORUM_DISABLED") && Enterprise.containsFeature(Enterprise.HELP_FORUMS_FEATURE)) helpMenu.add(sparkforumItem);
+        if (!Default.getBoolean(Default.HELP_FORUM_DISABLED) && Enterprise.containsFeature(Enterprise.HELP_FORUMS_FEATURE)) helpMenu.add(sparkforumItem);
 
 	// Build Help Menu
-	if (!Default.getBoolean("DISABLE_UPDATES") && Enterprise.containsFeature(Enterprise.UPDATES_FEATURE)) helpMenu.add(updateMenu);
+	if (!Default.getBoolean(Default.DISABLE_UPDATES) && Enterprise.containsFeature(Enterprise.UPDATES_FEATURE)) helpMenu.add(updateMenu);
 
 	helpMenu.addSeparator();
 	helpMenu.add(viewErrors);
@@ -529,8 +529,8 @@ public final class MainWindow extends ChatFrame implements ActionListener {
 	ResourceUtils.resButton(helpMenu, Res.getString("menuitem.help"));
 	ResourceUtils.resButton(menuAbout, Res.getString("menuitem.about"));
 
-	if (Default.getString("HELP_FORUM_TEXT").length() > 0) {
-	    ResourceUtils.resButton(sparkforumItem, Default.getString("HELP_FORUM_TEXT"));
+	if (Default.getString(Default.HELP_FORUM_TEXT).length() > 0) {
+	    ResourceUtils.resButton(sparkforumItem, Default.getString(Default.HELP_FORUM_TEXT));
 	} else {
 	    ResourceUtils.resButton(sparkforumItem, Res.getString("menuitem.online.help"));
 	}
@@ -547,7 +547,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
 	sparkforumItem.addActionListener(new AbstractAction() {
 	    private static final long serialVersionUID = -1423433460333010339L;
 
-	    final String url = Default.getString("HELP_FORUM");
+	    final String url = Default.getString(Default.HELP_FORUM);
 
 		@Override
 		public void actionPerformed(ActionEvent e) {
@@ -569,7 +569,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
 	    }
 	});
 
-	if (!Default.getBoolean("DISABLE_UPDATES") && Enterprise.containsFeature(Enterprise.UPDATES_FEATURE)) {
+	if (!Default.getBoolean(Default.DISABLE_UPDATES) && Enterprise.containsFeature(Enterprise.UPDATES_FEATURE)) {
 		// Execute spark update checker after one minute.
 		final TimerTask task = new SwingTimerTask() {
 			@Override

--- a/core/src/main/java/org/jivesoftware/MainWindow.java
+++ b/core/src/main/java/org/jivesoftware/MainWindow.java
@@ -428,7 +428,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         preferenceMenuItem.addActionListener(this);
 
         // Show the "Preferences" menu item ONLY in Maintenance Mode or when DISABLE_PREFERENCES_MENU_ITEM = false and Client Control allows it.
-        File myMaintFile = new File(Default.getString(Default.MAINT_FILESPEC));
+        File myMaintFile = new File(Default.getString(Default.MAINTENANCE_FILE_PATH));
 
         final boolean maintMode = (myMaintFile.exists() && !myMaintFile.isDirectory());
         final boolean prefsAllowed = (!Default.getBoolean(Default.DISABLE_PREFERENCES_MENU_ITEM) && Enterprise.containsFeature(Enterprise.PREFERENCES_MENU_FEATURE));
@@ -450,7 +450,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         // Set up the Logout and Exit menus...
         if (!Default.getBoolean(Default.DISABLE_EXIT) && Enterprise.containsFeature(Enterprise.LOGOUT_EXIT_FEATURE)) {
         	connectMenu.addSeparator();
-        	if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTOLOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
+        	if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
         		JMenuItem logoutMenuItem = new JMenuItem();
         		ResourceUtils.resButton(logoutMenuItem, Res.getString("menuitem.logout.no.status"));
         		logoutMenuItem.addActionListener( e -> logout(false) );

--- a/core/src/main/java/org/jivesoftware/Spark.java
+++ b/core/src/main/java/org/jivesoftware/Spark.java
@@ -185,7 +185,7 @@ public final class Spark {
 
         installBaseUIProperties();
 
-        if (Default.getBoolean("CHANGE_COLORS_DISABLED")) {
+        if (Default.getBoolean(Default.CHANGE_COLORS_DISABLED)) {
             ColorSettingManager.restoreDefault();
         }
 
@@ -369,7 +369,7 @@ public final class Spark {
     }
 
     public static boolean disableUpdatesOnCustom() {
-	return Default.getBoolean("DISABLE_UPDATES");
+	return Default.getBoolean(Default.DISABLE_UPDATES);
     }
 
 	public static void setApplicationFont(Font f) {

--- a/core/src/main/java/org/jivesoftware/resource/Default.java
+++ b/core/src/main/java/org/jivesoftware/resource/Default.java
@@ -121,7 +121,31 @@ public class Default {
     public static final String PROXY_ENABLED = "PROXY_ENABLED";
     public static final String OLD_SSL_ENABLED = "OLD_SSL_ENABLED";
     public static final String FILE_TRANSFER_IBB_ONLY = "FILE_TRANSFER_IBB_ONLY";
-    
+    public static final String CHANGE_COLORS_DISABLED = "CHANGE_COLORS_DISABLED";
+    public static final String ADD_CONTACT_GROUP_DISABLED = "ADD_CONTACT_GROUP_DISABLED";
+    public static final String DISABLE_AVATAR_TAB = "DISABLE_AVATAR_TAB";
+    public static final String DISABLE_BROADCAST_MENU_ITEM = "DISABLE_BROADCAST_MENU_ITEM";
+    public static final String DISABLE_EDIT_PROFILE = "DISABLE_EDIT_PROFILE";
+    public static final String DISABLE_EXIT = "DISABLE_EXIT";
+    public static final String DISABLE_FILE_XFER = "DISABLE_FILE_XFER";
+    public static final String DISABLE_MOVE_AND_COPY = "DISABLE_MOVE_AND_COPY";
+    public static final String DISABLE_PLUGINS_MENU_ITEM = "DISABLE_PLUGINS_MENU_ITEM";
+    public static final String DISABLE_PREFERENCES_MENU_ITEM = "DISABLE_PREFERENCES_MENU_ITEM";
+    public static final String DISABLE_PRESENCE_STATUS_CHANGE = "DISABLE_PRESENCE_STATUS_CHANGE";
+    public static final String DISABLE_REMOVALS = "DISABLE_REMOVALS";
+    public static final String DISABLE_RENAMES = "DISABLE_RENAMES";
+    public static final String DISABLE_VIEW_NOTES = "DISABLE_VIEW_NOTES";
+    public static final String DISABLE_VIEW_TASK_LIST = "DISABLE_VIEW_TASK_LIST";
+    public static final String HELP_FORUM = "HELP_FORUM";
+    public static final String HELP_FORUM_DISABLED = "HELP_FORUM_DISABLED";
+    public static final String HELP_FORUM_TEXT = "HELP_FORUM_TEXT";
+    public static final String HELP_USER_GUIDE_DISABLED = "HELP_USER_GUIDE_DISABLED";
+    public static final String PLUGIN_BLACKLIST = "PLUGIN_BLACKLIST";
+    public static final String PLUGIN_BLACKLIST_CLASS = "PLUGIN_BLACKLIST_CLASS";
+    public static final String PLUGIN_REPOSITORY = "PLUGIN_REPOSITORY";
+    public static final String PLUGIN_REPOSITORY_USE_PROXY = "PLUGIN_REPOSITORY_USE_PROXY";
+    public static final String PROXY_PROTOCOL = "PROXY_PROTOCOL";
+
     static ClassLoader cl = SparkRes.class.getClassLoader();
 
     static {

--- a/core/src/main/java/org/jivesoftware/resource/Default.java
+++ b/core/src/main/java/org/jivesoftware/resource/Default.java
@@ -232,7 +232,7 @@ public class Default {
      * @return Collection
      */
     public static Collection<String> getPluginBlacklist() {
-	String pluginlist = getString("PLUGIN_BLACKLIST").replace(" ", "")
+	String pluginlist = getString(Default.PLUGIN_BLACKLIST).replace(" ", "")
 		.toLowerCase();
 	StringTokenizer tokenizer = new StringTokenizer(pluginlist, ",");
 	ArrayList<String> list = new ArrayList<>();
@@ -242,7 +242,7 @@ public class Default {
 	}
 
 	StringTokenizer clazztokenz = new StringTokenizer(
-		getString("PLUGIN_BLACKLIST_CLASS").replace(" ", ""), ",");
+		getString(Default.PLUGIN_BLACKLIST_CLASS).replace(" ", ""), ",");
 
 	while (clazztokenz.hasMoreTokens()) {
 	    list.add(clazztokenz.nextToken());

--- a/core/src/main/java/org/jivesoftware/resource/Default.java
+++ b/core/src/main/java/org/jivesoftware/resource/Default.java
@@ -72,7 +72,7 @@ public class Default {
     public static final String DEFAULT_LOOK_AND_FEEL = "DEFAULT_LOOK_AND_FEEL";
     public static final String DEFAULT_LOOK_AND_FEEL_MAC = "DEFAULT_LOOK_AND_FEEL_MAC";
     public static final String INSTALL_PLUGINS_DISABLED = "INSTALL_PLUGINS_DISABLED";
-    public static final String DEINSTALL_PLUGINS_DISABLED = "DEINSTALL_PLUGINS_DISABLED";
+    public static final String UNINSTALL_PLUGINS_DISABLED = "UNINSTALL_PLUGINS_DISABLED";
     public static final String ADVANCED_DISABLED = "ADVANCED_DISABLED";
     public static final String SSO_DISABLED = "SSO_DISABLED";
     public static final String PROXY_DISABLED = "PROXY_DISABLED";
@@ -80,7 +80,7 @@ public class Default {
     public static final String CERTIFICATES_MANAGER_DISABLED = "CERTIFICATES_MANAGER_DISABLED";
     public static final String MUTUAL_AUTH_DISABLED = "MUTUAL_AUTH_DISABLED";
     public static final String HELP_USER_GUIDE = "HELP_USER_GUIDE";
-    public static final String BROADCAST_IN_CHATWINDOW = "BROADCAST_IN_CHATWINDOW";
+    public static final String BROADCAST_IN_CHAT_WINDOW = "BROADCAST_IN_CHAT_WINDOW";
     public static final String MENUBAR_TEXT = "MENUBAR_TEXT";
     public static final String FILE_TRANSFER_WARNING_SIZE = "FILE_TRANSFER_WARNING_SIZE";
     public static final String FILE_TRANSFER_MAXIMUM_SIZE = "FILE_TRANSFER_MAXIMUM_SIZE";
@@ -93,10 +93,10 @@ public class Default {
     public static final String VERSION_AS_RESOURCE = "VERSION_AS_RESOURCE";
     public static final String HISTORY_DISABLED = "HISTORY_DISABLED";
     public static final String HIDE_HISTORY_SETTINGS = "HIDE_HISTORY_SETTINGS";
-    public static final String HIDE_SAVE_PASSWORD_AND_AUTOLOGIN = "HIDE_SAVE_PASSWORD_AND_AUTOLOGIN";
+    public static final String HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN = "HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN";
     public static final String HIDE_LOGIN_AS_INVISIBLE = "HIDE_LOGIN_AS_INVISIBLE";
     public static final String HIDE_LOGIN_ANONYMOUSLY = "HIDE_LOGIN_ANONYMOUSLY";
-    public static final String MAINT_FILESPEC = "MAINT_FILESPEC";
+    public static final String MAINTENANCE_FILE_PATH = "MAINTENANCE_FILE_PATH";
     public static final String HIDE_START_A_CHAT = "HIDE_START_A_CHAT";  
     public static final String ACCEPT_EXPIRED = "ACCEPT_EXPIRED";
     public static final String ACCEPT_NOT_VALID_YET = "ACCEPT_NOT_VALID_YET";
@@ -127,7 +127,7 @@ public class Default {
     public static final String DISABLE_BROADCAST_MENU_ITEM = "DISABLE_BROADCAST_MENU_ITEM";
     public static final String DISABLE_EDIT_PROFILE = "DISABLE_EDIT_PROFILE";
     public static final String DISABLE_EXIT = "DISABLE_EXIT";
-    public static final String DISABLE_FILE_XFER = "DISABLE_FILE_XFER";
+    public static final String DISABLE_FILE_TRANSFER = "DISABLE_FILE_TRANSFER";
     public static final String DISABLE_MOVE_AND_COPY = "DISABLE_MOVE_AND_COPY";
     public static final String DISABLE_PLUGINS_MENU_ITEM = "DISABLE_PLUGINS_MENU_ITEM";
     public static final String DISABLE_PREFERENCES_MENU_ITEM = "DISABLE_PREFERENCES_MENU_ITEM";

--- a/core/src/main/java/org/jivesoftware/spark/PresenceManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/PresenceManager.java
@@ -65,7 +65,7 @@ public class PresenceManager {
         PRESENCES.add(phonePresence);
         PRESENCES.add(dndPresence);
 
-        if (!Default.getBoolean("HIDE_LOGIN_AS_INVISIBLE") && Enterprise.containsFeature(Enterprise.INVISIBLE_LOGIN_FEATURE)) PRESENCES.add(invisible);        
+        if (!Default.getBoolean(Default.HIDE_LOGIN_AS_INVISIBLE) && Enterprise.containsFeature(Enterprise.INVISIBLE_LOGIN_FEATURE)) PRESENCES.add(invisible);
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
@@ -141,7 +141,7 @@ public class SparkTransferManager {
     private SparkTransferManager() {
     	
     	// See if we should disable the option to transfer files and images
-    	if (Default.getBoolean("DISABLE_FILE_XFER") || !Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) return;
+    	if (Default.getBoolean(Default.DISABLE_FILE_XFER) || !Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) return;
 
         SparkManager.getConnection().addConnectionListener(new ConnectionListener() {
             @Override

--- a/core/src/main/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/filetransfer/SparkTransferManager.java
@@ -141,7 +141,7 @@ public class SparkTransferManager {
     private SparkTransferManager() {
     	
     	// See if we should disable the option to transfer files and images
-    	if (Default.getBoolean(Default.DISABLE_FILE_XFER) || !Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) return;
+    	if (Default.getBoolean(Default.DISABLE_FILE_TRANSFER) || !Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) return;
 
         SparkManager.getConnection().addConnectionListener(new ConnectionListener() {
             @Override

--- a/core/src/main/java/org/jivesoftware/spark/search/SearchService.java
+++ b/core/src/main/java/org/jivesoftware/spark/search/SearchService.java
@@ -65,7 +65,7 @@ public class SearchService extends JPanel {
 
         // add(findLabel, new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
 
-        boolean showPersonSearchField = (!Default.getBoolean("HIDE_PERSON_SEARCH_FIELD") && Enterprise.containsFeature(Enterprise.PERSON_SEARCH_FEATURE));
+        boolean showPersonSearchField = (!Default.getBoolean(Default.HIDE_PERSON_SEARCH_FIELD) && Enterprise.containsFeature(Enterprise.PERSON_SEARCH_FEATURE));
 
         if (showPersonSearchField) {
         	if (Spark.isMac()) {

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1388,9 +1388,9 @@ moveToOffline(moveToOfflineContactItem);
 
 
         final JPopupMenu popup = new JPopupMenu();
-        if (!Default.getBoolean("ADD_CONTACT_DISABLED") && Enterprise.containsFeature(Enterprise.ADD_CONTACTS_FEATURE)) popup.add(addContactMenu);
+        if (!Default.getBoolean(Default.ADD_CONTACT_DISABLED) && Enterprise.containsFeature(Enterprise.ADD_CONTACTS_FEATURE)) popup.add(addContactMenu);
 
-        if (!Default.getBoolean("ADD_CONTACT_GROUP_DISABLED") && Enterprise.containsFeature(Enterprise.ADD_GROUPS_FEATURE)) popup.add(addContactGroupMenu);
+        if (!Default.getBoolean(Default.ADD_CONTACT_GROUP_DISABLED) && Enterprise.containsFeature(Enterprise.ADD_GROUPS_FEATURE)) popup.add(addContactGroupMenu);
 
         popup.addSeparator();
 
@@ -1405,15 +1405,15 @@ moveToOffline(moveToOfflineContactItem);
             popup.addSeparator();
 
             // See if we should disable the "Delete" menu option
-            if (!Default.getBoolean("DISABLE_REMOVALS") && Enterprise.containsFeature(Enterprise.REMOVALS_FEATURE)) popup.add(delete);
+            if (!Default.getBoolean(Default.DISABLE_REMOVALS) && Enterprise.containsFeature(Enterprise.REMOVALS_FEATURE)) popup.add(delete);
 
             // See if we should disable the "Rename" menu option
-            if (!Default.getBoolean("DISABLE_RENAMES") && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE)) popup.add(rename);
+            if (!Default.getBoolean(Default.DISABLE_RENAMES) && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE)) popup.add(rename);
         }
 
         // Only display a horizontal separator if at least one of those options is present
-        final boolean allowRemovals = (!Default.getBoolean("DISABLE_REMOVALS") && Enterprise.containsFeature(Enterprise.REMOVALS_FEATURE));
-        final boolean allowRenames  = (!Default.getBoolean("DISABLE_RENAMES")  && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE));
+        final boolean allowRemovals = (!Default.getBoolean(Default.DISABLE_REMOVALS) && Enterprise.containsFeature(Enterprise.REMOVALS_FEATURE));
+        final boolean allowRenames  = (!Default.getBoolean(Default.DISABLE_RENAMES)  && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE));
         if (allowRemovals || allowRenames) popup.addSeparator();
 
         popup.add(expand);
@@ -1531,7 +1531,7 @@ moveToOffline(moveToOfflineContactItem);
         };
 
         // See if we should disable the option to transfer files and images
-        if (!Default.getBoolean("DISABLE_FILE_XFER") && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) {
+        if (!Default.getBoolean(Default.DISABLE_FILE_XFER) && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) {
         	sendAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.DOCUMENT_16x16));
         	sendAction.putValue(Action.NAME, Res.getString("menuitem.send.a.file"));
         	if (item.getPresence() != null) popup.add(sendAction);
@@ -1583,12 +1583,12 @@ moveToOffline(moveToOfflineContactItem);
         }
 
         // See if we should disable the option to remove a contact
-        if (!Default.getBoolean("DISABLE_REMOVALS") && Enterprise.containsFeature(Enterprise.REMOVALS_FEATURE)) {
+        if (!Default.getBoolean(Default.DISABLE_REMOVALS) && Enterprise.containsFeature(Enterprise.REMOVALS_FEATURE)) {
         	if (!contactGroup.isSharedGroup() && !isInSharedGroup) popup.add(removeAction);
         }
 
         // See if we should disable the option to rename a contact
-        if (!Default.getBoolean("DISABLE_RENAMES") && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE)) popup.add(renameMenu);
+        if (!Default.getBoolean(Default.DISABLE_RENAMES) && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE)) popup.add(renameMenu);
 
         Action viewProfile = new AbstractAction() {
 			private static final long serialVersionUID = -2562731455090634805L;
@@ -1704,7 +1704,7 @@ moveToOffline(moveToOfflineContactItem);
         fireContextMenuListenerPopup(popup, items);
 
         // See if we should disable all "Broadcast" menu items
-        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM") && Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) popup.add(sendMessagesMenu);
+        if (!Default.getBoolean(Default.DISABLE_BROADCAST_MENU_ITEM) && Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) popup.add(sendMessagesMenu);
 
         sendMessagesMenu.addActionListener( e1 -> sendMessages(items) );
 
@@ -1971,9 +1971,9 @@ moveToOffline(moveToOfflineContactItem);
         ResourceUtils.resButton(addContactsMenu, Res.getString("menuitem.add.contact"));
         ResourceUtils.resButton(addContactGroupMenu, Res.getString("menuitem.add.contact.group"));
 
-        if (!Default.getBoolean("ADD_CONTACT_DISABLED") && Enterprise.containsFeature(Enterprise.ADD_CONTACTS_FEATURE)) contactsMenu.add(addContactsMenu);
+        if (!Default.getBoolean(Default.ADD_CONTACT_DISABLED) && Enterprise.containsFeature(Enterprise.ADD_CONTACTS_FEATURE)) contactsMenu.add(addContactsMenu);
         
-        if (!Default.getBoolean("ADD_CONTACT_GROUP_DISABLED") && Enterprise.containsFeature(Enterprise.ADD_GROUPS_FEATURE)) contactsMenu.add(addContactGroupMenu);
+        if (!Default.getBoolean(Default.ADD_CONTACT_GROUP_DISABLED) && Enterprise.containsFeature(Enterprise.ADD_GROUPS_FEATURE)) contactsMenu.add(addContactGroupMenu);
 
         addContactsMenu.addActionListener( e -> new RosterDialog().showRosterDialog() );
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1531,7 +1531,7 @@ moveToOffline(moveToOfflineContactItem);
         };
 
         // See if we should disable the option to transfer files and images
-        if (!Default.getBoolean(Default.DISABLE_FILE_XFER) && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) {
+        if (!Default.getBoolean(Default.DISABLE_FILE_TRANSFER) && Enterprise.containsFeature(Enterprise.FILE_TRANSFER_FEATURE)) {
         	sendAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.DOCUMENT_16x16));
         	sendAction.putValue(Action.NAME, Res.getString("menuitem.send.a.file"));
         	if (item.getPresence() != null) popup.add(sendAction);

--- a/core/src/main/java/org/jivesoftware/spark/ui/RosterDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/RosterDialog.java
@@ -184,7 +184,7 @@ public class RosterDialog implements ActionListener {
         
         panel.add(groupBox, new GridBagConstraints(1, 4, 1, 1, 1.0D, 0.0D, 17, 2, new Insets(5, 5, 5, 5), 0, 0));
         
-        if (!Default.getBoolean("ADD_CONTACT_GROUP_DISABLED") && Enterprise.containsFeature(Enterprise.ADD_GROUPS_FEATURE)) {
+        if (!Default.getBoolean(Default.ADD_CONTACT_GROUP_DISABLED) && Enterprise.containsFeature(Enterprise.ADD_GROUPS_FEATURE)) {
         	panel.add(newGroupButton, new GridBagConstraints(2, 4, 1, 1, 0.0D, 0.0D, 17, 1, new Insets(5, 5, 5, 5), 0, 0));
         }
         newGroupButton.addActionListener(this);

--- a/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
@@ -488,8 +488,8 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener
             }
         } );
 
-        if (!Default.getBoolean("HIDE_HISTORY_SETTINGS") && Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE) 
-        		&& !Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
+        if (!Default.getBoolean(Default.HIDE_HISTORY_SETTINGS) && Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE)
+        		&& !Default.getBoolean(Default.HISTORY_DISABLED) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
             popup.add( new AbstractAction( Res.getString( "action.clear" ), SparkRes.getImageIcon( SparkRes.ERASER_IMAGE ) )
             {
                 @Override
@@ -527,7 +527,7 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener
         }
 
         // History window
-        if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
+        if (!Default.getBoolean(Default.HISTORY_DISABLED) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
         	popup.add( new AbstractAction( Res.getString( "action.viewlog" ) )
         	{
         		@Override

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/ProxyLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/ProxyLoginSettingsPanel.java
@@ -96,23 +96,23 @@ class ProxyLoginSettingsPanel extends JPanel
             protocolBox.setSelectedItem( localPreferences.getProtocol() );
         }
 
-        if ( Default.getString( "PROXY_PROTOCOL" ).length() > 0 )
+        if ( Default.getString( Default.PROXY_PROTOCOL ).length() > 0 )
         {
-            protocolBox.setSelectedItem( Default.getString( "PROXY_PROTOCOL" ) );
+            protocolBox.setSelectedItem( Default.getString( Default.PROXY_PROTOCOL ) );
             protocolBox.setEnabled( false );
             useProxyBox.setSelected( true );
             useProxyBox.setVisible( false );
         }
-        if ( Default.getString( "PROXY_HOST" ).length() > 0 )
+        if ( Default.getString( Default.PROXY_HOST ).length() > 0 )
         {
-            hostField.setText( Default.getString( "PROXY_HOST" ) );
+            hostField.setText( Default.getString( Default.PROXY_HOST ) );
             hostField.setEnabled( false );
             useProxyBox.setSelected( true );
             useProxyBox.setVisible( false );
         }
-        if ( Default.getString( "PROXY_PORT" ).length() > 0 )
+        if ( Default.getString( Default.PROXY_PORT ).length() > 0 )
         {
-            portField.setText( Default.getString( "PROXY_PORT" ) );
+            portField.setText( Default.getString( Default.PROXY_PORT ) );
             portField.setEnabled( false );
         }
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -186,7 +186,7 @@ public class ChatRoomImpl extends ChatRoom {
         addToRosterButton = new ChatRoomButton("", SparkRes.getImageIcon(SparkRes.ADD_IMAGE_24x24));
         if (entry == null && !privateChat) {
             addToRosterButton.setToolTipText(Res.getString("message.add.this.user.to.your.roster"));
-            if (!Default.getBoolean("ADD_CONTACT_DISABLED") && Enterprise.containsFeature(Enterprise.ADD_CONTACTS_FEATURE)) addChatRoomButton(addToRosterButton);
+            if (!Default.getBoolean(Default.ADD_CONTACT_DISABLED) && Enterprise.containsFeature(Enterprise.ADD_CONTACTS_FEATURE)) addChatRoomButton(addToRosterButton);
             addToRosterButton.addActionListener(this);
         }
 
@@ -766,7 +766,7 @@ public class ChatRoomImpl extends ChatRoom {
     	vcardPanel = new VCardPanel(participantJID.asBareJid());
     	getToolBar().add(vcardPanel, new GridBagConstraints(0, 1, 1, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL, new Insets(0, 2, 0, 2), 0, 0));
 
-       	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
+       	if (!Default.getBoolean(Default.HISTORY_DISABLED) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
     		final LocalPreferences localPreferences = SettingsManager.getLocalPreferences();
     		if (!localPreferences.isChatHistoryEnabled()) {
     			return;

--- a/core/src/main/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -572,7 +572,7 @@ public class StatusBar extends JPanel implements VCardListener {
 			statusLabel.setFont(new Font(Font.DIALOG, Font.PLAIN, 11));
 
 			// See if we should disable ability to change presence status
-			if (!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE") && Enterprise.containsFeature(Enterprise.PRESENCE_STATUS_FEATURE)) statusLabel.setIcon(SparkRes.getImageIcon(SparkRes.DOWN_ARROW_IMAGE));
+			if (!Default.getBoolean(Default.DISABLE_PRESENCE_STATUS_CHANGE) && Enterprise.containsFeature(Enterprise.PRESENCE_STATUS_FEATURE)) statusLabel.setIcon(SparkRes.getImageIcon(SparkRes.DOWN_ARROW_IMAGE));
 
 			statusLabel.setHorizontalTextPosition(JLabel.LEFT);
 
@@ -582,7 +582,7 @@ public class StatusBar extends JPanel implements VCardListener {
 			setBorder(border);
 
 			// See if we should disable ability to change presence status
-			if (!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE") && Enterprise.containsFeature(Enterprise.PRESENCE_STATUS_FEATURE)) {			
+			if (!Default.getBoolean(Default.DISABLE_PRESENCE_STATUS_CHANGE) && Enterprise.containsFeature(Enterprise.PRESENCE_STATUS_FEATURE)) {
 				statusLabel.addMouseListener(new MouseAdapter() {
 					@Override
 					public void mouseReleased(MouseEvent e) {
@@ -716,7 +716,7 @@ public class StatusBar extends JPanel implements VCardListener {
 
 	public void allowProfileEditing() {
 		// Allow profile editing ONLY if both client-side and server-side settings permit it
-		if (Default.getBoolean("DISABLE_EDIT_PROFILE") || !Enterprise.containsFeature(Enterprise.VCARD_FEATURE)) return;
+		if (Default.getBoolean(Default.DISABLE_EDIT_PROFILE) || !Enterprise.containsFeature(Enterprise.VCARD_FEATURE)) return;
 
 		// Go ahead and show the profile when clicking on the Avatar image
 		imageLabel.addMouseListener(new MouseAdapter() {

--- a/core/src/main/java/org/jivesoftware/spark/ui/themes/MainThemePanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/themes/MainThemePanel.java
@@ -49,7 +49,7 @@ public class MainThemePanel extends JPanel {
 	ImageIcon color = new ImageIcon(SparkRes.getImageIcon(SparkRes.COLOR_ICON).getImage().getScaledInstance(16, 16, Image.SCALE_SMOOTH));
 	
 	tabs.addTab(Res.getString("title.appearance.preferences"),appe, _themepanel);	
-	if(!Default.getBoolean("CHANGE_COLORS_DISABLED")){
+	if(!Default.getBoolean(Default.CHANGE_COLORS_DISABLED)){
 	    tabs.addTab(Res.getString("lookandfeel.color.label"),color,_colorpanel);
 	}
 	add(tabs);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -106,7 +106,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
     @Override
 	public void initialize() {
         // See if we should disable all "Broadcast" menu items
-    	if (Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM") || !Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) return;
+    	if (Default.getBoolean(Default.DISABLE_BROADCAST_MENU_ITEM) || !Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) return;
 
         // Add as ContainerDecoratr
         SparkManager.getChatManager().addSparkTabHandler(this);
@@ -127,7 +127,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
         // Register with action menu
         JMenuItem startConversationtMenu = new JMenuItem("", SparkRes.getImageIcon(SparkRes.SMALL_MESSAGE_IMAGE));
         ResourceUtils.resButton(startConversationtMenu, Res.getString("menuitem.start.a.chat"));
-        if (!Default.getBoolean("HIDE_START_A_CHAT") && Enterprise.containsFeature(Enterprise.START_A_CHAT_FEATURE)){
+        if (!Default.getBoolean(Default.HIDE_START_A_CHAT) && Enterprise.containsFeature(Enterprise.START_A_CHAT_FEATURE)){
         actionsMenu.add(startConversationtMenu,0);}
         startConversationtMenu.addActionListener( e -> {
             ContactList contactList = SparkManager.getWorkspace().getContactList();

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -299,7 +299,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
 
 	if (!from.hasLocalpart()) {
 	    // if theres no "@" it means the message came from the server
-	    if (Default.getBoolean(Default.BROADCAST_IN_CHATWINDOW)
+	    if (Default.getBoolean(Default.BROADCAST_IN_CHAT_WINDOW)
 		    || linebreaks > 20 || message.getBody().length() > 1000 || mightbeMOTD) {
 		// if we have more than 20 linebreaks or the message is longer
 		// than 1000characters we should broadcast

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/chat/ContactListAssistantPlugin.java
@@ -128,7 +128,7 @@ public class ContactListAssistantPlugin implements Plugin {
                     });
 
                     int index = -1;
-                    if (!Default.getBoolean("DISABLE_RENAMES") && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE)) {
+                    if (!Default.getBoolean(Default.DISABLE_RENAMES) && Enterprise.containsFeature(Enterprise.RENAMES_FEATURE)) {
                     	for (int i = 0; i < popup.getComponentCount(); i++) {
                     		Object o = popup.getComponent(i);
                     		if (o instanceof JMenuItem && ((JMenuItem)o).getText().equals(Res.getString("menuitem.rename"))) {
@@ -143,7 +143,7 @@ public class ContactListAssistantPlugin implements Plugin {
                         // Add MOVE/COPY options right after the RENAME option or in it's place if it doesn't exist.
                         if (index != -1) {
                         	// See if we should disable the "Move to" and "Copy to" menu options
-                        	if (!Default.getBoolean("DISABLE_MOVE_AND_COPY") && Enterprise.containsFeature(Enterprise.MOVE_COPY_FEATURE)) {
+                        	if (!Default.getBoolean(Default.DISABLE_MOVE_AND_COPY) && Enterprise.containsFeature(Enterprise.MOVE_COPY_FEATURE)) {
                         		popup.add(moveToMenu, index + 1);
                         		popup.add(copyToMenu, index + 2);
                         	}
@@ -151,14 +151,14 @@ public class ContactListAssistantPlugin implements Plugin {
                     }
                     else if (contactItems.size() > 1) {
                     	// See if we should disable the "Move to" and "Copy to" menu options
-                    	if (!Default.getBoolean("DISABLE_MOVE_AND_COPY") && Enterprise.containsFeature(Enterprise.MOVE_COPY_FEATURE)) {                    	
+                    	if (!Default.getBoolean(Default.DISABLE_MOVE_AND_COPY) && Enterprise.containsFeature(Enterprise.MOVE_COPY_FEATURE)) {
                     		popup.addSeparator();
                     		popup.add(moveToMenu);
                     		popup.add(copyToMenu);
                    	}                        
 
                         // Clean up the extra separator if "Broadcast" menu items are disabled
-                        if (!Default.getBoolean("DISABLE_BROADCAST_MENU_ITEM") && Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) popup.addSeparator();                        
+                        if (!Default.getBoolean(Default.DISABLE_BROADCAST_MENU_ITEM) && Enterprise.containsFeature(Enterprise.BROADCAST_FEATURE)) popup.addSeparator();
                     }
                 }
             }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/scratchpad/ScratchPadPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/scratchpad/ScratchPadPlugin.java
@@ -117,10 +117,10 @@ public class ScratchPadPlugin implements Plugin {
             actionsMenu.addSeparator();
 
             // See if we should disable the "View task list" option under "Actions"
-            if (!Default.getBoolean("DISABLE_VIEW_TASK_LIST") && Enterprise.containsFeature(Enterprise.VIEW_TASKS_FEATURE)) actionsMenu.add(taskMenu);
+            if (!Default.getBoolean(Default.DISABLE_VIEW_TASK_LIST) && Enterprise.containsFeature(Enterprise.VIEW_TASKS_FEATURE)) actionsMenu.add(taskMenu);
 
             // See if we should disable the "View notes" option under "Actions"
-            if (!Default.getBoolean("DISABLE_VIEW_NOTES") && Enterprise.containsFeature(Enterprise.VIEW_NOTES_FEATURE)) actionsMenu.add(notesMenu);
+            if (!Default.getBoolean(Default.DISABLE_VIEW_NOTES) && Enterprise.containsFeature(Enterprise.VIEW_NOTES_FEATURE)) actionsMenu.add(notesMenu);
 
             // Start notifications.
             new TaskNotification();

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
@@ -177,7 +177,7 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatStateListener {
 	    // Logout Menu
 	    if (Spark.isWindows()) {
 	    	if (!Default.getBoolean(Default.DISABLE_EXIT) && Enterprise.containsFeature(Enterprise.LOGOUT_EXIT_FEATURE)) {
-	    		if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTOLOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
+	    		if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
 	    			logoutMenu.addActionListener( new AbstractAction() {
 	    				private static final long serialVersionUID = 1L;
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
@@ -159,7 +159,7 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatStateListener {
 	    });
 	    
 	    // See if we should disable ability to change presence status
-	    if (!Default.getBoolean("DISABLE_PRESENCE_STATUS_CHANGE") && Enterprise.containsFeature(Enterprise.PRESENCE_STATUS_FEATURE)) {
+	    if (!Default.getBoolean(Default.DISABLE_PRESENCE_STATUS_CHANGE) && Enterprise.containsFeature(Enterprise.PRESENCE_STATUS_FEATURE)) {
 	    	popupMenu.addSeparator();
 	    	addStatusMessages();
 	    	popupMenu.add(statusMenu);
@@ -176,8 +176,8 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatStateListener {
 
 	    // Logout Menu
 	    if (Spark.isWindows()) {
-	    	if (!Default.getBoolean("DISABLE_EXIT") && Enterprise.containsFeature(Enterprise.LOGOUT_EXIT_FEATURE)) {
-	    		if(!Default.getBoolean("HIDE_SAVE_PASSWORD_AND_AUTOLOGIN") && SettingsManager.getLocalPreferences().getPswdAutologin()) {
+	    	if (!Default.getBoolean(Default.DISABLE_EXIT) && Enterprise.containsFeature(Enterprise.LOGOUT_EXIT_FEATURE)) {
+	    		if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTOLOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
 	    			logoutMenu.addActionListener( new AbstractAction() {
 	    				private static final long serialVersionUID = 1L;
 
@@ -201,7 +201,7 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatStateListener {
 		}
 	    });
 
-	    if (!Default.getBoolean("DISABLE_EXIT") && Enterprise.containsFeature(Enterprise.LOGOUT_EXIT_FEATURE)) popupMenu.add(exitMenu);
+	    if (!Default.getBoolean(Default.DISABLE_EXIT) && Enterprise.containsFeature(Enterprise.LOGOUT_EXIT_FEATURE)) popupMenu.add(exitMenu);
 
 	    /**
 	     * If connection closed set offline tray image

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscriptPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscriptPlugin.java
@@ -116,7 +116,7 @@ public class ChatTranscriptPlugin implements ChatRoomListener {
             @Override
 			public void poppingUp(Object object, JPopupMenu popup) {
                 if (object instanceof ContactItem) {
-                	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) popup.add(viewHistoryAction);
+                	if (!Default.getBoolean(Default.HISTORY_DISABLED) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) popup.add(viewHistoryAction);
                	 	popup.add(showStatusMessageAction);
                 }
             }
@@ -340,7 +340,7 @@ public class ChatTranscriptPlugin implements ChatRoomListener {
             }
             chatHistoryButton = UIComponentRegistry.getButtonFactory().createChatTranscriptButton();
 
-            if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) chatRoom.addChatRoomButton(chatHistoryButton);
+            if (!Default.getBoolean(Default.HISTORY_DISABLED) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) chatRoom.addChatRoomButton(chatHistoryButton);
 
             chatHistoryButton.setToolTipText(Res.getString("tooltip.view.history"));
             chatHistoryButton.addActionListener(this);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
@@ -72,7 +72,7 @@ public final class ChatTranscripts {
     public static void appendToTranscript(EntityBareJid jid, ChatTranscript transcript) {
     	final File transcriptFile = getTranscriptFile(jid);
 
-       	if (!Default.getBoolean("HISTORY_DISABLED") && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
+       	if (!Default.getBoolean(Default.HISTORY_DISABLED) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
     		// Write Full Transcript, appending the messages.
     		writeToFile(transcriptFile, transcript.getMessages(), true);
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -148,7 +148,7 @@ public class PluginViewer extends JPanel implements Plugin
     {
         deactivatedPanel.setLayout( new VerticalFlowLayout(
                 VerticalFlowLayout.TOP, 0, 0, true, false ) );
-        if ( !Default.getBoolean( Default.DEINSTALL_PLUGINS_DISABLED ) )
+        if ( !Default.getBoolean( Default.UNINSTALL_PLUGINS_DISABLED) )
         {
             tabbedPane.addTab( Res.getString( "tab.deactivated.plugins" ), new JScrollPane( deactivatedPanel ) );
         }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -66,7 +66,7 @@ public class PluginViewer extends JPanel implements Plugin
 
     private boolean loaded = false;
 
-    private String retrieveListURL = Default.getString( "PLUGIN_REPOSITORY" );
+    private String retrieveListURL = Default.getString( Default.PLUGIN_REPOSITORY );
 
     private JProgressBar progressBar;
 
@@ -191,7 +191,7 @@ public class PluginViewer extends JPanel implements Plugin
         viewPluginsMenu.setAction( viewAction );
 
         // See if we should disable the "Plugins" menu item
-        if ( !Default.getBoolean( "DISABLE_PLUGINS_MENU_ITEM" ) && Enterprise.containsFeature( Enterprise.PLUGINS_MENU_FEATURE ) )
+        if ( !Default.getBoolean( Default.DISABLE_PLUGINS_MENU_ITEM ) && Enterprise.containsFeature( Enterprise.PLUGINS_MENU_FEATURE ) )
         {
             sparkMenu.insert( viewPluginsMenu, 2 );
         }
@@ -307,7 +307,7 @@ public class PluginViewer extends JPanel implements Plugin
                 Protocol.registerProtocol( "https", new Protocol( "https", new EasySSLProtocolSocketFactory(), 443 ) );
                 final HttpClient httpclient = new HttpClient();
 
-                if ( Default.getBoolean( "PLUGIN_REPOSITORY_USE_PROXY" ) )
+                if ( Default.getBoolean( Default.PLUGIN_REPOSITORY_USE_PROXY ) )
                 {
                     String proxyHost = System.getProperty( "http.proxyHost" );
                     String proxyPort = System.getProperty( "http.proxyPort" );
@@ -392,7 +392,7 @@ public class PluginViewer extends JPanel implements Plugin
         String proxyHost = System.getProperty( "http.proxyHost" );
         String proxyPort = System.getProperty( "http.proxyPort" );
 
-        if ( Default.getBoolean( "PLUGIN_REPOSITORY_USE_PROXY" ) )
+        if ( Default.getBoolean( Default.PLUGIN_REPOSITORY_USE_PROXY ) )
         {
             if ( ModelUtil.hasLength( proxyHost )
                     && ModelUtil.hasLength( proxyPort ) )

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/SparkPlugUI.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/SparkPlugUI.java
@@ -138,7 +138,7 @@ public class SparkPlugUI extends JPanel {
             setBackground(new Color(234, 230, 212));
             showOperationButton();
             setBorder(BorderFactory.createEtchedBorder());
-	    if (Default.getBoolean(Default.DEINSTALL_PLUGINS_DISABLED)) {
+	    if (Default.getBoolean(Default.UNINSTALL_PLUGINS_DISABLED)) {
 		installButton.setVisible(false);
 	    }
         }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/preference/chat/ChatPreferencePanel.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/preference/chat/ChatPreferencePanel.java
@@ -116,7 +116,7 @@ public class ChatPreferencePanel extends JPanel implements ActionListener {
         generalPanel.setBorder(BorderFactory.createTitledBorder(Res.getString("group.general.information")));
         chatWindowPanel.setBorder(BorderFactory.createTitledBorder(Res.getString("group.chat.window.information")));
 
-        if (!Default.getBoolean("CHANGE_PASSWORD_DISABLED") && Enterprise.containsFeature(Enterprise.PASSWORD_CHANGE_FEATURE)) add(generalPanel);
+        if (!Default.getBoolean(Default.CHANGE_PASSWORD_DISABLED) && Enterprise.containsFeature(Enterprise.PASSWORD_CHANGE_FEATURE)) add(generalPanel);
         add(chatWindowPanel);
 
         generalPanel.setLayout(new GridBagLayout());
@@ -131,7 +131,7 @@ public class ChatPreferencePanel extends JPanel implements ActionListener {
 
         chatWindowPanel.add(groupChatNotificationBox, new GridBagConstraints(0, 2, 2, 1, 1.0, 1.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
 
-        if (!Default.getBoolean("HISTORY_DISABLED") && !Default.getBoolean("HIDE_HISTORY_SETTINGS")
+        if (!Default.getBoolean(Default.HISTORY_DISABLED) && !Default.getBoolean(Default.HIDE_HISTORY_SETTINGS)
         		&& Enterprise.containsFeature(Enterprise.HISTORY_SETTINGS_FEATURE) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
         	chatWindowPanel.add(hideChatHistory, new GridBagConstraints(0, 3, 2, 1, 1.0, 1.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
         	chatWindowPanel.add(hidePrevChatHistory, new GridBagConstraints(0, 4, 2, 1, 1.0, 1.0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));

--- a/core/src/main/java/org/jivesoftware/sparkimpl/preference/notifications/NotificationsUI.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/preference/notifications/NotificationsUI.java
@@ -102,7 +102,7 @@ public class NotificationsUI extends JPanel {
         
         betaCheckBox = new JCheckBox();
         ResourceUtils.resButton(betaCheckBox, Res.getString("menuitem.check.for.updates"));
-        if (!Default.getBoolean("DISABLE_UPDATES") && Enterprise.containsFeature(Enterprise.UPDATES_FEATURE)) {
+        if (!Default.getBoolean(Default.DISABLE_UPDATES) && Enterprise.containsFeature(Enterprise.UPDATES_FEATURE)) {
         	pn.add(betaCheckBox, new GridBagConstraints(0, 7, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
         }   
         	add(pn);	

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardEditor.java
@@ -92,7 +92,7 @@ public class VCardEditor {
 	tabbedPane.addTab(Res.getString("tab.home"), homePanel);
 
 	// See if we should remove the Avatar tab in profile dialog
-	if (!Default.getBoolean("DISABLE_AVATAR_TAB") && Enterprise.containsFeature(Enterprise.AVATAR_TAB_FEATURE)) {
+	if (!Default.getBoolean(Default.DISABLE_AVATAR_TAB) && Enterprise.containsFeature(Enterprise.AVATAR_TAB_FEATURE)) {
 		avatarPanel = new AvatarPanel();
 		tabbedPane.addTab(Res.getString("tab.avatar"), avatarPanel);
 	}
@@ -179,7 +179,7 @@ public class VCardEditor {
 	pane.addPropertyChangeListener(changeListener);
 	
 	// See if we should remove the Avatar tab in profile dialog	
-	if (!Default.getBoolean("DISABLE_AVATAR_TAB") && Enterprise.containsFeature(Enterprise.AVATAR_TAB_FEATURE)) avatarPanel.setParentDialog(dlg);
+	if (!Default.getBoolean(Default.DISABLE_AVATAR_TAB) && Enterprise.containsFeature(Enterprise.AVATAR_TAB_FEATURE)) avatarPanel.setParentDialog(dlg);
 	
 	dlg.setVisible(true);
 	dlg.toFront();
@@ -215,7 +215,7 @@ public class VCardEditor {
 	tabbedPane.addTab(Res.getString("tab.home"), homePanel);
 
 	// See if we should remove the Avatar tab in profile dialog
-	if (!Default.getBoolean("DISABLE_AVATAR_TAB") && Enterprise.containsFeature(Enterprise.AVATAR_TAB_FEATURE)) {	
+	if (!Default.getBoolean(Default.DISABLE_AVATAR_TAB) && Enterprise.containsFeature(Enterprise.AVATAR_TAB_FEATURE)) {
 		avatarPanel = new AvatarPanel();
 		avatarPanel.allowEditing(false);
 		tabbedPane.addTab(Res.getString("tab.avatar"), avatarPanel);
@@ -386,7 +386,7 @@ public class VCardEditor {
         	ImageIcon icon = new ImageIcon(bytes);
 	    
         	// See if we should remove the Avatar tab in profile dialog	    
-        	if (!Default.getBoolean("DISABLE_AVATAR_TAB") && Enterprise.containsFeature(Enterprise.AVATAR_TAB_FEATURE)) {	    
+        	if (!Default.getBoolean(Default.DISABLE_AVATAR_TAB) && Enterprise.containsFeature(Enterprise.AVATAR_TAB_FEATURE)) {
         		avatarPanel.setAvatar(icon);
         		avatarPanel.setAvatarBytes(bytes);
         	}	    

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -240,7 +240,7 @@ public class VCardManager {
     private void initializeUI() {
 
         // See if we should disable the "Edit my profile" option under "File"
-        if (Default.getBoolean("DISABLE_EDIT_PROFILE") || !Enterprise.containsFeature(Enterprise.VCARD_FEATURE)) return;
+        if (Default.getBoolean(Default.DISABLE_EDIT_PROFILE) || !Enterprise.containsFeature(Enterprise.VCARD_FEATURE)) return;
 
         // Add Actions Menu
         final JMenu contactsMenu = SparkManager.getMainWindow().getMenuByName(Res.getString("menuitem.contacts"));

--- a/core/src/main/java/org/jivesoftware/sparkimpl/search/users/UserSearchResults.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/search/users/UserSearchResults.java
@@ -198,7 +198,7 @@ public class UserSearchResults extends JPanel {
             }
         };
 
-        if (!Default.getBoolean("ADD_CONTACT_DISABLED") && Enterprise.containsFeature(Enterprise.ADD_CONTACTS_FEATURE)) {
+        if (!Default.getBoolean(Default.ADD_CONTACT_DISABLED) && Enterprise.containsFeature(Enterprise.ADD_CONTACTS_FEATURE)) {
 	        final JMenuItem addAsContact = new JMenuItem(addContactAction);
 	        addContactAction.putValue(Action.SMALL_ICON, SparkRes.getImageIcon(SparkRes.SMALL_ADD_IMAGE));
 	        addContactAction.putValue(Action.NAME, Res.getString("menuitem.add.as.contact"));

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferencePanel.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferencePanel.java
@@ -150,7 +150,7 @@ public class LocalPreferencePanel extends JPanel {
 	inputPanel.add(_idleStatusText, new GridBagConstraints(1, 4, 1, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST,GridBagConstraints.HORIZONTAL, new Insets(5, 5, 5, 5), 50, 0));
 	inputPanel.add(_idleBox,        new GridBagConstraints(0, 5, 2, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,new Insets(5, 5, 5, 5), 50, 0));
 
-	if(!Default.getBoolean("HIDE_SAVE_PASSWORD_AND_AUTOLOGIN") && SettingsManager.getLocalPreferences().getPswdAutologin()) {
+	if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTOLOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
 		if (!preferences.isSSOEnabled()) {
 			inputPanel.add(_savePasswordBox, new GridBagConstraints(0, 6, 2, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL, new Insets(5, 5, 5, 5), 50, 0));
 		}

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferencePanel.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferencePanel.java
@@ -150,7 +150,7 @@ public class LocalPreferencePanel extends JPanel {
 	inputPanel.add(_idleStatusText, new GridBagConstraints(1, 4, 1, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST,GridBagConstraints.HORIZONTAL, new Insets(5, 5, 5, 5), 50, 0));
 	inputPanel.add(_idleBox,        new GridBagConstraints(0, 5, 2, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL,new Insets(5, 5, 5, 5), 50, 0));
 
-	if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTOLOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
+	if(!Default.getBoolean(Default.HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN) && SettingsManager.getLocalPreferences().getPswdAutologin()) {
 		if (!preferences.isSSOEnabled()) {
 			inputPanel.add(_savePasswordBox, new GridBagConstraints(0, 6, 2, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL, new Insets(5, 5, 5, 5), 50, 0));
 		}

--- a/core/src/main/resources/default.properties
+++ b/core/src/main/resources/default.properties
@@ -17,21 +17,21 @@ SECONDARY_BACKGROUND_IMAGE = images/steel.png
 
 # Specify a fixed Hostname
 # Changing the Hostname will also be prohibited if set
-HOST_NAME = 
+HOST_NAME =
 # Set true if you dont want user to change the server
 HOST_NAME_CHANGE_DISABLED = false
 # Proxy Settings
 # Protocols are HTTP or SOCKS , case sensitive!!!
-PROXY_PROTOCOL = 
+PROXY_PROTOCOL =
 PROXY_HOST =
-PROXY_PORT = 
+PROXY_PORT =
 
-# Remove account creation Button from Loginwindow
+# Remove account creation Button from login window
 # Users wont be able to register new Accounts from within Spark
-ACCOUNT_DISABLED = 
-# Remove Advanced Configuration Button from Loginwindow
-# Users wont be able to access the advanced configuration 
-ADVANCED_DISABLED = 
+ACCOUNT_DISABLED =
+# Remove Advanced Configuration Button from login window
+# Users wont be able to access the advanced configuration
+ADVANCED_DISABLED =
 
 # Force using hostname or version as a resource (both are "false" by default; only one can be
 # "true" at a time; if both are "true", then hostname will be used as a resource)
@@ -44,8 +44,8 @@ HISTORY_DISABLED = false
 # When enabled, it hides history settings from the preferences and removes Clear button from the context menu in the Chat window
 HIDE_HISTORY_SETTINGS = false
 
-#If Advanded preferences is enabled you are able to remove tabs, except the "General" tab
-#Removes SSO Tab 
+#If Advanced preferences is enabled you are able to remove tabs, except the "General" tab
+#Removes SSO Tab
 SSO_DISABLED = false
 #Removes PKI Tab
 PKI_DISABLED = false
@@ -87,29 +87,29 @@ CHECK_OCSP = true
 ALLOW_SOFT_FAIL = true
 
 
-# Show Password Reset Button on LoginDialog. 
-# !!!! This will repleace the "register new user" button, please set ACCOUNT_DISABLED = true !!!!
+# Show Password Reset Button on LoginDialog.
+# !!!! This will replace the "register new user" button, please set ACCOUNT_DISABLED = true !!!!
 PASSWORD_RESET_ENABLED = false
-# URL to your password reset html 
-PASSWORD_RESET_URL = 
+# URL to your password reset html
+PASSWORD_RESET_URL =
 # Hides Save Password and Auto Login checkboxes on the Login screen and in the Preferences
-HIDE_SAVE_PASSWORD_AND_AUTOLOGIN = false
+HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN = false
 
 # Branding only
 # Branded images appear in the Top-Right corner, and must be included in the classpath
 # place them in src/resource/images and path will be "images/file.jpg"
 # BRANDED_IMAGE = images/my-corporation-logo.png
-BRANDED_IMAGE = 
+BRANDED_IMAGE =
 
 # Shows a powered by logo below the Main Image of Spark
-SHOW_POWERED_BY = 
-# Disables updateability, you should set this, if you have a custom Spark-build
-# or are in an environment where installfiles are distributed via network
-DISABLE_UPDATES = 
+SHOW_POWERED_BY =
+# Disables updatability, you should set this, if you have a custom Spark-build
+# or are in an environment where install files are distributed via network
+DISABLE_UPDATES =
 
 # If true, Spark cannot shut down
 # users wont be able to shut down Spark
-DISABLE_EXIT = 
+DISABLE_EXIT =
 
 # If true, hides "Login as invisible" checkbox on the login screen
 HIDE_LOGIN_AS_INVISIBLE = false
@@ -123,7 +123,7 @@ DISABLE_PREFERENCES_MENU_ITEM = false
 # The "Preferences" menu item will become enabled when the specified file exists
 # Specify the maintenance path/file here (i.e. \\\\server\\share\\filename.ext)
 # It is best to place this file on a read-only network share
-MAINT_FILESPEC =
+MAINTENANCE_FILE_PATH =
 
 # If true, don't allow user to manually change presence status
 DISABLE_PRESENCE_STATUS_CHANGE = false
@@ -141,7 +141,7 @@ DISABLE_AVATAR_TAB = false
 DISABLE_PLUGINS_MENU_ITEM = false
 
 # If true, disable the option to transfer files and images
-DISABLE_FILE_XFER = false
+DISABLE_FILE_TRANSFER = false
 
 # If true, disable the option to remove contacts and groups in roster
 DISABLE_REMOVALS = false
@@ -165,7 +165,7 @@ DISABLE_VIEW_TASK_LIST = false
 ################## File Transfer ################
 #################################################
 
-# Specify a size on which Users will get a 
+# Specify a size on which Users will get a
 # warning of a possibly too big file
 # 10MB  = 10485760
 # 100MB = 104857600
@@ -182,7 +182,7 @@ FILE_TRANSFER_WARNING_SIZE = -1
 # maximum is 9223372036854775806 byte = 8.388.608 TB
 FILE_TRANSFER_MAXIMUM_SIZE = -1
 
-#Force inband bytestream only.
+# Force in-band bytestream only.
 FILE_TRANSFER_IBB_ONLY = true
 
 
@@ -204,31 +204,31 @@ FILE_TRANSFER_IBB_ONLY = true
 #################################################
 
 # Disables adding of contacts
-# The User wont be able to add contacts, 
-# usefull for shared roster management
-ADD_CONTACT_DISABLED = 
+# The User wont be able to add contacts,
+# useful for shared roster management
+ADD_CONTACT_DISABLED =
 # Disables adding contact groups
-# The User wont be able to add contact groups, 
-# usefull for shared roster management
-ADD_CONTACT_GROUP_DISABLED = 
+# The User wont be able to add contact groups,
+# useful for shared roster management
+ADD_CONTACT_GROUP_DISABLED =
 
 # Change Password Disabled
 # Users wont be able to change their password
-CHANGE_PASSWORD_DISABLED = 
+CHANGE_PASSWORD_DISABLED =
 
-# Sets the Location of the Userguide
+# Sets the Location of the User's guide
 #Default is http://www.igniterealtime.org/builds/spark/docs/spark_user_guide.pdf
 HELP_USER_GUIDE = https://discourse.igniterealtime.org/t/spark-user-guide-revised/41731
 # Set to true, if you don't want this displayed
-HELP_USER_GUIDE_DISABLED = 
+HELP_USER_GUIDE_DISABLED =
 # Sets the Location of the Help-Forum
 #Default is http://www.igniterealtime.org/forum/forum.jspa?forumID=49
 HELP_FORUM = https://discourse.igniterealtime.org/c/spark/spark-support
 # Set to true, if you don't want this displayed
-HELP_FORUM_DISABLED = 
+HELP_FORUM_DISABLED =
 # Following Text will be displayed instead of "Spark forum"
 # leave blank for default
-HELP_FORUM_TEXT = 
+HELP_FORUM_TEXT =
 
 #################################################
 ############### About Box Window ################
@@ -274,10 +274,10 @@ PLUGIN_REPOSITORY_USE_PROXY = true
 #http://www.igniterealtime.org/updater/plugins.jsp
 # Disable Installing of Plugins
 # set true if you want to disable installing of Plugins
-INSTALL_PLUGINS_DISABLED = 
+INSTALL_PLUGINS_DISABLED =
 # Disable deleting of Plugins
-# set true if you want to disable deinstalling of Plugins
-DEINSTALL_PLUGINS_DISABLED = 
+# set true if you want to disable uninstalling of Plugins
+UNINSTALL_PLUGINS_DISABLED =
 # Put plugins here that you don't want enabled
 # comma separated, case insensitive
 # names of plugins can be found in the plugin.xml
@@ -292,30 +292,30 @@ PLUGIN_BLACKLIST_CLASS =
 
 
 #################################################
-#########     Color + LookandFeel     ###########
+#########     Color + LookAndFeel     ###########
 #################################################
 
 # by Default Server-Broadcast get their own JFrame containing the Message
 # also HTML tags like <b> <i> <u> can be used
 # if you want server broadcasts handled like every other message including transcripts
 # set this to true
-BROADCAST_IN_CHATWINDOW = false
+BROADCAST_IN_CHAT_WINDOW = false
 # Disable Look&Feel change || "true" = disabled ,  anything else = enabled
-# By Default the user can Change his Look&Feel in the Preferences Menu, 
+# By Default the user can Change his Look&Feel in the Preferences Menu,
 # if you don't want this then set it to true
 # Preferences -> Appearance -> Customization Tab
-LOOK_AND_FEEL_DISABLED = 
-# Disable if you don't want Users to be able to Change the Textcolors in the Preference Menu
+LOOK_AND_FEEL_DISABLED =
+# Disable if you don't want Users to be able to Change the text colors in the Preference Menu
 # the colors will be loaded from below
 # Preferences -> Appearance -> ColorTab
-CHANGE_COLORS_DISABLED = 
+CHANGE_COLORS_DISABLED =
 # Changes the Default Look&Feel, if empty it will load the SystemSkin
 # Default Spark skin is com.jtattoo.plaf.luna.LunaLookAndFeel
 # other nice skin is org.jvnet.substance.skin.SubstanceBusinessBlueSteelLookAndFeel
 DEFAULT_LOOK_AND_FEEL = com.jtattoo.plaf.luna.LunaLookAndFeel
 DEFAULT_LOOK_AND_FEEL_MAC =
-# in JTatto Menubars can have Texts, default is empty
-MENUBAR_TEXT = 
+# in JTatto menu bars can have Texts, default is empty
+MENUBAR_TEXT =
 
 # tabs are placed on bottom by default. if set to true will be placed on top
 TABS_PLACEMENT_TOP =
@@ -325,9 +325,9 @@ TABS_PLACEMENT_TOP =
 HIDE_PERSON_SEARCH_FIELD =
 
 # Below are Single Color Elements
-# They are Stored as Redvalue,Greenvalue,Bluevalue,Alphavalue
+# They are Stored as RedValue,GreenValue,BlueValue,AlphaValue
 # Ranging from 0 - 255
-# an Alpha value of 255 means it is completly opaque
+# an Alpha value of 255 means it is completely opaque
 # an Alpha value of 0 means it is transparent 
 # all values must be set or it will produce errors
 # they are preconfigured to look nice with the Windows theme or the SubstanceBusinessBlueSteel Look


### PR DESCRIPTION
1. Add missed string constants (static final fields) for default properties to Default class.
2. Replace string literals with constants from Default class.
3. Clean up grammar and typos, refactor some unobvious property names and remove trailing white space.

