### PR TITLE
SPARK-2175: Fix offline message handling after a reconnect

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ChatManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/ChatManager.java
@@ -211,19 +211,23 @@ public class ChatManager {
     /**
      * Creates and/or opens a chat room with the specified user.
      *
-     * @param userJID  the jid of the user to chat with.
+     * @param jid  the jid of the user to chat with.
      * @param nicknameCs the nickname to use for the user.
      * @param title    the title to use for the room.
      * @return the newly created <code>ChatRoom</code>.
      */
-    public ChatRoom createChatRoom(EntityJid userJID, CharSequence nicknameCs, CharSequence title) {
+    public ChatRoom createChatRoom(EntityJid jid, CharSequence nicknameCs, CharSequence title) {
         Resourcepart nickname = Resourcepart.fromOrThrowUnchecked(nicknameCs);
         ChatRoom chatRoom;
         try {
-            chatRoom = getChatContainer().getChatRoom(userJID);
+            if (jid instanceof EntityBareJid) {
+                chatRoom = getChatContainer().getChatRoom((EntityBareJid) jid);
+            } else {
+                chatRoom = getChatContainer().getChatRoom(jid);
+            }
         }
         catch (ChatRoomNotFoundException e) {
-            chatRoom = UIComponentRegistry.createChatRoom(userJID, nickname, title);
+            chatRoom = UIComponentRegistry.createChatRoom(jid, nickname, title);
             getChatContainer().addChatRoom(chatRoom);
         }
 

--- a/core/src/main/java/org/jivesoftware/spark/Workspace.java
+++ b/core/src/main/java/org/jivesoftware/spark/Workspace.java
@@ -402,26 +402,32 @@ public class Workspace extends JPanel implements StanzaListener {
         if (bareJID == null) {
             return;
         }
-        ContactItem contact = contactList.getContactItemByJID(bareJID);
-        String nickname = bareJID.getLocalpartOrNull() == null ? null : bareJID.getLocalpartOrNull().toString();
-        if (contact != null) {
-            nickname = contact.getDisplayName();
+
+        // Create the room if it does not exist.;
+        try {
+            ChatManager.getInstance().getChatContainer().getChatRoom(bareJID);
+        } catch (ChatRoomNotFoundException e) {
+            String nickname;
+            ContactItem contact = contactList.getContactItemByJID(bareJID);
+            if (contact != null) {
+                nickname = contact.getDisplayName();
+            } else {
+                nickname = bareJID.getLocalpartOrNull() == null ? null : bareJID.getLocalpartOrNull().toString();
+            }
+
+            ChatRoom room = SparkManager.getChatManager().createChatRoom(bareJID, nickname, nickname);
+            if (!SparkManager.getChatManager().getChatContainer().getChatFrame().isVisible()) {
+                SparkManager.getChatManager().getChatContainer().getChatFrame().setVisible(true);
+            }
+
+            // Insert offline message
+            room.getTranscriptWindow().insertMessage(nickname, message, ChatManager.FROM_COLOR);
+            room.addToTranscript(message, true);
+
+            // Send display and notified message back.
+            SparkManager.getMessageEventManager().sendDeliveredNotification(message.getFrom(), message.getStanzaId());
+            SparkManager.getMessageEventManager().sendDisplayedNotification(message.getFrom(), message.getStanzaId());
         }
-
-        // Create the room if it does not exist.
-        ChatRoom room = SparkManager.getChatManager().createChatRoom(bareJID, nickname, nickname);
-        if(!SparkManager.getChatManager().getChatContainer().getChatFrame().isVisible())
-        {
-            SparkManager.getChatManager().getChatContainer().getChatFrame().setVisible(true);
-        }
-
-        // Insert offline message
-        room.getTranscriptWindow().insertMessage(nickname, message, ChatManager.FROM_COLOR);
-        room.addToTranscript(message, true);
-
-        // Send display and notified message back.
-        SparkManager.getMessageEventManager().sendDeliveredNotification(message.getFrom(), message.getStanzaId());
-        SparkManager.getMessageEventManager().sendDisplayedNotification(message.getFrom(), message.getStanzaId());
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
@@ -605,11 +605,11 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
     /**
      * Returns a ChatRoom by name.
      *
-     * @param roomAddress the name of the ChatRoom.
+     * @param jid the name of the ChatRoom.
      * @return the ChatRoom
      * @throws ChatRoomNotFoundException if the room was not found.
      */
-    public ChatRoom getChatRoom(EntityJid roomAddress) throws ChatRoomNotFoundException {
+    public ChatRoom getChatRoom(EntityJid jid) throws ChatRoomNotFoundException {
         for (int i = 0; i < getTabCount(); i++) {
             ChatRoom room = null;
             try {
@@ -619,28 +619,13 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
                 // Ignore
             }
 
-            if (room != null && room.getJid().equals(roomAddress) && room.isActive()) {
-                return room;
+            if (jid instanceof EntityBareJid) {
+                if (room != null && room.getBareJid().equals(jid) && room.isActive()) return room;
+            } else {
+                if (room != null && room.getJid().equals(jid) && room.isActive()) return room;
             }
         }
-        throw new ChatRoomNotFoundException(roomAddress + " not found.");
-    }
-
-    public ChatRoom getChatRoom(EntityBareJid bareJid) throws ChatRoomNotFoundException {
-        for (int i = 0; i < getTabCount(); i++) {
-            ChatRoom room = null;
-            try {
-                room = getChatRoom(i);
-            }
-            catch (ChatRoomNotFoundException e1) {
-                // Ignore
-            }
-
-            if (room != null && room.getBareJid().equals(bareJid) && room.isActive()) {
-                return room;
-            }
-        }
-        throw new ChatRoomNotFoundException(bareJid + " not found.");
+        throw new ChatRoomNotFoundException(jid + " not found.");
     }
 
     /**


### PR DESCRIPTION
This prevents new tab creation for chat room that has already been opened. [SPARK-2175](https://issues.igniterealtime.org/browse/SPARK-2175)
