### PR TITLE
See comment! remove spaces and special characters from plugin names.

### DIFF
--- a/plugins/fileupload/pom.xml
+++ b/plugins/fileupload/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>fileupload</artifactId>
     <version>0.0.3</version>
 
-    <name>Http File Upload Plugin</name>
+    <name>HttpFileUploadPlugin</name>
     <description>Adds support for Openfire httpfileupload plugin to Spark</description>
 
     <contributors>

--- a/plugins/meet/pom.xml
+++ b/plugins/meet/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>meet</artifactId>
     <version>0.0.8</version>
 
-    <name>Pade Meetings Plugin</name>
+    <name>PadeMeetingsPlugin</name>
     <description>Adds support for Pade Meetings to the Spark IM client.</description>
 
     <contributors>

--- a/plugins/roar/pom.xml
+++ b/plugins/roar/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>roar</artifactId>
     <version>0.6</version>
 
-    <name>Roar!!!</name>
+    <name>Roar</name>
     <description>Provides customizable popup/notification functionality.</description>
 
     <contributors>

--- a/plugins/transferguard/pom.xml
+++ b/plugins/transferguard/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>transferguard</artifactId>
     <version>1.2</version>
 
-    <name>Transfer Guard</name>
+    <name>TransferGuard</name>
     <description>Adds the ability to automatically reject file transfers based on preference configuration.</description>
 
     <contributors>

--- a/plugins/translator/pom.xml
+++ b/plugins/translator/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>translator</artifactId>
     <version>1.7</version>
 
-    <name>Translator Plugin</name>
+    <name>TranslatorPlugin</name>
     <description>Translates instant messages between users using Google Translation Service.</description>
 
     <contributors>


### PR DESCRIPTION
I hope someone will fix the problem with spaces in the names of plugins for working with ClientControl SPARK-2219.
But if it doesn't, push this PR: D