### PR TITLE
SPARK-2153: Fix private messaging in group chat.

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
@@ -41,6 +41,7 @@ import org.jivesoftware.sparkimpl.plugin.alerts.SparkToaster;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
@@ -67,7 +68,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
      */
     private final List<ChatRoomListener> chatRoomListeners = new ArrayList<>();
     private final List<ChatRoom> chatRoomList = new ArrayList<>();
-    private final Map<EntityBareJid, StanzaListener> presenceMap = new HashMap<>();
+    private final Map<EntityJid, StanzaListener> presenceMap = new HashMap<>();
     private static final String WELCOME_TITLE = SparkRes.getString(SparkRes.WELCOME);
     private ChatFrame chatFrame;
     private final TimerTask focusTask;
@@ -280,7 +281,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
         SparkManager.getConnection().addAsyncStanzaListener(myListener, presenceFilter);
 
         // Add to PresenceMap
-        presenceMap.put(room.getRoomJid(), myListener);
+        presenceMap.put(room.getJid(), myListener);
 
         String tooltip;
         if (room instanceof ChatRoomImpl) {
@@ -529,7 +530,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
             room.closeChatRoom();
         }
 
-        final StanzaListener listener = presenceMap.get(room.getRoomname());
+        final StanzaListener listener = presenceMap.get(room.getJid());
         if (listener != null) {
             SparkManager.getConnection().removeAsyncStanzaListener(listener);
         }
@@ -538,7 +539,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
         room.removeMessageListener(this);
 
         // Remove mappings
-        presenceMap.remove(room.getRoomname());
+        presenceMap.remove(room.getJid());
 
         chatRoomList.remove(room);
 
@@ -583,7 +584,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
         fireChatRoomLeft(room);
         room.leaveChatRoom();
 
-        final StanzaListener listener = presenceMap.get(room.getRoomname());
+        final StanzaListener listener = presenceMap.get(room.getJid());
         if (listener != null && SparkManager.getConnection().isConnected()) {
             SparkManager.getConnection().removeAsyncStanzaListener(listener);
         }
@@ -608,7 +609,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
      * @return the ChatRoom
      * @throws ChatRoomNotFoundException if the room was not found.
      */
-    public ChatRoom getChatRoom(EntityBareJid roomAddress) throws ChatRoomNotFoundException {
+    public ChatRoom getChatRoom(EntityJid roomAddress) throws ChatRoomNotFoundException {
         for (int i = 0; i < getTabCount(); i++) {
             ChatRoom room = null;
             try {
@@ -618,7 +619,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
                 // Ignore
             }
 
-            if (room != null && room.getRoomJid().equals(roomAddress) && room.isActive()) {
+            if (room != null && room.getJid().equals(roomAddress) && room.isActive()) {
                 return room;
             }
         }

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
@@ -41,6 +41,7 @@ import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.EntityJid;
 import org.jxmpp.jid.parts.Resourcepart;
 
 import javax.swing.*;
@@ -925,6 +926,8 @@ public abstract class ChatRoom extends BackgroundPanel implements ActionListener
      * @return the XMPP address of this room
      */
     public abstract EntityBareJid getRoomJid();
+
+    public abstract EntityJid getJid();
 
     /**
      * Get the title to use in the tab holding this ChatRoom.

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
@@ -414,7 +414,7 @@ public class GroupChatParticipantList extends JPanel {
 			Log.debug("Could not find chat room - " + groupJID);
 
 			// Create new room
-			chatRoom = new ChatRoomImpl(groupJID.asEntityBareJid(), nicknameOfUser, roomTitle);
+			chatRoom = new ChatRoomImpl(groupJID, nicknameOfUser, roomTitle);
 			chatManager.getChatContainer().addChatRoom(chatRoom);
 		}
 
@@ -723,7 +723,7 @@ public class GroupChatParticipantList extends JPanel {
 		    if (selectedUser == null) {
 		        return;
 		    }
-		    startChat(groupChatRoom, userMap.get(selectedUser));
+		    startChat(groupChatRoom, userMap.get(Resourcepart.fromOrThrowUnchecked(selectedUser)));
 		}
 	    };
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -430,6 +430,11 @@ public class ChatRoomImpl extends ChatRoom {
         return presence.getFrom().asEntityFullJidOrThrow();
     }
 
+    @Override
+    public EntityJid getJid() {
+        return participantJID;
+    }
+
     /**
      * Process incoming packets.
      *

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
@@ -49,10 +49,7 @@ import org.jivesoftware.spark.util.UIComponentRegistry;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
-import org.jxmpp.jid.DomainBareJid;
-import org.jxmpp.jid.EntityBareJid;
-import org.jxmpp.jid.EntityFullJid;
-import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.*;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.util.XmppStringUtils;
 
@@ -439,7 +436,12 @@ public class GroupChatRoom extends ChatRoom
     {
         return chat.getRoom();
     }
- 
+
+    @Override
+    public EntityJid getJid() {
+        return chat.getRoom();
+    }
+
     /**
      * Retrieve the nickname of the user in this groupchat.
      *
@@ -658,7 +660,7 @@ public class GroupChatRoom extends ChatRoom
         {
             try
             {
-                SparkManager.getChatManager().getChatContainer().getChatRoom( message.getFrom() );
+                SparkManager.getChatManager().getChatContainer().getChatRoom( message.getFrom().asEntityJidOrThrow() );
             }
             catch ( ChatRoomNotFoundException e )
             {
@@ -669,7 +671,7 @@ public class GroupChatRoom extends ChatRoom
                 if ( message.getBody() != null )
                 {
                     // Create new room
-                    ChatRoom chatRoom = new ChatRoomImpl( message.getFrom().asEntityBareJidOrThrow(), userNickname, roomTitle );
+                    ChatRoom chatRoom = new ChatRoomImpl( message.getFrom().asEntityJidOrThrow(), userNickname, roomTitle );
                     SparkManager.getChatManager().getChatContainer().addChatRoom( chatRoom );
 
                     SparkManager.getChatManager().getChatContainer().activateChatRoom( chatRoom );


### PR DESCRIPTION
To address private rooms in a group chat, you need to use full JID instead of bare JID.
[See section 7.5 of XEP-0045: Multi-User Chat](https://xmpp.org/extensions/xep-0045.html#privatemessage)