### PR TITLE
Replace XStream with more compatible version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.13-java7</version>
+            <version>1.4.13</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Dependabot replaced the regular version of XStream with one that's 'java7' classified. This introduces a ClassNotFound exception.

This causes various XML file processing (such as done during update checks) to fail.

This commit replaces the XStream dependency with the regular variant, which resolves the issue.