### PR TITLE
name of the plugin is stick together with the word "as"

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/PluginManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/PluginManager.java
@@ -346,7 +346,7 @@ public class PluginManager implements MainWindowListener
                     if ( _blacklistPlugins.contains( lower ) || _blacklistPlugins.contains( clazz )
                         || SettingsManager.getLocalPreferences().getDeactivatedPlugins().contains( name ) )
                     {
-                        Log.warning( "Not loading plugin " + name + "as it is blacklisted." );
+                        Log.warning( "Not loading plugin " + name + " as it is blacklisted." );
                         return null;
                     }
                 }


### PR DESCRIPTION
In the logs, I see that the name of the plugin is stick together with the word "as".