### PR TITLE
Fix ignoring of line breaks

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/MessageEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/MessageEntry.java
@@ -149,10 +149,13 @@ public class MessageEntry extends TimeStampedEntry
             if ( block.isPreformattedCodeBlock() )
             {
                 final MutableAttributeSet style = applyMessageStyle( '`', messageStyle );
+              
                 for ( final String line : block.lines )
                 {
-                    doc.insertString( doc.getLength(), line + "\n", line.trim().startsWith( "```" ) ? directiveStyle : style );
+                    doc.insertString(doc.getLength(), line, line.trim().startsWith( "```" ) ? directiveStyle : style );
                 }
+
+                doc.insertString( doc.getLength(), "\n", messageStyle );
             }
             else
             {
@@ -201,10 +204,10 @@ public class MessageEntry extends TimeStampedEntry
                         insertFragment(chatArea, line.substring(from, to), messageStyle);
                     }
                     while (to < line.length());
+                }
                     doc.insertString( doc.getLength(), "\n", messageStyle );
                 }
             }
-        }
 
         chatArea.setCaretPosition( doc.getLength() );
     }
@@ -227,7 +230,7 @@ public class MessageEntry extends TimeStampedEntry
         final java.util.List<Block> result = new ArrayList<>();
 
         // Process the text line-by-line
-        final StringTokenizer tokenizer = new StringTokenizer( text, "\n", false );
+        final StringTokenizer tokenizer = new StringTokenizer(text, "\n", true);
         Block block = null;
         while ( tokenizer.hasMoreTokens() )
         {
@@ -240,7 +243,7 @@ public class MessageEntry extends TimeStampedEntry
             else if ( !block.tryAppend( line ) )
             {
                 // If this line does not belong to the block that's already being constructed, then that block is
-                // done. Add it to the resul    t, and create a new one.
+                // done. Add it to the result, and create a new one.
                 result.add( block );
                 block = new Block(line);
             }


### PR DESCRIPTION
When a message had more than one line break, like this:

```
a

b

c
```
the following problem used to happen:

![before_2](https://user-images.githubusercontent.com/38164565/124331182-458d4c80-db65-11eb-80ab-0f01cfb413bb.png)

now that problem has been fixed, it will appear like this, as it should:
![image](https://user-images.githubusercontent.com/38164565/124331510-b6ccff80-db65-11eb-802f-074c6f0fe864.png)

explanation of what I did, if necessary:
first, I changed **new StringTokenizer(text, "\n", false);** to **new StringTokenizer(text, "\n", true);** for it to return the delimiters as tokens, and it caused a problem of doubling each line-breaks.

For that reason, I refactored to add a new line only when finished the insertion on the lines of the block.

