### PR TITLE
SPARK-2005: Query ClientControl for additions to plugin blacklist

### DIFF
--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -35,6 +35,7 @@ import org.jivesoftware.smack.util.DNSUtil;
 import org.jivesoftware.smack.util.TLSUtils;
 import org.jivesoftware.smackx.carbons.CarbonManager;
 import org.jivesoftware.smackx.chatstates.ChatStateManager;
+import org.jivesoftware.spark.PluginManager;
 import org.jivesoftware.spark.SessionManager;
 import org.jivesoftware.spark.SparkManager;
 import org.jivesoftware.spark.Workspace;
@@ -207,6 +208,10 @@ public class LoginDialog {
     protected void afterLogin() {
         // Make certain Enterprise features persist across future logins
         persistEnterprise();
+
+        // Load plugins before Workspace initialization to avoid any UI delays during plugin rendering, but after
+        // Enterprise initialization, which can pull in additional plugin configuration (eg: blacklist).
+        PluginManager.getInstance().loadPlugins();
 
         // Initialize and write default values from "Advanced Connection Preferences" to disk
         initAdvancedDefaults();

--- a/core/src/main/java/org/jivesoftware/Spark.java
+++ b/core/src/main/java/org/jivesoftware/Spark.java
@@ -178,11 +178,6 @@ public final class Spark {
             new Spark();
         } );
 
-        //load plugins before Workspace initialization to avoid any UI delays
-        //during plugin rendering
-        final PluginManager pluginManager = PluginManager.getInstance();
-        pluginManager.loadPlugins();
-
         installBaseUIProperties();
 
         if (Default.getBoolean(Default.CHANGE_COLORS_DISABLED)) {


### PR DESCRIPTION
This commit augments the blacklist of plugins with the response to a query to the clientControl plugin for Openfire.

This functionality is added to the clientControl plugin in what will probably be release 2.1.6. See https://github.com/igniterealtime/openfire-clientControl-plugin/pull/18