### PR TITLE
SPARK-2207: Display correct name for received file

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/filetransfer/transfer/ui/ReceiveFileTransfer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/filetransfer/transfer/ui/ReceiveFileTransfer.java
@@ -498,7 +498,7 @@ public class ReceiveFileTransfer extends JPanel {
             transferMessage = Res.getString("message.transfer.cancelled");
             saveEventToHistory(Res.getString("message.file.transfer.history.receive.canceled", fileName, nickname));
         } else if (transfer.getAmountWritten() >= request.getFileSize()) {
-            transferMessage = Res.getString("message.transfer.complete", transfer.getFileName());
+            transferMessage = Res.getString("message.transfer.complete", downloadedFile.getName()); // TODO this overwrites the message that was set by transferDone
             saveEventToHistory(Res.getString("message.file.transfer.history.receive.success", fileName, nickname));
         }
 


### PR DESCRIPTION
When a file is received, it could be renamed (see SPARK-2198). The name that's displayed in the confirmation text needs to be modified accordingly.