### PR TITLE
Disable meet plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <module>plugins/flashing</module>
         <module>plugins/growl</module>
         <!--<module>plugins/jingle</module>-->
-        <module>plugins/meet</module>
+        <!--<module>plugins/meet</module>-->
         <!--<module>plugins/otr</module>-->
         <module>plugins/reversi</module>
         <module>plugins/roar</module>


### PR DESCRIPTION
There is currently no way to turn off Meet from the Openfire console due to the spaces in the name. Therefore, so that users do not face network load, you need to turn off this plugin.