### PR TITLE
SPARK-1469: Code cleanup

### DIFF
--- a/core/src/main/java/org/jivesoftware/launcher/Installer.java
+++ b/core/src/main/java/org/jivesoftware/launcher/Installer.java
@@ -104,8 +104,6 @@ public class Installer implements InstallAction {
      */
     private void setURI(String path) {
         boolean exists = WinRegistry.keyExists(RegistryRoot.HKEY_CLASSES_ROOT, "xmpp");
-        if (exists) {
-        }
         //   JOptionPane.showConfirmDialog(null, "Another application is currently registered to handle XMPP instant messaging. Make Spark the default XMPP instant messaging client?", "Confirmation",         }
         WinRegistry.deleteKey(RegistryRoot.HKEY_CLASSES_ROOT, "xmpp", true);
 

--- a/core/src/main/java/org/jivesoftware/spark/ButtonFactory.java
+++ b/core/src/main/java/org/jivesoftware/spark/ButtonFactory.java
@@ -59,17 +59,15 @@ public class ButtonFactory {
 		return new RolloverButton(SparkRes.getImageIcon(SparkRes.BUZZ_IMAGE));
 	}
 
-	public RolloverButton createEmoticonButton() {
-		final EmoticonManager emoticonManager = EmoticonManager.getInstance();
-		final String activeEmoticonSetName = emoticonManager.getActiveEmoticonSetName();
-		final Emoticon smileEmoticon = emoticonManager.getEmoticon(activeEmoticonSetName, ":)");
-                Emoticon firstEmoticon=(smileEmoticon == null) ? firstEmoticon=emoticonManager.getFirstEmotion(activeEmoticonSetName) : smileEmoticon;
-		URL emotionURL = emoticonManager.getEmoticonURL(firstEmoticon);
-		ImageIcon icon = new ImageIcon(emotionURL);
-                firstEmoticon=null;
-		return new RolloverButton(icon);
-                
-	}
+    public RolloverButton createEmoticonButton() {
+        final EmoticonManager emoticonManager = EmoticonManager.getInstance();
+        final String activeEmoticonSetName = emoticonManager.getActiveEmoticonSetName();
+        final Emoticon smileEmoticon = emoticonManager.getEmoticon(activeEmoticonSetName, ":)");
+        Emoticon firstEmoticon = (smileEmoticon == null) ? emoticonManager.getFirstEmotion(activeEmoticonSetName) : smileEmoticon;
+        URL emotionURL = emoticonManager.getEmoticonURL(firstEmoticon);
+        ImageIcon icon = new ImageIcon(emotionURL);
+        return new RolloverButton(icon);
+    }
 
 	public JLabel createDivider() {
 		return new JLabel(SparkRes.getImageIcon("DIVIDER_IMAGE"));

--- a/core/src/main/java/org/jivesoftware/spark/component/CheckTree.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/CheckTree.java
@@ -75,20 +75,10 @@ public class CheckTree extends JPanel {
                 CheckNode node = (CheckNode)path.getLastPathComponent();
                 boolean isSelected = !node.isSelected();
                 node.setSelected(isSelected);
-                if (node.getSelectionMode() == CheckNode.DIG_IN_SELECTION) {
-                    if (isSelected) {
-                        //tree.expandPath(path);
-                    }
-                    else {
-                        //tree.collapsePath(path);
-                    }
-                }
                 ((DefaultTreeModel)tree.getModel()).nodeChanged(node);
                 // I need revalidate if node is root.  but why?
-
                 tree.revalidate();
                 tree.repaint();
-
             }
         }
     }

--- a/core/src/main/java/org/jivesoftware/spark/component/FileDragLabel.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/FileDragLabel.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.spark.component;
 
+import org.jetbrains.annotations.NotNull;
 import org.jivesoftware.spark.util.log.Log;
 
 import java.awt.datatransfer.DataFlavor;
@@ -154,6 +155,7 @@ public class FileDragLabel extends JLabel implements DropTargetListener, DragSou
         }
 
 
+        @NotNull
         @Override
 		public synchronized Object getTransferData(DataFlavor flavor)
             throws UnsupportedFlavorException, IOException {

--- a/core/src/main/java/org/jivesoftware/spark/component/JiveSortableTable.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/JiveSortableTable.java
@@ -247,7 +247,7 @@ public abstract class JiveSortableTable extends Table {
 	private static final long serialVersionUID = 8670248883432881619L;
 	Border unselectedBorder;
         Border selectedBorder;
-        boolean isBordered = true;
+        boolean isBordered;
 
         /**
          * JLabelConstructor to build ui.

--- a/core/src/main/java/org/jivesoftware/spark/component/JiveSortableTable.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/JiveSortableTable.java
@@ -275,9 +275,6 @@ public abstract class JiveSortableTable extends Table {
             else {
                 setForeground(Color.black);
                 setBackground(Color.white);
-                if (row % 2 == 0) {
-                    //setBackground( new Color( 156, 207, 255 ) );
-                }
             }
 
             if (isBordered) {
@@ -362,9 +359,6 @@ public abstract class JiveSortableTable extends Table {
             else {
                 setForeground(Color.black);
                 setBackground(Color.white);
-                if (row % 2 == 0) {
-                    //setBackground( new Color( 156, 207, 255 ) );
-                }
             }
 
             if (isBordered) {

--- a/core/src/main/java/org/jivesoftware/spark/component/JiveTable.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/JiveTable.java
@@ -143,9 +143,6 @@ public class JiveTable extends JTable {
             else {
                 setForeground(Color.black);
                 setBackground(Color.white);
-                if (row % 2 == 0) {
-                    //setBackground( new Color( 156, 207, 255 ) );
-                }
             }
 
             if (isBordered) {
@@ -197,9 +194,6 @@ public class JiveTable extends JTable {
             else {
                 setForeground(Color.black);
                 setBackground(Color.white);
-                if (row % 2 == 0) {
-                    //setBackground( new Color( 156, 207, 255 ) );
-                }
             }
 
             if (isBordered) {

--- a/core/src/main/java/org/jivesoftware/spark/component/JiveTreeNode.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/JiveTreeNode.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.spark.component;
 
+import org.jetbrains.annotations.NotNull;
 import org.jivesoftware.resource.SparkRes;
 
 import javax.swing.Icon;
@@ -223,6 +224,7 @@ public class JiveTreeNode extends DefaultMutableTreeNode implements Transferable
 
     }
 
+    @NotNull
     @Override
 	public Object getTransferData(DataFlavor flavor)
             throws UnsupportedFlavorException, IOException {

--- a/core/src/main/java/org/jivesoftware/spark/component/MessageDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/MessageDialog.java
@@ -86,7 +86,7 @@ public final class MessageDialog
             titleLabel.setFont(new Font("dialog", Font.BOLD, 11 ) );
 
             final JLabel descriptionLabel = new JLabel(desc);
-            descriptionLabel.setFont(new Font("dialog", 0, 10 ) );
+            descriptionLabel.setFont(new Font("dialog", Font.PLAIN, 10 ) );
 
             // The stacktrace content.
             final JTextArea textPane = new JTextArea();

--- a/core/src/main/java/org/jivesoftware/spark/component/Table.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/Table.java
@@ -304,9 +304,6 @@ public abstract class Table extends JXTable {
             else {
                 setForeground(Color.black);
                 setBackground(Color.white);
-                if (row % 2 == 0) {
-                    //setBackground( new Color( 156, 207, 255 ) );
-                }
             }
 
             if (isBordered) {
@@ -393,9 +390,6 @@ public abstract class Table extends JXTable {
             else {
                 setForeground(Color.black);
                 setBackground(Color.white);
-                if (row % 2 == 0) {
-                    //setBackground( new Color( 156, 207, 255 ) );
-                }
             }
 
             if (isBordered) {

--- a/core/src/main/java/org/jivesoftware/spark/component/Table.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/Table.java
@@ -276,7 +276,7 @@ public abstract class Table extends JXTable {
 	private static final long serialVersionUID = 4433780600297455731L;
 	Border unselectedBorder;
         Border selectedBorder;
-        boolean isBordered = true;
+        boolean isBordered;
 
         /**
          * JLabelConstructor to build ui.

--- a/core/src/main/java/org/jivesoftware/spark/component/TitlePanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/TitlePanel.java
@@ -78,7 +78,7 @@ public final class TitlePanel extends JPanel {
             setBackground(Color.white);
 
             titleLabel.setFont(new Font("dialog", Font.BOLD, 11));
-            descriptionLabel.setFont(new Font("dialog", 0, 10));
+            descriptionLabel.setFont(new Font("dialog", Font.PLAIN, 10));
         }
         else {
             final JPanel panel = new ImagePanel();
@@ -91,7 +91,7 @@ public final class TitlePanel extends JPanel {
             titleLabel.setVerticalTextPosition(JLabel.CENTER);
             titleLabel.setFont(new Font("dialog", Font.BOLD, 14));
             titleLabel.setForeground(Color.black);
-            descriptionLabel.setFont(new Font("dialog", 0, 10));
+            descriptionLabel.setFont(new Font("dialog", Font.PLAIN, 10));
             add(panel, new GridBagConstraints(0, 0, 1, 0, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, 2, 2, 2), 0, 0));
         }
 

--- a/core/src/main/java/org/jivesoftware/spark/component/tabbedPane/SparkTab.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/tabbedPane/SparkTab.java
@@ -26,8 +26,8 @@ import javax.swing.JPanel;
 public class SparkTab extends JPanel 
 {
 	private static final long serialVersionUID = 2027267184472260195L;
-	private SparkTabbedPane pane = null;
-	private Component component = null;
+	private SparkTabbedPane pane;
+	private Component component;
 	
 	public SparkTab(SparkTabbedPane pane, Component comp)
 	{

--- a/core/src/main/java/org/jivesoftware/spark/component/tabbedPane/SparkTabbedPane.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/tabbedPane/SparkTabbedPane.java
@@ -42,7 +42,7 @@ public class SparkTabbedPane extends JPanel {
 	private static final long serialVersionUID = -9007068462231539973L;
 	private static final String NAME = "SparkTabbedPane";
 	private List<SparkTabbedPaneListener> listeners = new ArrayList<>();
-	private JTabbedPane pane = null;
+	private JTabbedPane pane;
 	private Icon closeInactiveButtonIcon;
 	private Icon closeActiveButtonIcon;
 	private boolean closeEnabled = false;

--- a/core/src/main/java/org/jivesoftware/spark/component/tabbedPane/SparkTabbedPane.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/tabbedPane/SparkTabbedPane.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.spark.component.tabbedPane;
 
+import org.jetbrains.annotations.NotNull;
 import org.jivesoftware.Spark;
 import org.jivesoftware.resource.SparkRes;
 import org.jivesoftware.spark.SparkManager;
@@ -507,7 +508,8 @@ public class SparkTabbedPane extends JPanel {
 
 	    final Transferable t = new Transferable() {
 	    	private final DataFlavor FLAVOR = new DataFlavor(DataFlavor.javaJVMLocalObjectMimeType, NAME);
-			@Override
+			@NotNull
+            @Override
 			public Object getTransferData(DataFlavor flavor)
 					throws UnsupportedFlavorException, IOException {
 				return pane;

--- a/core/src/main/java/org/jivesoftware/spark/ui/BroadcastHistoryFrame.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/BroadcastHistoryFrame.java
@@ -40,24 +40,20 @@ public class BroadcastHistoryFrame extends javax.swing.JFrame {
         BroadcastHistoryArea.setWrapStyleWord(true);
         initComponents();
     }
-    
+
     public void readFromFile(String date) throws FileNotFoundException, IOException {
         //String fileName = Spark.getSparkUserHome()+File.separator+"broadcast_history."+date+".txt";
-        String fileLocation=Spark.getSparkUserHome()+File.separator+"user"+File.separator+SparkManager.getSessionManager().getUsername()+"@"+SparkManager.getSessionManager().getServerAddress()+File.separator+"transcripts"+File.separator+"broadcast_history."+date+".txt";
+        String fileLocation = Spark.getSparkUserHome() + File.separator + "user" + File.separator + SparkManager.getSessionManager().getUsername() + "@" + SparkManager.getSessionManager().getServerAddress() + File.separator + "transcripts" + File.separator + "broadcast_history." + date + ".txt";
         File myfile = new File(fileLocation);
         FileInputStream fis = new FileInputStream(myfile);
- 
-	
+
         BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-        
-        String line = null;
-       
+
+        String line;
         while ((line = br.readLine()) != null) {
-            BroadcastHistoryArea.append(line+"\n");
-            }
- 
-	br.close();   
- 
+            BroadcastHistoryArea.append(line + "\n");
+        }
+        br.close();
     }
     
     private void initComponents() {        

--- a/core/src/main/java/org/jivesoftware/spark/ui/BroadcastHistoryFrame.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/BroadcastHistoryFrame.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.text.Format;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import javax.swing.JFrame;
 import javax.swing.JScrollPane;
@@ -75,7 +76,7 @@ public class BroadcastHistoryFrame extends javax.swing.JFrame {
         try {
             readFromFile(myDate);
         } catch (IOException ex) {
-            Log.error("Couldn't read from file"+ex.getMessage()+ex.getStackTrace());
+            Log.error("Couldn't read from file"+ex.getMessage()+ Arrays.toString(ex.getStackTrace()));
         }
        
         SearchButton.setText((Res.getString("button.search")));
@@ -155,7 +156,7 @@ public class BroadcastHistoryFrame extends javax.swing.JFrame {
         try {
             readFromFile(DateField.getText());
         } catch (IOException ex) {
-            Log.error("Couldn't read from file"+ex.getCause()+ex.getStackTrace());
+            Log.error("Couldn't read from file"+ex.getCause()+ Arrays.toString(ex.getStackTrace()));
         }
        
         

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatInputEditor.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatInputEditor.java
@@ -17,6 +17,7 @@ package org.jivesoftware.spark.ui;
 
 import java.awt.Color;
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.AbstractAction;
@@ -122,7 +123,7 @@ public class ChatInputEditor extends ChatArea implements DocumentListener {
 	    }
 	};
 
-        undoKeyStroke = KeyStroke.getKeyStroke('z', ActionEvent.CTRL_MASK);       
+        undoKeyStroke = KeyStroke.getKeyStroke('z', InputEvent.CTRL_MASK);
         ctrlbackspaceKeyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, KeyEvent.CTRL_MASK);
         escapeKeyStroke = KeyStroke.getKeyStroke("ESCAPE");
         

--- a/core/src/main/java/org/jivesoftware/spark/ui/ChatRoomTransferHandler.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ChatRoomTransferHandler.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import javax.swing.JComponent;
 import javax.swing.TransferHandler;
 
+import org.jetbrains.annotations.NotNull;
 import org.jivesoftware.spark.util.log.Log;
 
 /**
@@ -131,8 +132,9 @@ public class ChatRoomTransferHandler extends TransferHandler {
         }
 
         // Returns Selected Text
+        @NotNull
         @Override
-		public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+		public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
             if (!DataFlavor.stringFlavor.equals(flavor)) {
                 throw new UnsupportedFlavorException(flavor);
             }

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactGroupTransferHandler.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactGroupTransferHandler.java
@@ -15,6 +15,7 @@
  */ 
 package org.jivesoftware.spark.ui;
 
+import org.jetbrains.annotations.NotNull;
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.roster.Roster;
@@ -164,6 +165,7 @@ public class ContactGroupTransferHandler extends TransferHandler {
         }
 
         // Returns image
+        @NotNull
         @Override
 		public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
             if (!DataFlavor.imageFlavor.equals(flavor)) {

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
@@ -239,14 +239,8 @@ public class ContactInfoWindow extends JPanel {
         	//If user is offline or away, try to see last activity
 
 	        try {
-				Jid client = null;
-				if (!status.equals(Res.getString("offline"))) {
-					//If user is away (not offline), last activity request is sent to client
-					client = contactItem.getPresence().getFrom();
-				} else {
-				    client = contactItem.getJid();
-				}
-
+                //If user is away (not offline), last activity request is sent to client
+				Jid client = status.equals(Res.getString("offline")) ? contactItem.getJid() : contactItem.getPresence().getFrom();
 	            LastActivity activity = LastActivityManager.getInstanceFor( SparkManager.getConnection() ).getLastActivity(client);
 	
 	            long idleTime = (activity.getIdleTime() * 1000);

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -824,9 +824,7 @@ public class ContactList extends JPanel implements ActionListener,
 
                     ContactGroup unfiledGrp = getUnfiledGroup();
                     ContactItem unfiledItem = unfiledGrp.getContactItemByJID(jid.asBareJid());
-                    if (unfiledItem != null) {
-
-                    } else {
+                    if (unfiledItem == null) {
                         ContactItem offlineItem = offlineGroup.getContactItemByJID(jid.asBareJid());
                         if (offlineItem != null) {
                             if ((rosterEntry.getType() == RosterPacket.ItemType.none || rosterEntry.getType() == RosterPacket.ItemType.from)

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -75,6 +75,7 @@ public class ContactList extends JPanel implements ActionListener,
     ContactGroupListener, Plugin, RosterListener, ConnectionListener, ReconnectionListener {
 
     private static final long serialVersionUID = -4391111935248627078L;
+    private static final String GROUP_DELIMITER = "::";
     private JPanel mainPanel = new JPanel();
     private JScrollPane contactListScrollPane;
     private final List<ContactGroup> groupList = new ArrayList<>();
@@ -984,7 +985,7 @@ public class ContactList extends JPanel implements ActionListener,
      * @return the newly created ContactGroup.
      */
     private ContactGroup addContactGroup(String groupName) {
-        StringTokenizer tkn = new StringTokenizer(groupName, "::");
+        StringTokenizer tkn = new StringTokenizer(groupName, GROUP_DELIMITER);
 
         ContactGroup rootGroup = null;
         ContactGroup lastGroup = null;
@@ -1199,7 +1200,7 @@ public class ContactList extends JPanel implements ActionListener,
      * @param visible   true to show, otherwise false.
      */
     public void toggleGroupVisibility(String groupName, boolean visible) {
-        StringTokenizer tkn = new StringTokenizer(groupName, "::");
+        StringTokenizer tkn = new StringTokenizer(groupName, GROUP_DELIMITER);
         while (tkn.hasMoreTokens()) {
             String group = tkn.nextToken();
             ContactGroup contactGroup = getContactGroup(group);

--- a/core/src/main/java/org/jivesoftware/spark/ui/ReconnectPanelSmall.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ReconnectPanelSmall.java
@@ -16,7 +16,7 @@
 package org.jivesoftware.spark.ui;
 
 import java.awt.Component;
-import javax.swing.JLabel;
+import javax.swing.*;
 
 import org.jivesoftware.resource.Res;
 import org.jivesoftware.resource.SparkRes;
@@ -36,7 +36,7 @@ public class ReconnectPanelSmall extends ContactGroup implements
     private static final long serialVersionUID = 437696141257704105L;
     private JLabel _reconnectionlabel = new JLabel(
 	    Res.getString("message.reconnect.attempting"),
-	    SparkRes.getImageIcon(SparkRes.BUSY_IMAGE), 0);
+	    SparkRes.getImageIcon(SparkRes.BUSY_IMAGE), SwingConstants.CENTER);
     private Component thiscomp;
     private boolean _closedOnError;
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/RosterDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/RosterDialog.java
@@ -307,7 +307,7 @@ public class RosterDialog implements ActionListener {
 
     @Override
 	public void actionPerformed(ActionEvent e) {
-        String group = JOptionPane.showInputDialog(dialog, Res.getString("label.enter.group.name") + ":", Res.getString("title.new.roster.group"), 3);
+        String group = JOptionPane.showInputDialog(dialog, Res.getString("label.enter.group.name") + ":", Res.getString("title.new.roster.group"), JOptionPane.QUESTION_MESSAGE);
         if (group != null && group.length() > 0 && !groupModel.contains(group)) {
             Roster.getInstanceFor( SparkManager.getConnection() ).createGroup(group);
             groupModel.add(group);

--- a/core/src/main/java/org/jivesoftware/spark/ui/RosterDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/RosterDialog.java
@@ -660,28 +660,25 @@ public class RosterDialog implements ActionListener {
 	    nicknameField.setText(nickname);
 	}
 
-	ContactGroup contactGroup = contactList.getContactGroup(group);
-	boolean isSharedGroup = contactGroup != null
-		&& contactGroup.isSharedGroup();
+        ContactGroup contactGroup = contactList.getContactGroup(group);
+        boolean isSharedGroup = contactGroup != null && contactGroup.isSharedGroup();
 
-	if (isSharedGroup) {
-	    errorMessage = Res
-		    .getString("message.cannot.add.contact.to.shared.group");
-	} else if (!ModelUtil.hasLength(contact)) {
-	    errorMessage = Res.getString("message.specify.contact.jid");
-	} else if (!XmppStringUtils.parseBareJid(contact).contains("@")) {
-	    errorMessage = Res.getString("message.invalid.jid.error");
-	} else if (!ModelUtil.hasLength(group)) {
-	    errorMessage = Res.getString("message.specify.group");
-	} else if (ModelUtil.hasLength(contact) && ModelUtil.hasLength(group)
-		&& !isSharedGroup) {
-	    addEntry();
-	    dialog.setVisible(false);
-    } else {
+        if (isSharedGroup) {
+            errorMessage = Res.getString("message.cannot.add.contact.to.shared.group");
+        } else if (!ModelUtil.hasLength(contact)) {
+            errorMessage = Res.getString("message.specify.contact.jid");
+        } else if (!XmppStringUtils.parseBareJid(contact).contains("@")) {
+            errorMessage = Res.getString("message.invalid.jid.error");
+        } else if (!ModelUtil.hasLength(group)) {
+            errorMessage = Res.getString("message.specify.group");
+        }
 
-	    JOptionPane.showMessageDialog(dialog, errorMessage,
-		    Res.getString("title.error"), JOptionPane.ERROR_MESSAGE);
-	}
+        if (ModelUtil.hasLength(contact) && ModelUtil.hasLength(group) && !isSharedGroup) {
+            addEntry();
+            dialog.setVisible(false);
+        } else {
+            JOptionPane.showMessageDialog(dialog, errorMessage,Res.getString("title.error"), JOptionPane.ERROR_MESSAGE);
+        }
     }
 
     static class AccountItem extends JPanel {

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/AnswerFormDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/AnswerFormDialog.java
@@ -50,7 +50,7 @@ import org.jivesoftware.spark.util.ResourceUtils;
 public class AnswerFormDialog {
 
     private static final long serialVersionUID = 3637412110943006392L;
-    private JDialog dialog = null;
+    private JDialog dialog;
     private JPanel centerpanel;
 
 	HashMap<String, JComponent> _map = new HashMap<>();

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceRoomBrowser.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceRoomBrowser.java
@@ -344,27 +344,21 @@ public class ConferenceRoomBrowser extends JPanel implements ActionListener,
     }
 
     private RoomObject getRoomsAndInfo(final HostedRoom room) {
-        boolean stillSearchForOccupants = true;
         RoomObject result = null;
         try {
             try {
                 String roomName = room.getName();
                 EntityBareJid roomJID = room.getJid();
                 int numberOfOccupants = -1;
-                if (stillSearchForOccupants) {
                 RoomInfo roomInfo = null;
                 try {
-                    roomInfo = MultiUserChatManager.getInstanceFor( SparkManager.getConnection() ).getRoomInfo( roomJID );
+                    roomInfo = MultiUserChatManager.getInstanceFor(SparkManager.getConnection()).getRoomInfo(roomJID);
                 } catch (Exception e) {
                     // Nothing to do
                 }
 
                 if (roomInfo != null) {
                     numberOfOccupants = roomInfo.getOccupantsCount();
-                    if (numberOfOccupants == -1) {
-                    }
-                } else {
-                }
                 }
 
                 result = new RoomObject();

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConversationInvitation.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConversationInvitation.java
@@ -111,7 +111,7 @@ public class ConversationInvitation extends JPanel implements ContainerComponent
         add(dateLabelValue, new GridBagConstraints(1, 3, 3, 1, 0.0, 0.0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL, new Insets(2, 5, 2, 5), 0, 0));
 
         titleLabel.setFont(new Font("dialog", Font.BOLD, 12));
-        description.setFont(new Font("dialog", 0, 12));
+        description.setFont(new Font("dialog", Font.PLAIN, 12));
 
         titleLabel.setText(Res.getString("title.conference.invitation"));
         description.setText(nickname + " has invited you to chat in " + roomName + ". " + nickname + " writes \"" + reason + "\"");

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/DataFormDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/DataFormDialog.java
@@ -65,8 +65,7 @@ public class DataFormDialog extends JPanel {
     private static final long serialVersionUID = -1536217028590811636L;
     private final Map<String,JComponent> valueMap = new HashMap<>();
     private int row = 0;
-    JDialog dialog = null;
-
+    JDialog dialog;
 
     public DataFormDialog(JFrame parent, final MultiUserChat chat, final Form submitForm) {
         dialog = new JDialog(parent, true);

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
@@ -662,9 +662,6 @@ public class GroupChatParticipantList extends JPanel {
 			    while (true) {
 				newNickname = newNickname.trim();
 				String nick = chat.getNickname().toString();
-				if (newNickname.equals(nick)) {
-				    // return;
-				}
 				try {
 				    chat.changeNickname(Resourcepart.from(newNickname));
 				    break;

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/GroupChatParticipantList.java
@@ -303,7 +303,7 @@ public class GroupChatParticipantList extends JPanel {
 	    int index = getIndex(nickname);
 	    if (index != -1) {
 		final JLabel userLabel = new JLabel(nickname.toString(), icon,
-			JLabel.HORIZONTAL);
+            SwingConstants.CENTER);
 		model.setElementAt(userLabel, index);
 	    }
 	}
@@ -743,7 +743,7 @@ public class GroupChatParticipantList extends JPanel {
 			icon = SparkRes.getImageIcon(SparkRes.BRICKWALL_IMAGE);
 		    }
 
-		    JLabel label = new JLabel(user, icon, JLabel.HORIZONTAL);
+		    JLabel label = new JLabel(user, icon, SwingConstants.CENTER);
 		    model.setElementAt(label, index);
 		}
 	    };
@@ -1056,7 +1056,7 @@ public class GroupChatParticipantList extends JPanel {
 	public synchronized void addUser(Icon userIcon, CharSequence nickname) {
 		try {
 			final JLabel user = new JLabel(nickname.toString(), userIcon,
-					JLabel.HORIZONTAL);
+                SwingConstants.CENTER);
 			users.add(user);
 
 			// Sort users alpha.

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/InvitationDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/InvitationDialog.java
@@ -81,7 +81,7 @@ final class InvitationDialog extends JPanel {
     private JDialog dlg;
 
     public InvitationDialog(boolean adhoc) {
-        JComponent roomsField = new JTextField();
+        JComponent roomsField;
         if (adhoc) {
             roomsField = new JTextField();
             textRoomsField = (JTextField) roomsField;
@@ -91,7 +91,7 @@ final class InvitationDialog extends JPanel {
             comboRoomsField.setEditable(true);
             comboRoomsField.addActionListener( e -> {
                 // get selected bookmark and persist it:
-                BookmarkedConference bookmarkedConf = null;
+                BookmarkedConference bookmarkedConf;
                 Object bookmarkedConfItem = comboRoomsField.getSelectedItem();
                 if (bookmarkedConfItem instanceof ConferenceItem) {
                     bookmarkedConf = ((ConferenceItem) bookmarkedConfItem).getBookmarkedConf();

--- a/core/src/main/java/org/jivesoftware/spark/ui/history/HistoryEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/history/HistoryEntry.java
@@ -23,11 +23,10 @@ public class HistoryEntry {
 	public HistoryEntry(HistoryEntry orig) {
 		if (orig == null)
 			throw new IllegalArgumentException("Orig cannot be null");
-		setDate(orig.getDate());
-		setName(orig.getName());
-		for (HistoryMessage msg : orig.getMessages()) {
-			getMessages().add(new HistoryMessage(msg));
-		}
+		date = orig.getDate();
+		name = orig.getName();
+		entries = new ArrayList<>(orig.getEntries());
+		messages = new ArrayList<>(orig.getMessages());
 	}
 
 	/**

--- a/core/src/main/java/org/jivesoftware/spark/ui/history/HistoryMessage.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/history/HistoryMessage.java
@@ -48,12 +48,12 @@ public class HistoryMessage {
 
 	public HistoryMessage(HistoryMessage orig) {
 		if (orig == null)
-			throw new IllegalArgumentException(
-					"Original message cannot be null");
+			throw new IllegalArgumentException("Original message cannot be null");
 		setTo(orig.getTo());
 		setFrom(orig.getFrom());
 		setBody(orig.getBody());
 		setDate(orig.getDate());
+		messageElement = orig.getXML();
 	}
 
 	/**

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/LoginSettingDialog.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/LoginSettingDialog.java
@@ -164,7 +164,7 @@ public class LoginSettingDialog implements PropertyChangeListener
                 optionPane.setValue( JOptionPane.UNINITIALIZED_VALUE );
                 optionPane.addPropertyChangeListener( this );
             }
-        } else if (Res.getString("use.default") == value) {
+        } else if (Res.getString("use.default").equals(value)) {
             if (tabbedPane.getSelectedComponent().equals(generalPanel)) {
                 generalPanel.useDefault();
             } else if (tabbedPane.getSelectedComponent().equals(securityPanel)) {

--- a/core/src/main/java/org/jivesoftware/spark/ui/status/CustomMessages.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/status/CustomMessages.java
@@ -241,10 +241,7 @@ public class CustomMessages {
                             Iterator<CustomStatusItem> iter = customItems.iterator();
                             while (iter.hasNext()) {
                                 CustomStatusItem item = iter.next();
-                                if (item.getType().equals(messageType) && item.getStatus().equals(messageStatus)) {
-
-                                }
-                                else {
+                                if (!item.getType().equals(messageType) || !item.getStatus().equals(messageStatus)) {
                                     list.add(item);
                                 }
                             }

--- a/core/src/main/java/org/jivesoftware/spark/uri/UriManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/uri/UriManager.java
@@ -159,57 +159,53 @@ public class UriManager {
      * @throws Exception
      */
     public void handleRoster(URI uri) throws Exception {
-	// xmpp:romeo@montague.net?roster
-	// xmpp:romeo@montague.net?roster;name=Romeo%20Montague
-	// xmpp:romeo@montague.net?roster;group=Friends
-	// xmpp:romeo@montague.net?roster;name=Romeo%20Montague;group=Friends
-    BareJid jid;
-    try {
-        jid = JidCreate.bareFrom(retrieveJID(uri));
-    } catch (XmppStringprepException e) {
-        throw new IllegalStateException(e);
-    }
+        // xmpp:romeo@montague.net?roster
+        // xmpp:romeo@montague.net?roster;name=Romeo%20Montague
+        // xmpp:romeo@montague.net?roster;group=Friends
+        // xmpp:romeo@montague.net?roster;name=Romeo%20Montague;group=Friends
+        BareJid jid;
+        try {
+            jid = JidCreate.bareFrom(retrieveJID(uri));
+        } catch (XmppStringprepException e) {
+            throw new IllegalStateException(e);
+        }
 
-	String name = "";
-	String query = uri.getQuery();
-	if (query.contains("name=")) {
-	    StringBuilder buf = new StringBuilder();
-	    int x = query.indexOf("name=") + 5;
-	    while (x < query.length() && query.charAt(x) != ';') {
-		buf.append(query.charAt(x));
-		x++;
-	    }
-	}
-	String group = "";
-	if (query.contains("group=")) {
-	    StringBuilder buf = new StringBuilder();
-	    int x = query.indexOf("group=") + 6;
-	    while (x < query.length() && query.charAt(x) != ';') {
-		buf.append(query.charAt(x));
-		x++;
-	    }
-	}
+        String name = "";
+        String query = uri.getQuery();
+        if (query.contains("name=")) {
+            StringBuilder buf = new StringBuilder();
+            int x = query.indexOf("name=") + 5;
+            while (x < query.length() && query.charAt(x) != ';') {
+                buf.append(query.charAt(x));
+                x++;
+            }
+        }
+        String group = "";
+        if (query.contains("group=")) {
+            StringBuilder buf = new StringBuilder();
+            int x = query.indexOf("group=") + 6;
+            while (x < query.length() && query.charAt(x) != ';') {
+                buf.append(query.charAt(x));
+                x++;
+            }
+        }
 
-	Roster roster = Roster.getInstanceFor( SparkManager.getConnection() );
-	RosterEntry userEntry = roster.getEntry(jid);
+        Roster roster = Roster.getInstanceFor(SparkManager.getConnection());
+        RosterEntry userEntry = roster.getEntry(jid);
 
-	roster.createEntry(jid, name, new String[] { group });
+        roster.createEntry(jid, name, new String[]{group});
 
-	RosterGroup rosterGroup = roster.getGroup(group);
-	if (rosterGroup == null) {
-	    rosterGroup = roster.createGroup(group);
-	}
+        RosterGroup rosterGroup = roster.getGroup(group);
+        if (rosterGroup == null) {
+            rosterGroup = roster.createGroup(group);
+        }
 
-	if (userEntry == null) {
-	    roster.createEntry(jid, name, new String[] { group });
-	    userEntry = roster.getEntry(jid);
-	} else {
-	    userEntry.setName(name);
-	    rosterGroup.addEntry(userEntry);
-	}
-
-	userEntry = roster.getEntry(jid);
-
+        if (userEntry == null) {
+            roster.createEntry(jid, name, new String[]{group});
+        } else {
+            userEntry.setName(name);
+            rosterGroup.addEntry(userEntry);
+        }
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/spark/util/Base64.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/Base64.java
@@ -758,7 +758,7 @@ public class Base64 {
 
         java.io.ByteArrayInputStream bais = null;
         java.io.ObjectInputStream ois = null;
-        Object obj = null;
+        Object obj;
 
         try {
             bais = new java.io.ByteArrayInputStream(objBytes);

--- a/core/src/main/java/org/jivesoftware/spark/util/Base64.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/Base64.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.spark.util;
 
+import org.jetbrains.annotations.NotNull;
 import org.jivesoftware.spark.util.log.Log;
 
 /**
@@ -978,26 +979,20 @@ public class Base64 {
          * @since 1.3
          */
         @Override
-		public int read(byte[] dest, int off, int len) throws java.io.IOException {
+		public int read(@NotNull byte[] dest, int off, int len) throws java.io.IOException {
             int i;
-            int b;
             for (i = 0; i < len; i++) {
-                b = read();
-
-                //if( b < 0 && i == 0 )
-                //    return -1;
-
+                int b = read();
                 if (b >= 0)
-                    dest[off + i] = (byte)b;
+                    dest[off + i] = (byte) b;
                 else if (i == 0)
                     return -1;
                 else
-                    break; // Out of 'for' loop
-            }   // end for: each byte read
+                    break;
+            }
             return i;
-        }   // end read
-
-    }   // end inner class InputStream
+        }
+    }
 
     /* ********  I N N E R   C L A S S   O U T P U T S T R E A M  ******** */
 
@@ -1132,7 +1127,7 @@ public class Base64 {
          * @since 1.3
          */
         @Override
-		public void write(byte[] theBytes, int off, int len) throws java.io.IOException {
+		public void write(@NotNull byte[] theBytes, int off, int len) throws java.io.IOException {
             // Encoding suspended?
             if (suspendEncoding) {
                 super.out.write(theBytes, off, len);

--- a/core/src/main/java/org/jivesoftware/spark/util/ByteFormat.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/ByteFormat.java
@@ -15,6 +15,8 @@
  */
 package org.jivesoftware.spark.util;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.text.DecimalFormat;
 import java.text.FieldPosition;
 import java.text.Format;
@@ -60,7 +62,7 @@ public class ByteFormat extends Format {
      * @return A formatted string representing the given bytes in more human-readable form.
      */
     @Override
-	public StringBuffer format(Object obj, StringBuffer buf, FieldPosition pos) {
+	public StringBuffer format(Object obj, @NotNull StringBuffer buf, @NotNull FieldPosition pos) {
         if (obj instanceof Long) {
             long numBytes = (Long) obj;
             if (numBytes < 1024) {
@@ -91,7 +93,7 @@ public class ByteFormat extends Format {
      * @return returns null in this implementation.
      */
     @Override
-	public Object parseObject(String source, ParsePosition pos) {
+	public Object parseObject(String source, @NotNull ParsePosition pos) {
         return null;
     }
 }

--- a/core/src/main/java/org/jivesoftware/spark/util/StringUtils.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/StringUtils.java
@@ -281,52 +281,50 @@ public class StringUtils {
     /**
      * This method takes a string and strips out all tags while still leaving
      * the tag body intact.
-     * 
-     * @param in
-     *            the text to be converted.
-     * @param stripBRTag
-     *            Remove BR tags.
+     *
+     * @param in         the text to be converted.
+     * @param stripBRTag Remove BR tags.
      * @return the input string with all tags removed.
      */
     public static String stripTags(String in, boolean stripBRTag) {
-	if (in == null) {
-	    return null;
-	}
+        if (in == null) {
+            return null;
+        }
 
-	char ch;
-	int i = 0;
-	int last = 0;
-	char[] input = in.toCharArray();
-	int len = input.length;
-	StringBuilder out = new StringBuilder((int) (len * 1.3));
-	for (; i < len; i++) {
-	    ch = input[i];
-	    if (ch > '>') {
-		// Nothing to do
-	    } else if (ch == '<') {
-		if (!stripBRTag && i + 3 < len && input[i + 1] == 'b'
-			&& input[i + 2] == 'r' && input[i + 3] == '>') {
-		    i += 3;
-		    continue;
-		}
-		if (i > last) {
-		    if (last > 0) {
-			out.append(" ");
-		    }
-		    out.append(input, last, i - last);
-		}
-		last = i + 1;
-	    } else if (ch == '>') {
-		last = i + 1;
-	    }
-	}
-	if (last == 0) {
-	    return in;
-	}
-	if (i > last) {
-	    out.append(input, last, i - last);
-	}
-	return out.toString();
+        char ch;
+        int i = 0;
+        int last = 0;
+        char[] input = in.toCharArray();
+        int len = input.length;
+        StringBuilder out = new StringBuilder((int) (len * 1.3));
+        for (; i < len; i++) {
+            ch = input[i];
+            if (ch <= '>') {
+                if (ch == '<') {
+                    if (!stripBRTag && i + 3 < len && input[i + 1] == 'b'
+                        && input[i + 2] == 'r' && input[i + 3] == '>') {
+                        i += 3;
+                        continue;
+                    }
+                    if (i > last) {
+                        if (last > 0) {
+                            out.append(" ");
+                        }
+                        out.append(input, last, i - last);
+                    }
+                    last = i + 1;
+                } else if (ch == '>') {
+                    last = i + 1;
+                }
+            }
+        }
+        if (last == 0) {
+            return in;
+        }
+        if (i > last) {
+            out.append(input, last, i - last);
+        }
+        return out.toString();
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/spark/util/TaskEngine.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/TaskEngine.java
@@ -15,6 +15,7 @@
  */
 package org.jivesoftware.spark.util;
 
+import org.jetbrains.annotations.NotNull;
 import org.jivesoftware.spark.util.log.Log;
 
 import java.util.Date;
@@ -65,7 +66,7 @@ public class TaskEngine {
             final AtomicInteger threadNumber = new AtomicInteger(1);
 
             @Override
-			public Thread newThread(Runnable runnable) {
+			public Thread newThread(@NotNull Runnable runnable) {
                 // Use our own naming scheme for the threads.
                 Thread thread = new Thread(Thread.currentThread().getThreadGroup(), runnable,
                         "pool-spark" + threadNumber.getAndIncrement(), 0);

--- a/core/src/main/java/org/jivesoftware/spark/util/UIComponentRegistry.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/UIComponentRegistry.java
@@ -495,7 +495,7 @@ public final class UIComponentRegistry {
         } catch (final Exception e) {
             // not pretty but we're catching several exceptions we can do little
             // about
-            Log.error("Error calling constructor for " + currentClass.getName() + " with arguments " + classes, e);
+            Log.error("Error calling constructor for " + currentClass.getName() + " with arguments " + Arrays.toString(classes), e);
         }
         return instance;
     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateModel.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/CertificateModel.java
@@ -3,18 +3,11 @@ package org.jivesoftware.sparkimpl.certificates;
 import java.io.IOException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Date;
+import java.util.*;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
 
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Primitive;
@@ -91,12 +84,12 @@ public class CertificateModel {
         if (version != 1 && ((certificate.getKeyUsage() != null && !certificate.getKeyUsage()[5])
                 || certificate.getBasicConstraints() == -1)) {
             try {
-                this.issuerUniqueID = certificate.getIssuerUniqueID().toString();
+                this.issuerUniqueID = Arrays.toString(certificate.getIssuerUniqueID());
             } catch (NullPointerException e) {
                 Log.warning("Certificate doesn't have issuerUniqueID: " + issuer, e);
             }
             try {
-                this.subjectUniqueID = certificate.getIssuerUniqueID().toString();
+                this.subjectUniqueID = Arrays.toString(certificate.getIssuerUniqueID());
             } catch (NullPointerException e) {
                 Log.warning("Certificate doesn't have subjectUniqueID: " + subject, e);
             }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastDialog.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/BroadcastDialog.java
@@ -24,12 +24,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
+import java.util.*;
 import java.util.List;
-import java.util.Set;
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
@@ -396,7 +392,7 @@ Log.warning( "Unable to broadcast.", e1 );
         try {
             addDataToFile(out);
         } catch (IOException ex) {
-            Log.error("Couldn't add data to file"+ex.getStackTrace());
+            Log.error("Couldn't add data to file"+ Arrays.toString(ex.getStackTrace()));
         }
         
        

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/SparkToaster.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/alerts/SparkToaster.java
@@ -127,7 +127,7 @@ public class SparkToaster {
 
     // Flag that indicate if use alwaysOnTop or not.
     // method always on top start only SINCE JDK 5 !
-    boolean useAlwaysOnTop = true;
+    boolean useAlwaysOnTop;
 
     private String title;
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/emoticons/Emoticon.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/emoticons/Emoticon.java
@@ -29,7 +29,7 @@ public class Emoticon {
     private String imageName;
     private String emoticonName;
     private File emoticonDirectory;
-    private List<String> equivalants = new ArrayList<>();
+    private List<String> equivalants;
 
 
     /**

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/gateways/GatewayTabItem.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/gateways/GatewayTabItem.java
@@ -50,7 +50,7 @@ public class GatewayTabItem extends CollapsiblePane implements GatewayItem {
     private RolloverButton _signInOut = new RolloverButton();
     private RolloverButton _registerButton = new RolloverButton();
     private JCheckBox _autoJoin = new JCheckBox();
-    private boolean _transportRegistered = false;
+    private boolean _transportRegistered;
 
     private RolloverButton _autoJoinButton = new RolloverButton();
     

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/idle/linux/LinuxIdleTime.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/idle/linux/LinuxIdleTime.java
@@ -46,13 +46,13 @@ public class LinuxIdleTime implements IdleTime {
 
     @Override
 	public long getIdleTimeMillis() {
-        X11.Window win = null;
+        X11.Window win;
         Xss.XScreenSaverInfo info = null;
         X11.Display dpy = null;
         final X11 x11 = X11.INSTANCE;
         final Xss xss = Xss.INSTANCE;
 
-        long idlemillis = 0L;
+        long idlemillis;
         try {
             dpy = x11.XOpenDisplay(null);
             win = x11.XDefaultRootWindow(dpy);
@@ -61,13 +61,8 @@ public class LinuxIdleTime implements IdleTime {
 
             idlemillis = info.idle.longValue();
         } finally {
-            if (info != null)
-                x11.XFree(info.getPointer());
-            info = null;
-
-            if (dpy != null)
-                x11.XCloseDisplay(dpy);
-            dpy = null;
+            if (info != null) x11.XFree(info.getPointer());
+            if (dpy != null) x11.XCloseDisplay(dpy);
         }
         return idlemillis;
     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/PrivacyManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/PrivacyManager.java
@@ -54,7 +54,7 @@ public class PrivacyManager {
     private PrivacyListManager privacyManager;
     private PrivacyPresenceHandler _presenceHandler = new PrivacyPresenceHandler();
     private Set<SparkPrivacyListListener> _listListeners = new HashSet<>();
-    private boolean _active = false;
+    private boolean _active;
     private SparkPrivacyList previousActiveList;
 
     /**

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/list/SparkPrivacyList.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/privacy/list/SparkPrivacyList.java
@@ -32,9 +32,9 @@ public class SparkPrivacyList {
     /**
      * List name will be used to identify PrivacyList
      */
-    private String _listName   = "";
-    private boolean _isActive = false;
-    private boolean _isDefault = false;
+    private String _listName;
+    private boolean _isActive;
+    private boolean _isDefault;
     private List<PrivacyItem> _privacyItems = new LinkedList<>();
     private PrivacyList _myPrivacyList;
     private final Set<SparkPrivacyItemListener> _listeners = new HashSet<>();

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/HistoryTranscript.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/HistoryTranscript.java
@@ -63,8 +63,8 @@ public class HistoryTranscript extends SwingWorker {
 	private JButton pageLeft = new JButton("<");
 	private JButton pageRight = new JButton(">");
 	private BareJid jid = null;
-	private SimpleDateFormat notificationDateFormatter = null;
-	private SimpleDateFormat messageDateFormatter = null;
+	private SimpleDateFormat notificationDateFormatter;
+	private SimpleDateFormat messageDateFormatter;
 	private final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
 	private LocalPreferences pref = SettingsManager.getLocalPreferences();
@@ -400,7 +400,7 @@ public class HistoryTranscript extends SwingWorker {
 				cal.setTime(oldDate);
 				Date newDate;
 
-				ChatTranscript history = new ChatTranscript();
+				ChatTranscript history;
 				boolean handled = true;
 
 				for(int i = startValue; i != endValue; i += iteratorValue){

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginRenderer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginRenderer.java
@@ -57,9 +57,6 @@ public class PluginRenderer extends JLabel implements TableCellRenderer {
         else {
             setForeground(Color.black);
             setBackground(Color.white);
-            if (row % 2 == 0) {
-                //setBackground( new Color( 156, 207, 255 ) );
-            }
         }
 
         if (isBordered) {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/preference/sounds/SoundPreference.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/preference/sounds/SoundPreference.java
@@ -316,7 +316,6 @@ public class SoundPreference implements Preference {
             return incomingInvitationBox.isSelected();
         }
 
-
         private void pickFile(String title, JTextField field) {
             if (fc == null) {
                 fc = new JFileChooser();
@@ -336,11 +335,7 @@ public class SoundPreference implements Preference {
                     Log.error(e);
                 }
             }
-            else {
-
-            }
         }
-
     }
 
     private File getSoundSettingsFile() {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -72,8 +72,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class VCardManager {
 
     private VCard personalVCard;
-    private transient byte[] personalVCardAvatar = null; // lazy loaded cache of avatar binary data.
-    private transient String personalVCardHash = null; // lazy loaded cache of avatar hash.
+    private transient byte[] personalVCardAvatar; // lazy loaded cache of avatar binary data.
+    private transient String personalVCardHash; // lazy loaded cache of avatar hash.
 
     private Map<BareJid, VCard> vcards = Collections.synchronizedMap( new HashMap<>());
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -460,10 +460,7 @@ public class VCardManager {
             // Create temp vcard.
             vcard = new VCard();
             vcard.setJabberId(jid.toString());
-        } else {
-        	//System.out.println(jid+"  HDD ---------->");
         }
-        
 
         return vcard;
     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/search/users/UserSearchForm.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/search/users/UserSearchForm.java
@@ -139,16 +139,11 @@ public class UserSearchForm extends JPanel {
                 Log.error(ioe);
                 
                } 
-           } 
-           else { 
-	    // Log.error("Search-Searvice-Error: Properties-file does not exist= " + pluginsettings.getPath()); 
-           }        
-
+           }
 
            if (servicesBox.getItemCount() > 0) {
                servicesBox.setSelectedIndex(0);
            }
-           
         
         titlePanel = new TitlePanel("", "", SparkRes.getImageIcon(SparkRes.BLANK_IMAGE), true);
         add(titlePanel, new GridBagConstraints(0, 0, 3, 1, 1.0, 0.0, GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));

--- a/core/src/main/java/org/jivesoftware/sparkimpl/updater/EasyX509TrustManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/updater/EasyX509TrustManager.java
@@ -50,7 +50,7 @@ import java.security.cert.X509Certificate;
  */
 
 public class EasyX509TrustManager implements X509TrustManager {
-    private X509TrustManager standardTrustManager = null;
+    private X509TrustManager standardTrustManager;
 
     /**
      * Log object for this class.

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/internal/FormUtils.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/internal/FormUtils.java
@@ -133,7 +133,7 @@ final public class FormUtils {
 
 
     public static String getPushedURL(String body) {
-        String urlToPush = null;
+        String urlToPush;
         int index = body.indexOf("]");
         urlToPush = body.substring(index + 1);
         int index2 = urlToPush.indexOf("http://");

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/internal/WorkgroupDataForm.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/internal/WorkgroupDataForm.java
@@ -52,7 +52,7 @@ public class WorkgroupDataForm extends JPanel {
 	private final Map valueMap = new HashMap<String, JComponent>();
     private int row = 5;
     private Form searchForm;
-    private Map presetVariables = new HashMap();
+    private Map presetVariables;
     private List<String> requiredList = new ArrayList<String>();
     private EnterListener listener;
 
@@ -173,13 +173,8 @@ public class WorkgroupDataForm extends JPanel {
             }
             else if (o instanceof JComboBox) {
                 Object v = ((JComboBox)o).getSelectedItem();
-                String value = "";
-                if (v instanceof FormField.Option) {
-                    value = ((FormField.Option)v).getValue();
-                }
-                else {
-                    value = (String)v;
-                }
+                String value = (v instanceof FormField.Option) ? ((FormField.Option) v).getValue() : (String) v;
+
                 List<String> list = new ArrayList<String>();
                 list.add(value);
                 if (list.size() > 0) {

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/Workpane.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/Workpane.java
@@ -387,7 +387,7 @@ public class Workpane {
 
         room.getSplitPane().setRightComponent(tabbedPane);
 
-        Form form = null;
+        Form form;
         try {
             form = FastpathPlugin.getWorkgroup().getWorkgroupForm();
         }
@@ -801,13 +801,6 @@ public class Workpane {
 
             try {
                 if (FastpathPlugin.getAgentSession().isOnline()) {
-                    Presence.Mode mode = presence.getMode();
-                    if (status == null) {
-                        status = "";
-                    }
-                    if (mode == null) {
-                        mode = Presence.Mode.available;
-                    }
                     FastpathPlugin.getAgentSession().setStatus(presence.getMode(), status);
                 }
             }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/invite/WorkgroupRosterTree.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/invite/WorkgroupRosterTree.java
@@ -52,7 +52,7 @@ public final class WorkgroupRosterTree extends JPanel {
 	private final JiveTreeNode rootNode = new JiveTreeNode(FpRes.getString("title.contact.list"));
     private final Tree rosterTree;
     private final Map<JiveTreeNode, EntityBareJid> addressMap = new HashMap<>();
-    private boolean showUnavailableAgents = true;
+    private boolean showUnavailableAgents;
     private final List workgroupList;
     private Collection<? extends BareJid> exclusionList;
 

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/AgentConversations.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/AgentConversations.java
@@ -188,11 +188,6 @@ public final class AgentConversations extends JPanel implements ChangeListener {
                             EntityBareJid agentJID = presence.getFrom().asEntityBareJidOrThrow();
                             AgentStatus agentStatus = presence.getExtension("agent-status", "http://jabber.org/protocol/workgroup");
 
-                            String status = presence.getStatus();
-                            if (status == null) {
-                                status = "Available";
-                            }
-
                             if (agentStatus != null) {
                                 List list = agentStatus.getCurrentChats();
 
@@ -224,12 +219,9 @@ public final class AgentConversations extends JPanel implements ChangeListener {
                             }
                             calculateNumberOfChats(agentRoster);
                         }
-
-
                     });
                 }
             };
-
             agentWorker.start();
         }
     }
@@ -311,7 +303,7 @@ public final class AgentConversations extends JPanel implements ChangeListener {
 
                                 if (muc.isJoined()) {
                                     // Try and remove myself as an owner if I am one.
-                                    Collection owners = null;
+                                    Collection owners;
                                     try {
                                         owners = muc.getOwners();
                                     }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/CurrentActivity.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/CurrentActivity.java
@@ -172,11 +172,6 @@ public final class CurrentActivity extends JPanel {
                         BareJid agentJID = presence.getFrom().asBareJid();
                         AgentStatus agentStatus = presence.getExtension("agent-status", "http://jabber.org/protocol/workgroup");
 
-                        String status = presence.getStatus();
-                        if (status == null) {
-                            status = "Available";
-                        }
-
                         if (agentStatus != null) {
                             List<ChatInfo> list = agentStatus.getCurrentChats();
 
@@ -261,7 +256,7 @@ public final class CurrentActivity extends JPanel {
 
                                 if (muc.isJoined()) {
                                     // Try and remove myself as an owner if I am one.
-                                    Collection owners = null;
+                                    Collection owners;
                                     try {
                                         owners = muc.getOwners();
                                     }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/InvitationPane.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/InvitationPane.java
@@ -253,7 +253,7 @@ public class InvitationPane {
     private void removeOwner(MultiUserChat muc) {
         if (muc.isJoined()) {
             // Try and remove myself as an owner if I am one.
-            Collection owners = null;
+            Collection owners;
             try {
                 owners = muc.getOwners();
             }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/UserInvitationPane.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/panes/UserInvitationPane.java
@@ -316,7 +316,7 @@ public class UserInvitationPane {
     private void removeOwner(MultiUserChat muc) {
         if (muc.isJoined()) {
             // Try and remove myself as an owner if I am one.
-            Collection<Affiliate> owners = null;
+            Collection<Affiliate> owners;
             try {
                 owners = muc.getOwners();
             }

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/search/ChatSearch.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/workspace/search/ChatSearch.java
@@ -90,7 +90,7 @@ public class ChatSearch implements Searchable {
             List<String> workgroupStrings = JidUtil.toStringList(workgroups);
             filledForm.setAnswer("workgroups", workgroupStrings);
 
-            ReportedData reportedData = null;
+            ReportedData reportedData;
             try {
                 reportedData = agentSession.searchTranscripts(filledForm);
                 for ( final ReportedData.Row row : reportedData.getRows() ) {

--- a/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/SparkFileUploadPlugin.java
+++ b/plugins/fileupload/src/main/java/org/jivesoftware/spark/plugin/fileupload/SparkFileUploadPlugin.java
@@ -110,7 +110,6 @@ public class SparkFileUploadPlugin implements Plugin, ChatRoomListener, GlobalMe
         {
             ChatRoomDecorator decorator = decorators.remove(roomId);
             decorator.finished();
-            decorator = null;
         }
     }
 

--- a/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
+++ b/plugins/meet/src/main/java/org/jivesoftware/spark/plugin/ofmeet/SparkMeetPlugin.java
@@ -265,7 +265,6 @@ public class SparkMeetPlugin implements Plugin, ChatRoomListener, GlobalMessageL
         {
             ChatRoomDecorator decorator = decorators.remove(roomId);
             decorator.finished();
-            decorator = null;
         }
 
         if (electronThread != null)
@@ -410,7 +409,7 @@ public class SparkMeetPlugin implements Plugin, ChatRoomListener, GlobalMessageL
     {
         BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(filePath));
         byte[] bytesIn = new byte[4096];
-        int read = 0;
+        int read;
 
         while ((read = zipIn.read(bytesIn)) != -1)
         {

--- a/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiPanel.java
+++ b/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiPanel.java
@@ -107,9 +107,9 @@ public class ReversiPanel extends JPanel {
                             // Redraw board.
                             ReversiPanel.this.repaint();
                         }
-                        else {
-                            // TODO: other user automatically forfeits!
-                        }
+                        // TODO: other user automatically forfeits!
+                        // else {
+                        // }
                         // Execute move.
                     }
                 }

--- a/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiPlugin.java
+++ b/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiPlugin.java
@@ -240,9 +240,9 @@ public class ReversiPlugin implements Plugin {
         // before adding the new one (possible if the opponent sends two invites
         // in a row).
         Object oldInvitation = gameInvitations.put(invitation.getFrom(), inviteAlert);
-        if (oldInvitation != null) {
-            // TODO: clean it up by removing it from the transcript window.
-        }
+        // TODO: clean it up by removing it from the transcript window.
+        // if (oldInvitation != null) {
+        // }
 
         // Add the response panel to the transcript window.
         room.getTranscriptWindow().addComponent(inviteAlert);

--- a/plugins/roar/src/main/java/org/jivesoftware/spark/roar/gui/SparkToaster.java
+++ b/plugins/roar/src/main/java/org/jivesoftware/spark/roar/gui/SparkToaster.java
@@ -106,7 +106,7 @@ public class SparkToaster {
 
     // Flag that indicate if use alwaysOnTop or not.
     // method always on top start only SINCE JDK 5 !
-    boolean useAlwaysOnTop = true;
+    boolean useAlwaysOnTop;
 
     private String title;
 


### PR DESCRIPTION
Fix probable bugs: Magic Constants
Fix probable bugs: Copy constructor missed fields
Fix probable bugs: Replace group delimiter literals with constant
Fix probable bugs: Remove empty statements and the code that does nothing.
Fix probable bugs: Call to toString() on arrays
Fix probable bugs: Add NotNull annotations
Fix probable bugs: Remove unused assignment and redundant initializers

