### PR TITLE
SPARK-2177: Fix own presence state during and after a reconnection

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/SessionManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/SessionManager.java
@@ -152,6 +152,8 @@ public final class SessionManager implements ConnectionListener {
             final Presence presence = new Presence(Presence.Type.unavailable);
             changePresence(presence);
 
+            Workspace.getInstance().getStatusBar().setStatusPanelEnabled(false);
+
             Log.debug("Connection closed on error.: " + ex.getMessage());
         } );
     }
@@ -299,6 +301,8 @@ public final class SessionManager implements ConnectionListener {
             {
                 changePresence( preError );
                 preError = null;
+
+                Workspace.getInstance().getStatusBar().setStatusPanelEnabled(true);
             });
         }
     }

--- a/core/src/main/java/org/jivesoftware/spark/SessionManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/SessionManager.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.spark;
 
+import org.jivesoftware.resource.Res;
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.smack.provider.ProviderManager;
@@ -150,6 +151,7 @@ public final class SessionManager implements ConnectionListener {
         SwingUtilities.invokeLater( () -> {
             preError = Workspace.getInstance().getStatusBar().getPresence();
             final Presence presence = new Presence(Presence.Type.unavailable);
+            presence.setStatus(Res.getString("status.offline"));
             changePresence(presence);
 
             Workspace.getInstance().getStatusBar().setStatusPanelEnabled(false);

--- a/core/src/main/java/org/jivesoftware/spark/ui/status/StatusBar.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/status/StatusBar.java
@@ -548,6 +548,10 @@ public class StatusBar extends JPanel implements VCardListener {
 		return nicknameLabel;
 	}
 
+	public void setStatusPanelEnabled(Boolean enabled) {
+	    getStatusPanel().setEnabled(enabled);
+    }
+
 	private class StatusPanel extends JPanel {
 		private static final long serialVersionUID = -5086334443225239032L;
 		private JLabel iconLabel;
@@ -586,11 +590,13 @@ public class StatusBar extends JPanel implements VCardListener {
 				statusLabel.addMouseListener(new MouseAdapter() {
 					@Override
 					public void mouseReleased(MouseEvent e) {
-						showPopup(e);
+						if (!isEnabled()) return;
+					    showPopup(e);
 					}
 
 					@Override
 					public void mouseEntered(MouseEvent e) {
+                        if (!isEnabled()) return;
 						setCursor(GraphicUtils.HAND_CURSOR);
 						setBorder(BorderFactory.createBevelBorder(0));
 					}
@@ -603,6 +609,7 @@ public class StatusBar extends JPanel implements VCardListener {
 
 					@Override
 					public void mousePressed(MouseEvent e) {
+                        if (!isEnabled()) return;
 						setBorder(BorderFactory.createBevelBorder(1));
 					}
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/idle/UserIdlePlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/idle/UserIdlePlugin.java
@@ -144,6 +144,8 @@ public class UserIdlePlugin extends TimerTask implements Plugin {
 	public void run() {
 		if (pref.isIdleOn()) {
 
+		    if (!SparkManager.getConnection().isConnected()) return;
+
 			// Windows Desktop Lock
 			if (Spark.isWindows()) {
 				if (IsLocked && !hasChanged) {


### PR DESCRIPTION
- Prevent automatic status change to away/offline during reconnection
- Disable manual status change during reconnection
- Add offline status text to the status panel

Issue ticket: [SPARK-2177](https://issues.igniterealtime.org/browse/SPARK-2177)