### PR TITLE
Enable meet plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <module>plugins/flashing</module>
         <module>plugins/growl</module>
         <!--<module>plugins/jingle</module>-->
-        <!--<module>plugins/meet</module>-->
+        <module>plugins/meet</module>
         <!--<module>plugins/otr</module>-->
         <module>plugins/reversi</module>
         <module>plugins/roar</module>


### PR DESCRIPTION
Hi, now Openfire can control Meet plugin https://github.com/igniterealtime/openfire-clientControl-plugin/pull/25
Therefore, I think we need to enable this plugin.