### PR TITLE
SPARK-2143: Fix behavior of contact list during reconnection

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
@@ -626,6 +626,23 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
         throw new ChatRoomNotFoundException(roomAddress + " not found.");
     }
 
+    public ChatRoom getChatRoom(EntityBareJid bareJid) throws ChatRoomNotFoundException {
+        for (int i = 0; i < getTabCount(); i++) {
+            ChatRoom room = null;
+            try {
+                room = getChatRoom(i);
+            }
+            catch (ChatRoomNotFoundException e1) {
+                // Ignore
+            }
+
+            if (room != null && room.getBareJid().equals(bareJid) && room.isActive()) {
+                return room;
+            }
+        }
+        throw new ChatRoomNotFoundException(bareJid + " not found.");
+    }
+
     /**
      * Returns a ChatRoom in the specified tab location.
      *

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
@@ -265,7 +265,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
         createFrameIfNeeded();
        
         room.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.LIGHT_GRAY));
-        AndFilter presenceFilter = new AndFilter(new StanzaTypeFilter(Presence.class), FromMatchesFilter.createBare( room.getRoomJid()));
+        AndFilter presenceFilter = new AndFilter(new StanzaTypeFilter(Presence.class), FromMatchesFilter.createBare( room.getBareJid()));
 
         // Next, create a packet listener. We use an anonymous inner class for brevity.
         StanzaListener myListener = stanza -> SwingUtilities.invokeLater(() -> {
@@ -291,7 +291,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
             tooltip = "<html><body><b>Contact:&nbsp;</b>" + nickname + "<br><b>JID:&nbsp;</b>" + tooltip;
         }
         else {
-            tooltip = room.getRoomJid().toString();
+            tooltip = room.getBareJid().toString();
         }
 
         // Create ChatRoom UI and dock

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
@@ -913,11 +913,11 @@ public abstract class ChatRoom extends BackgroundPanel implements ActionListener
      * Get the roomname to use for this ChatRoom. This is expected to be a bare jid.
      *
      * @return - the Roomname of this ChatRoom.
-     * @deprecated use {@link #getRoomJid()} instead.
+     * @deprecated use {@link #getBareJid()} instead.
      */
     @Deprecated
     public EntityBareJid getRoomname() {
-        return getRoomJid();
+        return getBareJid();
     }
 
     /**
@@ -925,7 +925,7 @@ public abstract class ChatRoom extends BackgroundPanel implements ActionListener
      *
      * @return the XMPP address of this room
      */
-    public abstract EntityBareJid getRoomJid();
+    public abstract EntityBareJid getBareJid();
 
     public abstract EntityJid getJid();
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactGroup.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactGroup.java
@@ -174,7 +174,7 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
             final ContactItem offlineItem = UIComponentRegistry.createContactItem(alias, nickname, jid);
             offlineItem.setGroupName(getGroupName());
 
-            final Presence offlinePresence = PresenceManager.getPresence(jid);
+            final Presence offlinePresence = new Presence(Presence.Type.unavailable);
             offlineItem.setPresence(offlinePresence);
 
             // set offline icon
@@ -196,7 +196,7 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
                     final ContactItem offlineItem = UIComponentRegistry.createContactItem(alias, nickname, jid);
                     offlineItem.setGroupName(getGroupName());
 
-                    final Presence offlinePresence = PresenceManager.getPresence(jid);
+                    final Presence offlinePresence = new Presence(Presence.Type.unavailable);
                     offlineItem.setPresence(offlinePresence);
 
                     // set offline icon

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -389,12 +389,6 @@ public class ContactList extends JPanel implements ActionListener,
                     TaskEngine.getInstance().schedule(new SwingTimerTask() {
                         @Override
                         public void doRun() {
-                            // Check to see if the user is offline, if so, move them to the offline group.
-                            Presence userPresence = PresenceManager.getPresence(bareJID);
-                            if (userPresence.isAvailable()) {
-                                return;
-                            }
-
                             item.setPresence(presence);
 
                             // Check for ContactItemHandler.

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceUtils.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceUtils.java
@@ -393,7 +393,7 @@ public class ConferenceUtils {
 	public static boolean isChatRoomClosable(Component c) {
 		if(c instanceof GroupChatRoom ) {
 			GroupChatRoom groupChatRoom = (GroupChatRoom) c;
-    		EntityBareJid roomName = groupChatRoom.getChatRoom().getRoomJid();
+    		EntityBareJid roomName = groupChatRoom.getChatRoom().getBareJid();
 
     		if(unclosableChatRooms.contains(roomName)){
     			return false;

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
@@ -397,7 +397,7 @@ public class GroupChatParticipantList extends JPanel {
 	protected void startChat(ChatRoom groupChat, EntityFullJid groupJID) {
 		Resourcepart userNickname = groupJID.getResourcepart();
 		String roomTitle = userNickname + " - "
-				+ groupChat.getRoomJid();
+				+ groupChat.getBareJid();
 
 		// TODO: Remove duplicate variable userNickname and nicknameOfUser.
 		Resourcepart nicknameOfUser = userNickname;

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -361,7 +361,7 @@ public class ChatRoomImpl extends ChatRoom {
     }
 
     @Override
-    public EntityBareJid getRoomJid() {
+    public EntityBareJid getBareJid() {
         return roomname;
     }
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
@@ -432,7 +432,7 @@ public class GroupChatRoom extends ChatRoom
     }
 
     @Override
-    public EntityBareJid getRoomJid()
+    public EntityBareJid getBareJid()
     {
         return chat.getRoom();
     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscriptPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscriptPlugin.java
@@ -192,7 +192,7 @@ public class ChatTranscriptPlugin implements ChatRoomListener {
             return;
         }
 
-        final EntityBareJid jid = room.getRoomJid();
+        final EntityBareJid jid = room.getBareJid();
 
         File transcriptFile = ChatTranscripts.getTranscriptFile(jid);
         if (!transcriptFile.exists()) {
@@ -223,7 +223,7 @@ public class ChatTranscriptPlugin implements ChatRoomListener {
             return;
         }
 
-        final EntityBareJid jid = room.getRoomJid();
+        final EntityBareJid jid = room.getBareJid();
 
         final List<Message> transcripts = room.getTranscripts();
         ChatTranscript transcript = new ChatTranscript();

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/Workpane.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/Workpane.java
@@ -238,7 +238,7 @@ public class Workpane {
                 if (!(room instanceof GroupChatRoom)) {
                     return;
                 }
-                EntityBareJid roomName = room.getRoomJid();
+                EntityBareJid roomName = room.getBareJid();
                 Localpart sessionID = roomName.getLocalpart();
                 if (offerMap.get(sessionID.toString()) != null) {
                     Offer offer = offerMap.get(sessionID.toString());
@@ -248,7 +248,7 @@ public class Workpane {
             }
 
             public void chatRoomClosed(ChatRoom room) {
-                EntityBareJid roomName = room.getRoomJid();
+                EntityBareJid roomName = room.getBareJid();
                 Localpart sessionID = roomName.getLocalpart();
                 offerMap.remove(sessionID.toString());
             }
@@ -263,7 +263,7 @@ public class Workpane {
     }
 
     public void decorateRoom(ChatRoom room, Map metadata) {
-        EntityBareJid roomName = room.getRoomJid();
+        EntityBareJid roomName = room.getBareJid();
         Localpart sessionID =roomName.getLocalpart();
 
 

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/invite/WorkgroupInvitationDialog.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/invite/WorkgroupInvitationDialog.java
@@ -110,7 +110,7 @@ public class WorkgroupInvitationDialog implements PropertyChangeListener {
         final DomainBareJid workgroupService = JidCreate.domainBareFromOrThrowUnchecked("workgroup." + SparkManager.getSessionManager().getServerAddress());
         final EntityFullJid jid = SparkManager.getSessionManager().getJID();
 
-        EntityBareJid room = chatRoom.getRoomJid();
+        EntityBareJid room = chatRoom.getBareJid();
         Collection agents = null;
         try
         {

--- a/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/ChatRoomDecorator.java
+++ b/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/ChatRoomDecorator.java
@@ -85,7 +85,7 @@ public class ChatRoomDecorator
 
     public void finished()
     {
-        Log.warning("ChatRoomDecorator: finished " + room.getRoomJid());
+        Log.warning("ChatRoomDecorator: finished " + room.getBareJid());
     }
 
     private void getUploadUrl(ChatRoom room, Message.Type type)
@@ -129,13 +129,13 @@ public class ChatRoomDecorator
 
         } catch (Exception e) {
             Log.error("uploadFile error", e);
-            broadcastUploadUrl(room.getRoomJid(), file.getName() + " upload failed", type);
+            broadcastUploadUrl(room.getBareJid(), file.getName() + " upload failed", type);
         }
     }
 
     private void uploadFile(File file, UploadRequest response, ChatRoom room, Message.Type type)
     {
-        Log.warning("uploadFile request " + room.getRoomJid() + " " + response.putUrl);
+        Log.warning("uploadFile request " + room.getBareJid() + " " + response.putUrl);
         URLConnection urlconnection = null;
 
         try {
@@ -159,7 +159,7 @@ public class ChatRoomDecorator
 
             if ((statusCode >= 200) && (statusCode <= 202))
             {
-                broadcastUploadUrl(room.getRoomJid(), response.getUrl, type);
+                broadcastUploadUrl(room.getBareJid(), response.getUrl, type);
             }
 
         } catch (Exception e) {

--- a/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/SparkFileUploadPlugin.java
+++ b/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/SparkFileUploadPlugin.java
@@ -102,7 +102,7 @@ public class SparkFileUploadPlugin implements Plugin, ChatRoomListener, GlobalMe
 
     public void chatRoomClosed(ChatRoom chatroom)
     {
-        EntityBareJid roomId = chatroom.getRoomJid();
+        EntityBareJid roomId = chatroom.getBareJid();
 
         Log.debug("chatRoomClosed:  " + roomId);
 
@@ -116,28 +116,28 @@ public class SparkFileUploadPlugin implements Plugin, ChatRoomListener, GlobalMe
 
     public void chatRoomActivated(ChatRoom chatroom)
     {
-        EntityBareJid roomId = chatroom.getRoomJid();
+        EntityBareJid roomId = chatroom.getBareJid();
 
         Log.debug("chatRoomActivated:  " + roomId);
     }
 
     public void userHasJoined(ChatRoom room, String s)
     {
-        EntityBareJid roomId = room.getRoomJid();
+        EntityBareJid roomId = room.getBareJid();
 
         Log.debug("userHasJoined:  " + roomId + " " + s);
     }
 
     public void userHasLeft(ChatRoom room, String s)
     {
-        EntityBareJid roomId = room.getRoomJid();
+        EntityBareJid roomId = room.getBareJid();
 
         Log.debug("userHasLeft:  " + roomId + " " + s);
     }
 
     public void chatRoomOpened(final ChatRoom room)
     {
-        EntityBareJid roomId = room.getRoomJid();
+        EntityBareJid roomId = room.getBareJid();
 
         Log.debug("chatRoomOpened:  " + roomId);
 

--- a/plugins/roar/src/main/java/org/jivesoftware/spark/roar/RoarMessageListener.java
+++ b/plugins/roar/src/main/java/org/jivesoftware/spark/roar/RoarMessageListener.java
@@ -146,20 +146,20 @@ public class RoarMessageListener implements GlobalMessageListener {
 
         if (room.getChatType() == Message.Type.groupchat) {
 
-            if (_rooms.containsKey(room.getRoomJid()) && _rooms.get(room.getRoomJid()) == -1L) {
+            if (_rooms.containsKey(room.getBareJid()) && _rooms.get(room.getBareJid()) == -1L) {
                 return true;
             }
 
-            if (!_rooms.containsKey(room.getRoomJid())) {
-                _rooms.put(room.getRoomJid(), System.currentTimeMillis());
+            if (!_rooms.containsKey(room.getBareJid())) {
+                _rooms.put(room.getBareJid(), System.currentTimeMillis());
                 return true;
             } else {
-                long start = _rooms.get(room.getRoomJid());
+                long start = _rooms.get(room.getBareJid());
                 long now = System.currentTimeMillis();
 
                 result = (now - start) < 1500;
                 if (result) {
-                    _rooms.put(room.getRoomJid(), -1L);
+                    _rooms.put(room.getBareJid(), -1L);
                 }
 
             }
@@ -182,7 +182,7 @@ public class RoarMessageListener implements GlobalMessageListener {
      * @return boolean
      */
     private boolean isMessageFromRoom(ChatRoom room, Message message) {
-        return message.getFrom().equals(room.getRoomJid());
+        return message.getFrom().equals(room.getBareJid());
     }
 
 }


### PR DESCRIPTION
Contact list behavior corrected according to items no. 2, 3 and 5 of [ilyaHlevnoy feedback](https://discourse.igniterealtime.org/t/spark-2-9-0-after-reconnecting-some-users-change-their-status-to-red/88485/12?u=r87a).
No change of contact's status to offline in the dialog box when the user lost the connection (item no. 1 of feedback) seems to be another issue, that shoud be reported.
Item no. 4 of feedback - I could not understand what it was about :). 
Also fixed one-on-one chats broken during [SPARK-2153](https://issues.igniterealtime.org/browse/SPARK-2153) fix.