### PR TITLE
SPARK-2162: Fix history issues for contacts with spaces in usernames

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/SparkManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/SparkManager.java
@@ -356,7 +356,7 @@ public final class SparkManager {
      * @return the UserDirectory for Spark.
      */
     public static File getUserDirectory() {
-        final String bareJID = sessionManager.getBareAddress();
+        final String bareJID = sessionManager.getBareUserAddress().asUnescapedString();
         File userDirectory = new File(Spark.getSparkUserHome(), "/user/" + bareJID);
         if (!userDirectory.exists()) {
             userDirectory.mkdirs();

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1371,7 +1371,7 @@ moveToOffline(moveToOfflineContactItem);
         boolean handled = chatManager.fireContactItemDoubleClicked(item);
 
         if (!handled) {
-            chatManager.activateChat(item.getJID(), item.getDisplayName());
+            chatManager.activateChat(item.getJid().asUnescapedString(), item.getDisplayName());
         }
 
         clearSelectionList(item);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/history/ConversationHistoryPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/history/ConversationHistoryPlugin.java
@@ -272,7 +272,7 @@ public class ConversationHistoryPlugin implements Plugin {
         final StringBuilder builder = new StringBuilder();
         builder.append("<conversations>");
         for (EntityBareJid user : historyList) {
-            builder.append("<user>").append(user).append("</user>");
+            builder.append("<user>").append(user.asUnescapedString()).append("</user>");
         }
         builder.append("</conversations>");
 


### PR DESCRIPTION
Use unescaped JID to prevent creating files with backslashes in the name.