### PR TITLE
SPARK-1160: Replace usage of deprecated methods with alternatives and delete methods themselves

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ChatManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/ChatManager.java
@@ -238,30 +238,11 @@ public class ChatManager {
      * Returns the <code>ChatRoom</code> for the giving jid. If the ChatRoom is not found,
      * a new ChatRoom will be created.
      *
-     * @param jid the jid of the user to chat with.
-     * @return the ChatRoom.
-     * @deprecated use {@link #getChatRoom(BareJid)} instead.
-     */
-    @Deprecated
-    public ChatRoom getChatRoom(String jid) {
-        BareJid mucAddress;
-        try {
-            mucAddress = JidCreate.bareFrom(jid);
-        } catch (XmppStringprepException e) {
-            throw new IllegalStateException(e);
-        }
-        return getChatRoom(mucAddress);
-    }
-
-    /**
-     * Returns the <code>ChatRoom</code> for the giving jid. If the ChatRoom is not found,
-     * a new ChatRoom will be created.
-     *
-     * @param jid the jid of the user to chat with.
+     * @param bareJid the jid of the user to chat with.
+     * @param bareJid
      * @return the ChatRoom.
      */
-    public ChatRoom getChatRoom(BareJid bareJid) {
-        // TODO: Change signature of method to use EntityBareJid.
+    public ChatRoom getChatRoom(EntityBareJid bareJid) {
         EntityBareJid jid = bareJid.asEntityBareJidOrThrow();
         ChatRoom chatRoom;
         try {

--- a/core/src/main/java/org/jivesoftware/spark/ChatManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/ChatManager.java
@@ -197,7 +197,7 @@ public class ChatManager {
         for (ChatRoom chatRoom : getChatContainer().getChatRooms()) {
             if (chatRoom instanceof GroupChatRoom) {
                 GroupChatRoom groupChat = (GroupChatRoom)chatRoom;
-                if (groupChat.getRoomname().equals(roomName)) {
+                if (groupChat.getBareJid().equals(roomName)) {
                     return groupChat;
                 }
             }

--- a/core/src/main/java/org/jivesoftware/spark/PresenceManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/PresenceManager.java
@@ -146,11 +146,11 @@ public class PresenceManager {
     /**
      * Returns the presence of a user.
      *
-     * @param jidString the users jid.
+     * @param jid the users JID.
      * @return the users presence.
      */
     public static Presence getPresence(BareJid jid) {
-        if (jid.equals(SparkManager.getSessionManager().getBareAddress())) {
+        if (jid.equals(SparkManager.getSessionManager().getUserBareAddress())) {
             return SparkManager.getWorkspace().getStatusBar().getPresence();
         } else {
             final Roster roster = Roster.getInstanceFor( SparkManager.getConnection() );

--- a/core/src/main/java/org/jivesoftware/spark/SessionManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/SessionManager.java
@@ -28,7 +28,6 @@ import org.jivesoftware.sparkimpl.plugin.manager.Features;
 import org.jxmpp.jid.DomainBareJid;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
-import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.util.XmppStringUtils;
 
 import javax.swing.SwingUtilities;
@@ -260,24 +259,12 @@ public final class SessionManager implements ConnectionListener {
     }
 
     /**
-     * Returns the users bare address. A bare-address is the address without a resource (ex. derek@jivesoftware.com/spark would
+     * Returns the users bare JID. A bare-JID is the JID without a resource (ex. derek@jivesoftware.com/spark would
      * be derek@jivesoftware.com)
      *
-     * @return the users bare address.
-     * @deprecated use {@link #getBareUserAddress()} instead.
+     * @return the users bare JID.
      */
-    @Deprecated
-    public String getBareAddress() {
-        return userBareAddress.toString();
-    }
-
-    /**
-     * Returns the users bare address. A bare-address is the address without a resource (ex. derek@jivesoftware.com/spark would
-     * be derek@jivesoftware.com)
-     *
-     * @return the users bare address.
-     */
-    public EntityBareJid getBareUserAddress() {
+    public EntityBareJid getUserBareAddress() {
         return userBareAddress;
     }
 

--- a/core/src/main/java/org/jivesoftware/spark/SparkManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/SparkManager.java
@@ -356,7 +356,7 @@ public final class SparkManager {
      * @return the UserDirectory for Spark.
      */
     public static File getUserDirectory() {
-        final String bareJID = sessionManager.getBareUserAddress().asUnescapedString();
+        final String bareJID = sessionManager.getUserBareAddress().asUnescapedString();
         File userDirectory = new File(Spark.getSparkUserHome(), "/user/" + bareJID);
         if (!userDirectory.exists()) {
             userDirectory.mkdirs();

--- a/core/src/main/java/org/jivesoftware/spark/UserManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/UserManager.java
@@ -284,20 +284,6 @@ public class UserManager {
         return new ArrayList<>();
     }
 
-    /**
-     * @deprecated use {@link #getUserNicknameFromJID(BareJid)} instead.
-     */
-    @Deprecated
-    public String getUserNicknameFromJID(CharSequence jid) {
-        BareJid bareJid;
-        try {
-            bareJid = JidCreate.bareFrom(jid);
-        } catch (XmppStringprepException e) {
-            throw new IllegalStateException(e);
-        }
-        return getUserNicknameFromJID(bareJid);
-    }
-
     public String getUserNicknameFromJID(BareJid jid) {
         ContactList contactList = SparkManager.getWorkspace().getContactList();
         ContactItem item = contactList.getContactItemByJID(jid);

--- a/core/src/main/java/org/jivesoftware/spark/UserManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/UserManager.java
@@ -399,9 +399,9 @@ public class UserManager {
         for (ContactGroup contactGroup : contactList.getContactGroups()) {
             contactGroup.clearSelection();
             for (ContactItem contactItem : contactGroup.getContactItems()) {
-                if (!contactMap.containsKey(contactItem.getJID())) {
+                if (!contactMap.containsKey(contactItem.getJid().toString())) {
                     contacts.add(contactItem);
-                    contactMap.put(contactItem.getJID(), contactItem);
+                    contactMap.put(contactItem.getJid().toString(), contactItem);
                 }
             }
         }
@@ -433,7 +433,7 @@ public class UserManager {
                             parent.setGlassPane(glassPane);
                             parent.getGlassPane().setVisible(false);
                             contactField.dispose();
-                            SparkManager.getChatManager().activateChat(item.getJID(), item.getDisplayName());
+                            SparkManager.getChatManager().activateChat(item.getJid(), item.getDisplayName());
                         }
                     }
 

--- a/core/src/main/java/org/jivesoftware/spark/UserManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/UserManager.java
@@ -226,7 +226,7 @@ public class UserManager {
      * @return the Occupant found.
      */
     public Occupant getOccupant(GroupChatRoom groupChatRoom, Resourcepart nickname) {
-        EntityFullJid userJID = JidCreate.entityFullFrom(groupChatRoom.getRoomname(), nickname);
+        EntityFullJid userJID = JidCreate.entityFullFrom(groupChatRoom.getBareJid(), nickname);
         Occupant occ = null;
         try {
             occ = groupChatRoom.getMultiUserChat().getOccupant(userJID);

--- a/core/src/main/java/org/jivesoftware/spark/component/JContactItemField.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/JContactItemField.java
@@ -67,7 +67,7 @@ public class JContactItemField extends JPanel {
                 {
                     final ContactItem item = (ContactItem)getModel().getElementAt(row);
                     if (item != null) {
-                        return item.getJID();
+                        return item.getJid().toString();
                 }
                 }
                 return null;

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatContainer.java
@@ -847,7 +847,7 @@ public class ChatContainer extends SparkTabbedPane implements MessageListener, C
 	public String toString() {
         StringBuilder buf = new StringBuilder();
         for (ChatRoom room : chatRoomList) {
-            buf.append("Roomname=").append(room.getRoomname()).append("\n");
+            buf.append("Roomname=").append(room.getBareJid()).append("\n");
         }
         return buf.toString();
     }

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
@@ -42,6 +42,7 @@ import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.EntityJid;
+import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 
 import javax.swing.*;
@@ -605,8 +606,8 @@ public abstract class ChatRoom extends BackgroundPanel implements ActionListener
      */
     public void addToTranscript(String to, String from, String body, Date date) {
         final Message newMessage = new Message();
-        newMessage.setTo(to);
-        newMessage.setFrom(from);
+        newMessage.setTo(JidCreate.fromOrThrowUnchecked(to));
+        newMessage.setFrom(JidCreate.fromOrThrowUnchecked(from));
         newMessage.setBody(body);
         final Map<String, Object> properties = new HashMap<>();
         properties.put( "date", new Date() );

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
@@ -910,17 +910,6 @@ public abstract class ChatRoom extends BackgroundPanel implements ActionListener
     public abstract Icon getTabIcon();
 
     /**
-     * Get the roomname to use for this ChatRoom. This is expected to be a bare jid.
-     *
-     * @return - the Roomname of this ChatRoom.
-     * @deprecated use {@link #getBareJid()} instead.
-     */
-    @Deprecated
-    public EntityBareJid getRoomname() {
-        return getBareJid();
-    }
-
-    /**
      * Get the XMPP address of this room.
      *
      * @return the XMPP address of this room

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatRoom.java
@@ -459,7 +459,7 @@ public abstract class ChatRoom extends BackgroundPanel implements ActionListener
                 }
                 else
                 {
-                    username = re.getUser().substring( 0, re.getUser().indexOf( '@' ) );
+                    username = re.getJid().toString().substring( 0, re.getJid().toString().indexOf( '@' ) );
                 }
 
                 if ( username.toLowerCase().startsWith( needle.toLowerCase() ) )

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactGroup.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactGroup.java
@@ -1064,7 +1064,7 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
         ContactInfoWindow contact = UIComponentRegistry.getContactInfoWindow();
         int loc = getList().locationToIndex(e.getPoint());
         ContactItem item = (ContactItem) getList().getModel().getElementAt(loc);
-        return item == null || contact == null || contact.getContactItem() == null ? true : !contact.getContactItem().getJID().equals(item.getJID());
+        return item == null || contact == null || contact.getContactItem() == null ? true : !contact.getContactItem().getJid().equals(item.getJid());
     }
 
     protected DefaultListModel getModel() {

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactGroupTransferHandler.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactGroupTransferHandler.java
@@ -124,7 +124,7 @@ public class ContactGroupTransferHandler extends TransferHandler {
                     if (o instanceof java.util.Collection) {
                         Collection<File> files = (Collection<File>)o;
                         ContactItem source = (ContactItem)list.getSelectedValue();
-                        if (source == null || source.getJID() == null) {
+                        if (source == null || source.getJid() == null) {
                             return false;
                         }
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
@@ -176,7 +176,7 @@ public class ContactInfoWindow extends JPanel {
 
 
         ContactItem item = (ContactItem)group.getList().getModel().getElementAt(loc);
-        if (item == null || item.getJID() == null) {
+        if (item == null || item.getJid() == null) {
             return;
         }
 
@@ -280,13 +280,10 @@ public class ContactInfoWindow extends JPanel {
         Transport transport = TransportUtils.getTransport(contactItem.getJid().asDomainBareJid());
         if (transport != null) {
             fullJIDLabel.setIcon(transport.getIcon());
-            String name = XmppStringUtils.parseLocalpart(contactItem.getJID());
-            name = XmppStringUtils.unescapeLocalpart(name);
-            fullJIDLabel.setText(transport.getName() + " - " + name);
+            fullJIDLabel.setText(transport.getName() + " - " + contactItem.getJid().getLocalpartOrThrow().asUnescapedString());
         }
         else {
-            String name = XmppStringUtils.unescapeLocalpart(contactItem.getJID());
-            fullJIDLabel.setText(name);
+            fullJIDLabel.setText(contactItem.getJid().getLocalpartOrThrow().asUnescapedString());
             fullJIDLabel.setIcon(null);
         }
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
@@ -277,7 +277,7 @@ public class ContactInfoWindow extends JPanel {
         }
         statusLabel.setText(status);
 
-        Transport transport = TransportUtils.getTransport( XmppStringUtils.parseDomain(contactItem.getJID()));
+        Transport transport = TransportUtils.getTransport(contactItem.getJid().asDomainBareJid());
         if (transport != null) {
             fullJIDLabel.setIcon(transport.getIcon());
             String name = XmppStringUtils.parseLocalpart(contactItem.getJID());

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactItem.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactItem.java
@@ -245,18 +245,6 @@ public class ContactItem extends JPanel {
     }
 
     /**
-     * Returns the fully qualified JID of the contact. (If available). Otherwise will
-     * return the bare jid.
-     *
-     * @return the fully qualified jid (ex. derek@jivesoftware.com).
-     * @deprecated use {@link #getJid()} instead.
-     */
-    @Deprecated
-    public String getJID() {
-        return getJid().toString();
-    }
-
-    /**
      * Return the XMPP address, aka. JID< of this contact item.
      *
      * @return the XMPP address of this item.
@@ -476,14 +464,7 @@ public class ContactItem extends JPanel {
             getNicknameLabel().setFont(new Font("Dialog", Font.PLAIN, fontSize));
             getNicknameLabel().setForeground((Color)UIManager.get("ContactItemOffline.color"));
 
-            BareJid bareJid;
-            try {
-                bareJid = JidCreate.bareFrom(getJID());
-            } catch (XmppStringprepException e) {
-                throw new IllegalStateException(e);
-            }
-
-            RosterEntry entry = Roster.getInstanceFor( SparkManager.getConnection() ).getEntry(bareJid);
+            RosterEntry entry = Roster.getInstanceFor( SparkManager.getConnection() ).getEntry(getJid());
             if (entry != null && (entry.getType() == RosterPacket.ItemType.none || entry.getType() == RosterPacket.ItemType.from)
                     && entry.isSubscriptionPending()) {
                 // Do not move out of group.

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1621,7 +1621,7 @@ public class ContactList extends JPanel implements ActionListener,
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                String jid = item.getJID();
+                BareJid jid = item.getJid();
                 Presence response = new Presence(Presence.Type.subscribe);
                 response.setTo(jid);
 
@@ -1708,7 +1708,7 @@ public class ContactList extends JPanel implements ActionListener,
             final Map<String, Message> broadcastMessages = new HashMap<>();
             for (ContactItem item : items) {
                 final Message message = new Message();
-                message.setTo(item.getJID());
+                message.setTo(item.getJid());
                 final Map<String, Object> properties = new HashMap<>();
                 properties.put("broadcast", true);
                 message.addExtension(new JivePropertiesExtension(properties));

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1603,7 +1603,7 @@ public class ContactList extends JPanel implements ActionListener,
                     JOptionPane.showMessageDialog(getGUI(), Res.getString("message.idle.for", time), Res.getString("title.last.activity"), JOptionPane.INFORMATION_MESSAGE);
                 } catch (Exception e1) {
                     UIManager.put("OptionPane.okButtonText", Res.getString("ok"));
-                    JOptionPane.showMessageDialog(getGUI(), Res.getString("message.unable.to.retrieve.last.activity", item.getJID()), Res.getString("title.error"), JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(getGUI(), Res.getString("message.unable.to.retrieve.last.activity", item.getJid()), Res.getString("title.error"), JOptionPane.ERROR_MESSAGE);
                 }
 
             }
@@ -1713,9 +1713,9 @@ public class ContactList extends JPanel implements ActionListener,
                 properties.put("broadcast", true);
                 message.addExtension(new JivePropertiesExtension(properties));
                 message.setBody(messageText);
-                if (!broadcastMessages.containsKey(item.getJID())) {
+                if (!broadcastMessages.containsKey(item.getJid().toString())) {
                     buf.append(item.getDisplayName()).append("\n");
-                    broadcastMessages.put(item.getJID(), message);
+                    broadcastMessages.put(item.getJid().toString(), message);
                 }
             }
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/RosterPickList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/RosterPickList.java
@@ -141,7 +141,7 @@ public class RosterPickList extends JPanel {
         for (int i = 0; i < no; i++) {
             try {
                 ContactItem item = (ContactItem)values[i];
-                selectedContacts.add(item.getJID());
+                selectedContacts.add(item.getJid().toString());
             }
             catch (NullPointerException e) {
                 Log.error(e);

--- a/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/TranscriptWindow.java
@@ -500,7 +500,7 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener
                     {
                         ChatManager manager = SparkManager.getChatManager();
                         ChatRoom room = manager.getChatContainer().getActiveChatRoom();
-                        user = room.getRoomname().toString();
+                        user = room.getBareJid().toString();
 
                         int ok = JOptionPane.showConfirmDialog( (TranscriptWindow) object,
                                                                 Res.getString( "delete.permanently" ),
@@ -537,7 +537,7 @@ public class TranscriptWindow extends ChatArea implements ContextMenuListener
         			try
         			{
         				room = SparkManager.getChatManager().getChatContainer().getActiveChatRoom();
-        				HistoryWindow hw = new HistoryWindow( SparkManager.getUserDirectory(), room.getRoomname().toString() );
+        				HistoryWindow hw = new HistoryWindow( SparkManager.getUserDirectory(), room.getBareJid().toString() );
         				hw.showWindow();
         			}
         			catch ( Exception ex )

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/AnswerFormDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/AnswerFormDialog.java
@@ -126,7 +126,7 @@ public class AnswerFormDialog {
      */
     private void sendAnswerForm(Form answer, MultiUserChat chat) {
 	
-	ChatRoom room = SparkManager.getChatManager().getChatRoom(chat.getRoom().toString()); 
+	ChatRoom room = SparkManager.getChatManager().getChatRoom(chat.getRoom());
 	
 	for (String key : _map.keySet()) {
 	    String value = getValueFromComponent(key);

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceRoomBrowser.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceRoomBrowser.java
@@ -882,7 +882,7 @@ public class ConferenceRoomBrowser extends JPanel implements ActionListener,
 		}
 
 		List<String> owners = new ArrayList<>();
-		owners.add(SparkManager.getSessionManager().getBareUserAddress().toString());
+		owners.add(SparkManager.getSessionManager().getUserBareAddress().toString());
 		form.setAnswer("muc#roomconfig_roomowners", owners);
 
 		// new DataFormDialog(groupChat, form);

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceUtils.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceUtils.java
@@ -326,7 +326,7 @@ public class ConferenceUtils {
 
         // Check if room already is open
         try {
-            chatManager.getChatContainer().getChatRoom(room.getRoomname());
+            chatManager.getChatContainer().getChatRoom(room.getBareJid());
         }
         catch (ChatRoomNotFoundException e) {
             chatManager.getChatContainer().addChatRoom(room);

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceUtils.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceUtils.java
@@ -312,7 +312,7 @@ public class ConferenceUtils {
             submitForm.setAnswer("muc#roomconfig_roomname", roomName);
 
             final List<String> owners = new ArrayList<>();
-            owners.add(SparkManager.getSessionManager().getBareAddress());
+            owners.add(SparkManager.getSessionManager().getUserBareAddress().toString());
             submitForm.setAnswer("muc#roomconfig_roomowners", owners);
 
             multiUserChat.sendConfigurationForm(submitForm);

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConversationInvitation.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConversationInvitation.java
@@ -99,7 +99,7 @@ public class ConversationInvitation extends JPanel implements ContainerComponent
         final JLabel dateLabelValue = new JLabel();
 
 
-        String nickname = SparkManager.getUserManager().getUserNicknameFromJID(inviter);
+        String nickname = SparkManager.getUserManager().getUserNicknameFromJID(this.inviter);
 
 
         add(titleLabel, new GridBagConstraints(0, 0, 4, 1, 1.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL, new Insets(2, 5, 2, 5), 0, 0));

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
@@ -157,7 +157,7 @@ public class GroupChatParticipantList extends JPanel {
 	chat = groupChatRoom.getMultiUserChat();
 
 	chat.addInvitationRejectionListener( ( jid1, reason, message, rejection ) -> {
-    String nickname = userManager.getUserNicknameFromJID( jid1.toString() );
+    String nickname = userManager.getUserNicknameFromJID(jid1);
 
     userHasLeft(nickname);
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/InvitationDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/InvitationDialog.java
@@ -330,7 +330,7 @@ final class InvitationDialog extends JPanel {
                 for (ChatRoom chatRoom : chatManager.getChatContainer().getChatRooms()) {
                     if (chatRoom instanceof GroupChatRoom) {
                         GroupChatRoom groupRoom = (GroupChatRoom) chatRoom;
-                        if (groupRoom.getRoomname().equals(roomTitle)) {
+                        if (groupRoom.getBareJid().equals(roomTitle)) {
                             roomName = groupRoom.getMultiUserChat().getRoom();
                             break;
                         }

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -48,10 +48,8 @@ import org.jivesoftware.sparkimpl.profile.VCardManager;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.*;
-import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Localpart;
 import org.jxmpp.jid.parts.Resourcepart;
-import org.jxmpp.stringprep.XmppStringprepException;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -124,7 +122,7 @@ public class ChatRoomImpl extends ChatRoom {
     public ChatRoomImpl(final EntityJid participantJID, Resourcepart participantNickname, CharSequence title, boolean initUi) {
         this.active = true;
         //activateNotificationTime = System.currentTimeMillis();
-        setparticipantJID(participantJID);
+        setParticipantJID(participantJID);
         this.participantNickname = participantNickname;
 
         // Loads the current history for this user.
@@ -197,21 +195,9 @@ public class ChatRoomImpl extends ChatRoom {
     /**
      * Set the XMPP address of the participant.
      *
-     * @param jidString the XMPP address
-     * @deprecated use {@link #setparticipantJID(Jid)} instead.
+     * @param jid the XMPP address
      */
-    @Deprecated
-    private void setparticipantJID(String jidString) {
-        EntityJid jid;
-        try {
-            jid = JidCreate.entityFrom(jidString);
-        } catch (XmppStringprepException e) {
-            throw new IllegalStateException(e);
-        }
-        setparticipantJID(jid);
-    }
-
-    private void setparticipantJID(Jid jid) {
+    private void setParticipantJID(Jid jid) {
         if (!jid.isEntityJid()) {
             return;
         }
@@ -549,13 +535,13 @@ public class ChatRoomImpl extends ChatRoom {
                             if ( carbon.getDirection() == CarbonExtension.Direction.received )
                             {
                                 // This is a stanza that we received from someone on one of our other clients.
-                                setparticipantJID(forwardedStanza.getFrom());
+                                setParticipantJID(forwardedStanza.getFrom());
                                 insertMessage( forwardedStanza );
                             }
                             else
                             {
                                 // This is a stanza that one of our own clients sent.
-                                setparticipantJID(forwardedStanza.getTo());
+                                setParticipantJID(forwardedStanza.getTo());
                                 displaySendMessage( forwardedStanza );
                             }
                             showTyping( false );
@@ -564,7 +550,7 @@ public class ChatRoomImpl extends ChatRoom {
                     else if ( message.getBody() != null )
                     {
                         // If the message is not from the current agent. Append to chat.
-                        setparticipantJID(message.getFrom());
+                        setParticipantJID(message.getFrom());
                         insertMessage( message );
 
                         showTyping( false );
@@ -611,7 +597,7 @@ public class ChatRoomImpl extends ChatRoom {
         getTranscriptWindow().insertMessage(participantNickname, message, ChatManager.FROM_COLOR);
 
         // Set the participant jid to their full JID.
-        setparticipantJID(message.getFrom());
+        setParticipantJID(message.getFrom());
     }
 
     private void checkEvents(Jid from, String packetID, MessageEvent messageEvent) {

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -138,7 +138,7 @@ public class ChatRoomImpl extends ChatRoom {
         );
 
         final StanzaFilter carbonFilter = new AndFilter(
-            FromMatchesFilter.create( SparkManager.getSessionManager().getBareUserAddress() ), // Security Consideration, see https://xmpp.org/extensions/xep-0280.html#security
+            FromMatchesFilter.create( SparkManager.getSessionManager().getUserBareAddress() ), // Security Consideration, see https://xmpp.org/extensions/xep-0280.html#security
             new StanzaTypeFilter( Message.class ),
             new OrFilter(
                 new StanzaExtensionFilter( "sent", CarbonExtension.NAMESPACE ),
@@ -798,7 +798,7 @@ public class ChatRoomImpl extends ChatRoom {
     			String messageBody = message.getBody();
     			if (nickname.equals(message.getFrom().toString()) || nickname.equals(message.getFrom().asBareJid().toString())) {
     				BareJid otherJID = message.getFrom().asBareJid();
-    				EntityBareJid myJID = SparkManager.getSessionManager().getBareUserAddress();
+    				EntityBareJid myJID = SparkManager.getSessionManager().getUserBareAddress();
 
     				if (otherJID.equals(myJID)) {
     					nickname = personalNickname;

--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/GroupChatRoom.java
@@ -420,17 +420,6 @@ public class GroupChatRoom extends ChatRoom
         lastActivity = System.currentTimeMillis();
     }
 
-    /**
-     * Return name of the room specified when the room was created.
-     *
-     * @return the roomname.
-     */
-    @Override
-    public EntityBareJid getRoomname()
-    {
-        return chat.getRoom();
-    }
-
     @Override
     public EntityBareJid getBareJid()
     {
@@ -665,7 +654,7 @@ public class GroupChatRoom extends ChatRoom
             catch ( ChatRoomNotFoundException e )
             {
                 final Resourcepart userNickname = message.getFrom().getResourceOrEmpty();
-                final String roomTitle = userNickname + " - " + getRoomname();
+                final String roomTitle = userNickname + " - " + getBareJid();
 
                 // Check to see if this is a message notification.
                 if ( message.getBody() != null )

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastDialog.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastDialog.java
@@ -373,7 +373,7 @@ Log.warning( "Unable to broadcast.", e1 );
         
         for (String jid : jids) {
             final Message message = new Message();
-            String nickname = SparkManager.getUserManager().getUserNicknameFromJID(jid);
+            String nickname = SparkManager.getUserManager().getUserNicknameFromJID(JidCreate.bareFromOrThrowUnchecked(jid));
             recipients.add(nickname);
             message.setTo(JidCreate.fromOrThrowUnchecked(jid));
             message.setBody(text);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastDialog.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastDialog.java
@@ -98,13 +98,13 @@ public class BroadcastDialog extends JPanel {
         for(ContactGroup group : contactList.getContactGroups())
 	        for (ContactItem item : group.getContactItems()) 
 	        {
-	      	  if(item.isAvailable() && !onlineJIDs.contains(item.getJID()))
+	      	  if(item.isAvailable() && !onlineJIDs.contains(item.getJid().toString()))
 	      	  {
 	           CheckNode itemNode = new CheckNode(item.getDisplayName(), false, item.getIcon());
-	           itemNode.setAssociatedObject(item.getJID());
+	           itemNode.setAssociatedObject(item.getJid().toString());
 	           groupNode.add(itemNode);
 	           nodes.add(itemNode);
-	           onlineJIDs.add(item.getJID());
+	           onlineJIDs.add(item.getJid().toString());
 	      	  }
 	        }
 	        
@@ -122,7 +122,7 @@ public class BroadcastDialog extends JPanel {
             // Now add contact items from contact group.
             for (ContactItem item : group.getContactItems()) {
                 CheckNode itemNode = new CheckNode(item.getDisplayName(), false, item.getIcon());
-                itemNode.setAssociatedObject(item.getJID());
+                itemNode.setAssociatedObject(item.getJid().toString());
                 groupNode.add(itemNode);
                 nodes.add(itemNode);
             }
@@ -132,7 +132,7 @@ public class BroadcastDialog extends JPanel {
 
             for (ContactItem item : offlineContacts) {
                 CheckNode itemNode = new CheckNode(item.getDisplayName(), false, item.getIcon());
-                itemNode.setAssociatedObject(item.getJID());
+                itemNode.setAssociatedObject(item.getJid().toString());
                 groupNode.add(itemNode);
                 nodes.add(itemNode);
             }
@@ -173,7 +173,7 @@ public class BroadcastDialog extends JPanel {
             // Iterate through selected users.
             for (ContactItem item : selectedUsers) {
                 for (CheckNode node : nodes) {
-                    if (node.getAssociatedObject().toString().equals(item.getJID())) {
+                    if (node.getAssociatedObject().toString().equals(item.getJid().toString())) {
                         node.setSelected(true);
                     }
                 }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastDialog.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastDialog.java
@@ -61,6 +61,7 @@ import org.jivesoftware.spark.ui.ContactList;
 import org.jivesoftware.spark.util.ModelUtil;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.plugin.layout.LayoutSettingsManager;
+import org.jxmpp.jid.impl.JidCreate;
 
 /**
  * Allows for better selective broadcasting.
@@ -374,7 +375,7 @@ Log.warning( "Unable to broadcast.", e1 );
             final Message message = new Message();
             String nickname = SparkManager.getUserManager().getUserNicknameFromJID(jid);
             recipients.add(nickname);
-            message.setTo(jid);
+            message.setTo(JidCreate.fromOrThrowUnchecked(jid));
             message.setBody(text);
             
             if (normalMessageButton.isSelected()) {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastPlugin.java
@@ -136,7 +136,7 @@ public class BroadcastPlugin extends SparkTabHandler implements Plugin, StanzaLi
             Iterator<ContactItem> selectedUsersIterator = selectedUsers.iterator();
             if (selectedUsersIterator.hasNext()) {
                 ContactItem contactItem = selectedUsersIterator.next();
-                selectedUser = contactItem.getJID();
+                selectedUser = contactItem.getJid().toString();
             }
 
             UIManager.put("OptionPane.okButtonText", Res.getString("ok"));

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/chat/PresenceChangePlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/chat/PresenceChangePlugin.java
@@ -43,6 +43,7 @@ import org.jivesoftware.sparkimpl.plugin.alerts.SparkToaster;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.BareJid;
+import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.util.XmppStringUtils;
 
@@ -172,13 +173,13 @@ if (localPref.getShowToasterPopup()) {
                                     @Override
                                     public void actionPerformed( ActionEvent e )
                                     {
-                                        SparkManager.getChatManager().getChatRoom( jid );
+                                        SparkManager.getChatManager().getChatRoom( jid.asEntityBareJidOrThrow() );
                                     }
                                 } );
                             } );
 }
 
-ChatRoom room = SparkManager.getChatManager().getChatRoom(jid);
+ChatRoom room = SparkManager.getChatManager().getChatRoom(jid.asEntityBareJidOrThrow());
 
 if (localPref.getWindowTakesFocus())
 {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/chat/PresenceChangePlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/chat/PresenceChangePlugin.java
@@ -104,7 +104,7 @@ public class PresenceChangePlugin implements Plugin {
 			public void poppingUp(Object object, JPopupMenu popup) {
                 if (object instanceof ContactItem) {
                     ContactItem item = (ContactItem)object;
-                    String bareAddress = XmppStringUtils.parseBareJid(item.getJID());
+                    BareJid bareAddress = item.getJid();
                     if (!item.getPresence().isAvailable() || item.getPresence().isAway()) {
                         if (sparkContacts.contains(bareAddress)) {
                             popup.add(removeAction);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/gateways/GatewayPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/gateways/GatewayPlugin.java
@@ -239,7 +239,7 @@ public class GatewayPlugin implements Plugin, ContactItemHandler {
             }
             else if (stanza instanceof Message) {
                 Message message = (Message)stanza;
-                String from = message.getFrom().toString();
+                DomainBareJid from = message.getFrom().asDomainBareJid();
                 boolean hasError = message.getType() == Message.Type.error;
                 String body = message.getBody();
 
@@ -264,8 +264,8 @@ public class GatewayPlugin implements Plugin, ContactItemHandler {
             for (ContactItem contactItem : contactGroup.getContactItems()) {
                 Presence presence = contactItem.getPresence();
                 if (presence.isAvailable()) {
-                    Domainpart domain = presence.getFrom().getDomain();
-                    Transport transport = TransportUtils.getTransport(domain.toString());
+                    DomainBareJid domain = presence.getFrom().asDomainBareJid();
+                    Transport transport = TransportUtils.getTransport(domain);
                     if (transport != null) {
                         handlePresence(contactItem, presence);
                         contactGroup.fireContactGroupUpdated();
@@ -301,8 +301,8 @@ public class GatewayPlugin implements Plugin, ContactItemHandler {
     @Override
 	public boolean handlePresence(ContactItem item, Presence presence) {
         if (presence.isAvailable()) {
-            Domainpart domain = presence.getFrom().getDomain();
-            Transport transport = TransportUtils.getTransport(domain.toString());
+            DomainBareJid domain = presence.getFrom().asDomainBareJid();
+            Transport transport = TransportUtils.getTransport(domain);
             if (transport != null) {
                 if (presence.getType() == Presence.Type.available) {
                     item.setSpecialIcon(transport.getIcon());

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/gateways/transports/TransportUtils.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/gateways/transports/TransportUtils.java
@@ -113,18 +113,11 @@ public class TransportUtils {
 
     /**
      * 
-     * @param serviceName
+     * @param address
      * @param transport
-     * @deprecated use {@link #addTransport(DomainBareJid, Transport)} instead.
      */
-    @Deprecated
-    public static void addTransport(String serviceName, Transport transport) {
-        DomainBareJid transportAddress = JidCreate.domainBareFromOrThrowUnchecked(serviceName);
-         addTransport(transportAddress, transport);
-    }
-
-    public static void addTransport(DomainBareJid transportAddress, Transport transport) {
-        transports.put(transportAddress, transport);
+    public static void addTransport(DomainBareJid address, Transport transport) {
+        transports.put(address, transport);
     }
 
     public static Collection<Transport> getTransports() {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/gateways/transports/TransportUtils.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/gateways/transports/TransportUtils.java
@@ -93,16 +93,9 @@ public class TransportUtils {
 
     /**
      * 
-     * @param serviceName
+     * @param transportAddress
      * @return
-     * @deprecated use {@link #getTransport(DomainBareJid)} instead.
      */
-    @Deprecated
-    public static Transport getTransport(String serviceName) {
-        DomainBareJid transportAddress = JidCreate.domainBareFromOrThrowUnchecked(serviceName);
-        return getTransport(transportAddress);
-    }
-
     public static Transport getTransport(DomainBareJid transportAddress) {
         // Return transport.
         return transports.get(transportAddress);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/history/FrequentContactsPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/history/FrequentContactsPlugin.java
@@ -22,6 +22,7 @@ import org.jivesoftware.spark.plugin.Plugin;
 import org.jivesoftware.spark.ui.ContactItem;
 import org.jivesoftware.spark.ui.ContactList;
 import org.jivesoftware.spark.util.GraphicUtils;
+import org.jxmpp.jid.impl.JidCreate;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -109,7 +110,7 @@ public class FrequentContactsPlugin implements Plugin {
 		    String user = jidMap.get(label);
 		    if (user != null) {
 			final String contactUsername = SparkManager
-				.getUserManager().getUserNicknameFromJID(user);
+				.getUserManager().getUserNicknameFromJID(JidCreate.bareFromOrThrowUnchecked(user));
 			SparkManager.getChatManager().activateChat(user,
 				contactUsername);
 			window.dispose();
@@ -125,7 +126,7 @@ public class FrequentContactsPlugin implements Plugin {
                     final JLabel label = (JLabel) contacts.getSelectedValue();
                     String user = jidMap.get(label);
                     if (user != null) {
-                        final String contactUsername = SparkManager.getUserManager().getUserNicknameFromJID(user);
+                        final String contactUsername = SparkManager.getUserManager().getUserNicknameFromJID(JidCreate.bareFromOrThrowUnchecked(user));
                         SparkManager.getChatManager().activateChat(user, contactUsername);
                         window.dispose();
                     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/VersionViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/VersionViewer.java
@@ -28,6 +28,8 @@ import org.jivesoftware.spark.UserManager;
 import org.jivesoftware.spark.component.MessageDialog;
 import org.jivesoftware.spark.util.ResourceUtils;
 import org.jivesoftware.spark.util.log.Log;
+import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.impl.JidCreate;
 
 import javax.swing.*;
 
@@ -40,7 +42,9 @@ public class VersionViewer {
 
     }
 
-    public static void viewVersion(String jid) {
+    public static void viewVersion(String jidString) {
+        final Jid jid = JidCreate.fromOrThrowUnchecked(jidString);
+
         final JPanel loadingCard = new JPanel();
         final ImageIcon icon = new ImageIcon( VersionViewer.class.getClassLoader().getResource( "images/ajax-loader.gif"));
         loadingCard.add(new JLabel("loading... ", icon, JLabel.CENTER));
@@ -122,7 +126,7 @@ public class VersionViewer {
             ((CardLayout)(cards.getLayout())).last( cards );
         }
 
-        MessageDialog.showComponent(Res.getString("title.version.and.time"), Res.getString("message.client.information", UserManager.unescapeJID(jid)), SparkRes.getImageIcon(SparkRes.PROFILE_IMAGE_24x24), cards, SparkManager.getMainWindow(), 400, 300, false);
+        MessageDialog.showComponent(Res.getString("title.version.and.time"), Res.getString("message.client.information", UserManager.unescapeJID(jidString)), SparkRes.getImageIcon(SparkRes.PROFILE_IMAGE_24x24), cards, SparkManager.getMainWindow(), 400, 300, false);
     }
 
 }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/PrivacyPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/PrivacyPlugin.java
@@ -104,13 +104,13 @@ public class PrivacyPlugin implements Plugin {
                             final ContactItem item = (ContactItem) object;
                             JMenuItem blockMenu;
 
-                            if (activeList.isBlockedItem(item.getJID())) {
+                            if (activeList.isBlockedItem(item.getJid().toString())) {
                                 blockMenu = new JMenuItem(Res.getString("menuitem.unblock.contact"), SparkRes.getImageIcon(SparkRes.UNBLOCK_CONTACT_16x16));
                                 blockMenu.addActionListener( ae -> {
                                     if (item != null) {
                                         try
                                         {
-                                            activeList.removeItem( item.getJID());
+                                            activeList.removeItem( item.getJid().toString());
                                             activeList.save();
                                         }
                                         catch ( SmackException.NotConnectedException e )
@@ -123,7 +123,7 @@ public class PrivacyPlugin implements Plugin {
                                 blockMenu = new JMenuItem(Res.getString("menuitem.block.contact"), SparkRes.getImageIcon(SparkRes.BLOCK_CONTACT_16x16));
                                 blockMenu.addActionListener( ae -> {
                                     if (item != null) {
-                                        PrivacyItem pItem = new PrivacyItem(Type.jid, item.getJID(), false, activeList.getNewItemOrder());
+                                        PrivacyItem pItem = new PrivacyItem(Type.jid, item.getJid().toString(), false, activeList.getNewItemOrder());
                                         pItem.setFilterMessage(true);
                                         pItem.setFilterPresenceOut(true);
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/list/PrivacyPresenceHandler.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/list/PrivacyPresenceHandler.java
@@ -22,34 +22,11 @@ import org.jxmpp.stringprep.XmppStringprepException;
  */
 
 public class PrivacyPresenceHandler implements SparkPrivacyItemListener {
-
-  
-
     /**
      * Send Unavailable (offline status) to jid .
      * 
-     * @param jid
-     *            JID to send offline status
-     * @deprecated use {#link {@link #sendUnavailableTo(Jid)}} instead. 
-     */
-    @Deprecated
-    public void sendUnavailableTo(String jidString) throws SmackException.NotConnectedException
-    {
-        Jid jid;
-        try {
-            jid = JidCreate.from(jidString);
-        } catch (XmppStringprepException e) {
-            throw new IllegalStateException(e);
-        }
-        sendUnavailableTo(jid);
-    }
-
-    /**
-     * Send Unavailable (offline status) to jid .
-     * 
-     * @param jid
-     *            JID to send offline status
-     * @throws InterruptedException 
+     * @param jid the JID to send offline status
+     * @throws SmackException.NotConnectedException if Spark is not connected
      */
     public void sendUnavailableTo(Jid jid) throws SmackException.NotConnectedException
     {
@@ -65,32 +42,13 @@ public class PrivacyPresenceHandler implements SparkPrivacyItemListener {
     /**
      * Send my presence for user
      * 
-     * @param jidString
-     *            JID to send presence
-     * @deprecated use {@link #sendRealPresenceTo(Jid)} instead.
-     */
-    @Deprecated
-    public void sendRealPresenceTo(String jidString) throws SmackException.NotConnectedException
-    {
-        Jid jid;
-        try {
-            jid = JidCreate.from(jidString);
-        } catch (XmppStringprepException e) {
-            throw new IllegalStateException(e);
-        }
-        sendUnavailableTo(jid);
-    }
-    
-    /**
-     * Send my presence for user
-     * 
-     * @param jid
-     *            JID to send presence
+     * @param jid the JID to send presence
+     * @throws SmackException.NotConnectedException if Spark is not connected
      */
     public void sendRealPresenceTo(Jid jid) throws SmackException.NotConnectedException
     {
         Presence presence = SparkManager.getWorkspace().getStatusBar().getPresence(); 
-        Presence pack = new Presence(presence.getType(), presence.getStatus(), 1, presence.getMode()); 
+        Presence pack = new Presence(presence.getType(), presence.getStatus(), 1, presence.getMode());
         pack.setTo(jid);
         try {
             SparkManager.getConnection().sendStanza(pack);
@@ -102,31 +60,34 @@ public class PrivacyPresenceHandler implements SparkPrivacyItemListener {
     public void setIconsForList(SparkPrivacyList list) throws SmackException.NotConnectedException
     {
         for (PrivacyItem pItem : list.getPrivacyItems()) {
-            if (pItem.getType().equals(PrivacyItem.Type.jid)) {
-                setBlockedIconToContact(pItem.getValue());
-                if (pItem.isFilterPresenceOut()) {
-                    sendUnavailableTo(pItem.getValue());
-                }
-            }
-
-            if (pItem.getType().equals(PrivacyItem.Type.group)) {
-                ContactGroup group = SparkManager.getWorkspace().getContactList().getContactGroup(pItem.getValue());
-                for (ContactItem citem : group.getContactItems()) {
-                    setBlockedIconToContact(citem.getJID());
-                    if (pItem.isFilterPresenceOut()) {
-                        sendUnavailableTo(citem.getJID());
-                    }
-                }
-
-            }
-
+            setIconsForItem(pItem);
         }
         SparkManager.getContactList().updateUI();
     }
 
-    private void setBlockedIconToContact(CharSequence cs) {
-        Jid jid = JidCreate.fromOrThrowUnchecked(cs);
-        setBlockedIconToContact(jid);
+    private void setIconsForItem(PrivacyItem item) throws SmackException.NotConnectedException {
+        if (item.getType().equals(PrivacyItem.Type.jid)) {
+            Jid jid;
+            try {
+                jid = JidCreate.from(item.getValue());
+            } catch (XmppStringprepException e) {
+                throw new IllegalStateException(e);
+            }
+            setBlockedIconToContact(jid);
+            if (item.isFilterPresenceOut()) {
+                sendUnavailableTo(jid);
+            }
+        }
+
+        if (item.getType().equals(PrivacyItem.Type.group)) {
+            ContactGroup group = SparkManager.getWorkspace().getContactList().getContactGroup(item.getValue());
+            for (ContactItem contact : group.getContactItems()) {
+                setBlockedIconToContact(contact.getJid());
+                if (item.isFilterPresenceOut()) {
+                    sendUnavailableTo(contact.getJid());
+                }
+            }
+        }
     }
 
     private void setBlockedIconToContact(Jid jid) {
@@ -141,30 +102,34 @@ public class PrivacyPresenceHandler implements SparkPrivacyItemListener {
     public void removeIconsForList(SparkPrivacyList list) throws SmackException.NotConnectedException
     {
         for (PrivacyItem pItem : list.getPrivacyItems()) {
-            if (pItem.getType().equals(PrivacyItem.Type.jid)) {
-                removeBlockedIconFromContact(pItem.getValue());
-                if (pItem.isFilterPresenceOut()) {
-                    sendRealPresenceTo(pItem.getValue());
-                }
-            }
-
-            if (pItem.getType().equals(PrivacyItem.Type.group)) {
-                ContactGroup group = SparkManager.getWorkspace().getContactList().getContactGroup(pItem.getValue());
-                for (ContactItem citem : group.getContactItems()) {
-                    removeBlockedIconFromContact(citem.getJid());
-                    if (pItem.isFilterPresenceOut()) {
-                        sendRealPresenceTo(citem.getJid());
-                    }
-                }
-            }
-
+            removeIconsForItem(pItem);
         }
         SparkManager.getContactList().updateUI();
     }
 
-    private void removeBlockedIconFromContact(CharSequence cs) {
-        Jid jid = JidCreate.fromOrThrowUnchecked(cs);
-        removeBlockedIconFromContact(jid);
+    private void removeIconsForItem(PrivacyItem item) throws SmackException.NotConnectedException {
+        if (item.getType().equals(PrivacyItem.Type.jid)) {
+            Jid jid;
+            try {
+                jid = JidCreate.from(item.getValue());
+            } catch (XmppStringprepException e) {
+                throw new IllegalStateException(e);
+            }
+            removeBlockedIconFromContact(jid);
+            if (item.isFilterPresenceOut()) {
+                sendRealPresenceTo(jid);
+            }
+        }
+
+        if (item.getType().equals(PrivacyItem.Type.group)) {
+            ContactGroup group = SparkManager.getWorkspace().getContactList().getContactGroup(item.getValue());
+            for (ContactItem contact : group.getContactItems()) {
+                removeBlockedIconFromContact(contact.getJid());
+                if (item.isFilterPresenceOut()) {
+                    sendRealPresenceTo(contact.getJid());
+                }
+            }
+        }
     }
 
     private void removeBlockedIconFromContact(Jid jid) {
@@ -174,60 +139,23 @@ public class PrivacyPresenceHandler implements SparkPrivacyItemListener {
                 item.setSpecialIcon(null);
             }
         }
-
     }
 
     @Override
-    public void itemAdded(PrivacyItem item, String listname) throws SmackException.NotConnectedException
+    public void itemAdded(PrivacyItem item, String listName) throws SmackException.NotConnectedException
     {
-        PrivacyManager pmanager = PrivacyManager.getInstance();
-        if (pmanager.getPrivacyList(listname).isActive()) {
-            if (item.getType().equals(PrivacyItem.Type.jid)) {
-                setBlockedIconToContact(item.getValue());
-                if (item.isFilterPresenceOut()) {
-                    sendUnavailableTo(item.getValue());
-                }
-            }
-
-            if (item.getType().equals(PrivacyItem.Type.group)) {
-                ContactGroup group = SparkManager.getWorkspace().getContactList().getContactGroup(item.getValue());
-                for (ContactItem citem : group.getContactItems()) {
-                    setBlockedIconToContact(citem.getJID());
-                    if (item.isFilterPresenceOut()) {
-                        sendUnavailableTo(citem.getJID());
-                    }
-                }
-
-            }
+        if (PrivacyManager.getInstance().getPrivacyList(listName).isActive()) {
+            setIconsForItem(item);
             SparkManager.getContactList().updateUI();
         }
     }
 
     @Override
-    public void itemRemoved(PrivacyItem item, String listname) throws SmackException.NotConnectedException
+    public void itemRemoved(PrivacyItem item, String listName) throws SmackException.NotConnectedException
     {
-        PrivacyManager pmanager = PrivacyManager.getInstance();
-        if (pmanager.getPrivacyList(listname).isActive()) {
-            if (item.getType().equals(PrivacyItem.Type.jid)) {
-                removeBlockedIconFromContact(item.getValue());
-                if (item.isFilterPresenceOut()) {
-                    sendRealPresenceTo(item.getValue());
-                }
-            }
-
-            if (item.getType().equals(PrivacyItem.Type.group)) {
-                ContactGroup group = SparkManager.getWorkspace().getContactList().getContactGroup(item.getValue());
-                for (ContactItem citem : group.getContactItems()) {
-                    removeBlockedIconFromContact(citem.getJID());
-                    if (item.isFilterPresenceOut()) {
-                        sendRealPresenceTo(citem.getJID());
-                    }
-                }
-
-            }
+        if (PrivacyManager.getInstance().getPrivacyList(listName).isActive()) {
+            removeIconsForItem(item);
             SparkManager.getContactList().updateUI();
         }
-
     }
-
 }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/ui/PrivacyAddDialogUI.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/ui/PrivacyAddDialogUI.java
@@ -222,7 +222,7 @@ public class PrivacyAddDialogUI extends JPanel {
                 ContactItem item = (ContactItem) values[i];
 
                 PrivacyItem.Type type = _showGroups ? PrivacyItem.Type.group : PrivacyItem.Type.jid;
-                PrivacyItem pitem = new PrivacyItem(type, item.getJID(), false, 999);
+                PrivacyItem pitem = new PrivacyItem(type, item.getJid().toString(), false, 999);
                 pitem.setFilterIQ(_blockIQ.isSelected());
                 pitem.setFilterMessage(_blockMsg.isSelected());
                 pitem.setFilterPresenceIn(_blockPIn.isSelected());

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/HistoryTranscript.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/HistoryTranscript.java
@@ -196,7 +196,7 @@ public class HistoryTranscript extends SwingWorker {
 				BareJid otherJID = message
 						.getFrom().asBareJid();
 				EntityBareJid myJID = SparkManager.getSessionManager()
-						.getBareUserAddress();
+						.getUserBareAddress();
 
 				if (otherJID.equals(myJID)) {
 					nickname = personalNickname;
@@ -207,7 +207,7 @@ public class HistoryTranscript extends SwingWorker {
 			}
 
 			if (!from.asBareJid().equals(
-					SparkManager.getSessionManager().getBareUserAddress())) {
+					SparkManager.getSessionManager().getUserBareAddress())) {
 				color = "red";
 			}
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferencePanel.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferencePanel.java
@@ -81,7 +81,7 @@ public class LocalPreferencePanel extends JPanel {
 			if (!_savePasswordBox.isSelected()) {
 				_autoLoginBox.setSelected(false);
 				try {
-					preferences.clearPasswordForUser(SparkManager.getSessionManager().getBareAddress());
+					preferences.clearPasswordForUser(SparkManager.getSessionManager().getUserBareAddress().toString());
 				} catch (Exception e1) {
 					Log.debug("Unable to clear saved password..." + e1);
 				}

--- a/core/src/main/java/org/jivesoftware/sparkimpl/updater/CheckUpdates.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/updater/CheckUpdates.java
@@ -42,6 +42,7 @@ import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.settings.JiveInfo;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
+import org.jxmpp.jid.impl.JidCreate;
 
 import javax.swing.JEditorPane;
 import javax.swing.JFrame;
@@ -565,7 +566,7 @@ public class CheckUpdates {
     {
         SparkVersion request = new SparkVersion();
         request.setType(IQ.Type.get);
-        request.setTo("updater." + connection.getXMPPServiceDomain());
+        request.setTo(JidCreate.fromOrThrowUnchecked("updater." + connection.getXMPPServiceDomain()));
 
         // TODO: This should not use stanza collectors but simply createStanzaCollectorAndSend(IQ).nextResultOrThrow();
         StanzaCollector collector = connection.createStanzaCollector(new IQReplyFilter( request, connection ));

--- a/core/src/main/java/org/jivesoftware/sparkimpl/updater/CheckUpdates.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/updater/CheckUpdates.java
@@ -581,7 +581,7 @@ public class CheckUpdates {
         }
 
         if (response == null) {
-            throw SmackException.NoResponseException.newWith( connection, collector );
+            throw SmackException.NoResponseException.newWith(connection, collector.getStanzaFilter());
         }
         XMPPException.XMPPErrorException.ifHasErrorThenThrow( response );
 

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/assistants/CoBrowser.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/assistants/CoBrowser.java
@@ -379,7 +379,7 @@ public class CoBrowser extends JPanel implements ActionListener, BrowserListener
     private void send(Message message) {
         GroupChatRoom groupChatRoom = (GroupChatRoom)chatRoom;
         try {
-            message.setTo(groupChatRoom.getRoomname());
+            message.setTo(groupChatRoom.getBareJid());
             message.setType(Message.Type.groupchat);
             MessageEventManager.addNotificationsRequests(message, true, true, true, true);
 

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/AgentConversations.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/AgentConversations.java
@@ -325,7 +325,7 @@ public final class AgentConversations extends JPanel implements ChangeListener {
                                     while (iter.hasNext()) {
                                         Affiliate affilitate = (Affiliate)iter.next();
                                         Jid jid = affilitate.getJid();
-                                        if (!jid.equals(SparkManager.getSessionManager().getBareUserAddress())) {
+                                        if (!jid.equals(SparkManager.getSessionManager().getUserBareAddress())) {
                                             list.add(jid);
                                         }
                                     }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/ChatHistory.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/ChatHistory.java
@@ -140,7 +140,7 @@ public class ChatHistory extends JPanel {
 
 
         agentSession = FastpathPlugin.getAgentSession();
-        EntityBareJid jid = SparkManager.getSessionManager().getBareUserAddress();
+        EntityBareJid jid = SparkManager.getSessionManager().getUserBareAddress();
         try {
             history = agentSession.getAgentHistory(jid, 10, null);
         }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/CurrentActivity.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/CurrentActivity.java
@@ -274,7 +274,7 @@ public final class CurrentActivity extends JPanel {
                                     while (iter.hasNext()) {
                                         Affiliate affilitate = (Affiliate)iter.next();
                                         Jid jid = affilitate.getJid();
-                                        if (!jid.equals(SparkManager.getSessionManager().getBareUserAddress())) {
+                                        if (!jid.equals(SparkManager.getSessionManager().getUserBareAddress())) {
                                             list.add(jid);
                                         }
                                     }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/InvitationPane.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/InvitationPane.java
@@ -271,7 +271,7 @@ public class InvitationPane {
             while (iter.hasNext()) {
                 Affiliate affilitate = (Affiliate)iter.next();
                 Jid jid = affilitate.getJid();
-                if (!jid.equals(SparkManager.getSessionManager().getBareUserAddress())) {
+                if (!jid.equals(SparkManager.getSessionManager().getUserBareAddress())) {
                     list.add(jid);
                 }
             }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/UserInvitationPane.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/UserInvitationPane.java
@@ -334,7 +334,7 @@ public class UserInvitationPane {
             while (iter.hasNext()) {
                 Affiliate affilitate = iter.next();
                 Jid jid = affilitate.getJid();
-                if (!jid.equals(SparkManager.getSessionManager().getBareUserAddress())) {
+                if (!jid.equals(SparkManager.getSessionManager().getUserBareAddress())) {
                     list.add(jid);
                 }
             }

--- a/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/ChatRoomDecorator.java
+++ b/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/ChatRoomDecorator.java
@@ -41,6 +41,7 @@ import org.apache.commons.httpclient.protocol.Protocol;
 
 import org.jivesoftware.sparkimpl.updater.EasySSLProtocolSocketFactory;
 
+import org.jxmpp.jid.impl.JidCreate;
 import sun.misc.BASE64Decoder;
 
 public class ChatRoomDecorator
@@ -113,7 +114,7 @@ public class ChatRoomDecorator
         }
         try {
             UploadRequest request = new UploadRequest(fileName, file.length());
-            request.setTo("httpfileupload." + SparkManager.getSessionManager().getServerAddress());
+            request.setTo(JidCreate.fromOrThrowUnchecked("httpfileupload." + SparkManager.getSessionManager().getServerAddress()));
             request.setType(IQ.Type.get);
 
             IQ result = SparkManager.getConnection().createStanzaCollectorAndSend(request).nextResultOrThrow();

--- a/plugins/growl/src/main/java/com/jivesoftware/spark/plugin/growl/GrowlTalker.java
+++ b/plugins/growl/src/main/java/com/jivesoftware/spark/plugin/growl/GrowlTalker.java
@@ -19,6 +19,8 @@ import com.google.code.jgntp.*;
 import org.jivesoftware.spark.SparkManager;
 import org.jivesoftware.spark.ui.ChatRoom;
 import org.jivesoftware.spark.util.log.Log;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.util.XmppStringUtils;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -120,8 +122,8 @@ public class GrowlTalker implements GntpListener
     public void onClickCallback( GntpNotification notification )
     {
         Log.debug( "Callback clicked: " + notification );
-        final String jid = XmppStringUtils.parseBareJid( (String) notification.getContext() );
-        final ChatRoom room = SparkManager.getChatManager().getChatRoom( jid );
+        final EntityBareJid jid = JidCreate.entityBareFromOrThrowUnchecked( (String) notification.getContext() );
+        final ChatRoom room = SparkManager.getChatManager().getChatRoom(jid);
         SparkManager.getChatManager().getChatContainer().activateChatRoom( room );
         SparkManager.getChatManager().getChatContainer().requestFocusInWindow();
     }

--- a/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/ChatRoomDecorator.java
+++ b/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/ChatRoomDecorator.java
@@ -52,7 +52,7 @@ public class ChatRoomDecorator
             ImageIcon ofmeetIcon = new ImageIcon(imageByte);
             ofmeetButton = new RolloverButton(ofmeetIcon);
             ofmeetButton.setToolTipText(GraphicUtils.createToolTip("Pade Meetings"));
-            final String roomId = getNode(room.getRoomname().toString());
+            final String roomId = getNode(room.getBareJid().toString());
             final String sessionID = roomId + "-" + System.currentTimeMillis();
             final String nickname = getNode(XmppStringUtils.parseBareAddress(SparkManager.getSessionManager().getJID().toString()));
 
@@ -86,7 +86,7 @@ public class ChatRoomDecorator
 
     public void finished()
     {
-        Log.warning("ChatRoomDecorator: finished " + room.getRoomname());
+        Log.warning("ChatRoomDecorator: finished " + room.getBareJid());
     }
 
     private String getNode(String jid)

--- a/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
+++ b/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
@@ -428,7 +428,7 @@ public class SparkMeetPlugin implements Plugin, ChatRoomListener, GlobalMessageL
     private void sendInvite(ChatRoom room, String url, Message.Type type)
     {
         Message message2 = new Message();
-        message2.setTo(room.getBareJid().toString());
+        message2.setTo(room.getBareJid());
         message2.setType(type);
         message2.setBody(url);
         room.sendMessage(message2);

--- a/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
+++ b/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
@@ -262,7 +262,7 @@ public class SparkMeetPlugin implements Plugin, ChatRoomListener, GlobalMessageL
 
     public void chatRoomClosed(ChatRoom chatroom)
     {
-        String roomId = chatroom.getRoomname().toString();
+        String roomId = chatroom.getBareJid().toString();
 
         Log.warning("chatRoomClosed:  " + roomId);
 
@@ -283,28 +283,28 @@ public class SparkMeetPlugin implements Plugin, ChatRoomListener, GlobalMessageL
 
     public void chatRoomActivated(ChatRoom chatroom)
     {
-        String roomId = chatroom.getRoomname().toString();
+        String roomId = chatroom.getBareJid().toString();
 
         Log.warning("chatRoomActivated:  " + roomId);
     }
 
     public void userHasJoined(ChatRoom room, String s)
     {
-        String roomId = room.getRoomname().toString();
+        String roomId = room.getBareJid().toString();
 
         Log.warning("userHasJoined:  " + roomId + " " + s);
     }
 
     public void userHasLeft(ChatRoom room, String s)
     {
-        String roomId = room.getRoomname().toString();
+        String roomId = room.getBareJid().toString();
 
         Log.warning("userHasLeft:  " + roomId + " " + s);
     }
 
     public void chatRoomOpened(final ChatRoom room)
     {
-        String roomId = room.getRoomname().toString();
+        String roomId = room.getBareJid().toString();
 
         Log.warning("chatRoomOpened:  " + roomId);
 
@@ -428,7 +428,7 @@ public class SparkMeetPlugin implements Plugin, ChatRoomListener, GlobalMessageL
     private void sendInvite(ChatRoom room, String url, Message.Type type)
     {
         Message message2 = new Message();
-        message2.setTo(room.getRoomname().toString());
+        message2.setTo(room.getBareJid().toString());
         message2.setType(type);
         message2.setBody(url);
         room.sendMessage(message2);

--- a/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
+++ b/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
@@ -114,7 +114,7 @@ public class SparkMeetPlugin implements Plugin, ChatRoomListener, GlobalMessageL
     public void messageReceived(ChatRoom room, Message message) {
 
         try {
-            Localpart roomId = room.getRoomJid().getLocalpart();
+            Localpart roomId = room.getJid().getLocalpart();
             String body = message.getBody();
             int pos = body.indexOf("https://");
 

--- a/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiPlugin.java
+++ b/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiPlugin.java
@@ -148,7 +148,7 @@ public class ReversiPlugin implements Plugin {
         // Got an offer to start a new game. So, make sure that a chat is
         // started with the other
         // user and show an invite panel.
-        final ChatRoom room = SparkManager.getChatManager().getChatRoom( invitation.getFrom().asBareJid() );
+        final ChatRoom room = SparkManager.getChatManager().getChatRoom( invitation.getFrom().asEntityBareJidOrThrow() );
 
         inviteAlert = new JPanel();
         inviteAlert.setLayout(new BorderLayout());

--- a/plugins/roar/src/main/java/org/jivesoftware/spark/roar/displaytype/RoarPopupHelper.java
+++ b/plugins/roar/src/main/java/org/jivesoftware/spark/roar/displaytype/RoarPopupHelper.java
@@ -24,7 +24,7 @@ public final class RoarPopupHelper {
      * @return nickname
      */
     public static String getNickname(ChatRoom room, Message message) {
-        String nickname = SparkManager.getUserManager().getUserNicknameFromJID(message.getFrom());
+        String nickname = SparkManager.getUserManager().getUserNicknameFromJID(message.getFrom().asBareJid());
         if (room.getChatType() == Message.Type.groupchat) {
             nickname = message.getFrom().getResourceOrEmpty().toString();
         }

--- a/plugins/tictactoe/src/main/java/tic/tac/toe/TicTacToePlugin.java
+++ b/plugins/tictactoe/src/main/java/tic/tac/toe/TicTacToePlugin.java
@@ -230,7 +230,7 @@ public class TicTacToePlugin implements Plugin {
 	invitation.setTo(invitation.getFrom());
 	
 	
-	final ChatRoom room = SparkManager.getChatManager().getChatRoom( invitation.getFrom().asBareJid());
+	final ChatRoom room = SparkManager.getChatManager().getChatRoom( invitation.getFrom().asEntityBareJidOrThrow());
 	
 	Localpart name = invitation.getFrom().getLocalpartOrThrow();
 	

--- a/plugins/tictactoe/src/main/java/tic/tac/toe/ui/GamePanel.java
+++ b/plugins/tictactoe/src/main/java/tic/tac/toe/ui/GamePanel.java
@@ -112,7 +112,7 @@ public class GamePanel extends JPanel {
 			message.addExtension(inval);
 			_connection.sendStanza(message);
 			
-			ChatRoom cr = SparkManager.getChatManager().getChatRoom( _opponent.asBareJid());
+			ChatRoom cr = SparkManager.getChatManager().getChatRoom( _opponent.asEntityBareJid());
 			cr.getTranscriptWindow().insertCustomText(_opponent+"seems to be cheating\n"+
 				"He tried placing a wrong Move", true, false, Color.red);
 			
@@ -129,7 +129,7 @@ public class GamePanel extends JPanel {
 	    public void processStanza(Stanza stanza) {
 		
 		//InvalidMove im = (InvalidMove)packet.getExtension(InvalidMove.ELEMENT_NAME, InvalidMove.NAMESPACE);
-		ChatRoom cr = SparkManager.getChatManager().getChatRoom(_opponent.asBareJid());
+		ChatRoom cr = SparkManager.getChatManager().getChatRoom(_opponent.asEntityBareJid());
 		cr.getTranscriptWindow().insertCustomText("You seem to be Cheating\n"+
 			"You placed a wrong Move", true, false, Color.red);
 		ShakeWindow sw = new ShakeWindow(_frame);

--- a/plugins/translator/src/main/java/org/jivesoftware/spark/translator/TranslatorPlugin.java
+++ b/plugins/translator/src/main/java/org/jivesoftware/spark/translator/TranslatorPlugin.java
@@ -70,7 +70,7 @@ public class TranslatorPlugin implements Plugin {
                             if (type != null && type != TranslatorUtil.TranslationType.None) {
                             	message.setBody(null);
                             	currentBody = TranslatorUtil.translate(currentBody, type);
-                                TranscriptWindow transcriptWindow = chatManager.getChatRoom( message.getTo().asBareJid() ).getTranscriptWindow();
+                                TranscriptWindow transcriptWindow = chatManager.getChatRoom( message.getTo().asEntityBareJidOrThrow() ).getTranscriptWindow();
                                 if(oldBody.equals(currentBody.substring(0,currentBody.length()-1)))
                                 {
                                 	transcriptWindow.insertNotificationMessage("Could not translate: "+currentBody, ChatManager.ERROR_COLOR);


### PR DESCRIPTION
Most of the bugs that I had to work on were related, among other things, to the use of deprecated methods.
Also the condition of some parts of Spark's code is depressing :).
So I think it's worth doing a little code cleanup and refactor.
Let's start with getting rid of deprecated methods and dead code.
[SPARK-1160: Remove deprecated methods usage](https://issues.igniterealtime.org/browse/SPARK-1160)