### PR TITLE
SPARK-2234: Fix 'freeze' when joining a new chat

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/CustomTextEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/CustomTextEntry.java
@@ -72,6 +72,7 @@ public class CustomTextEntry extends TimeStampedEntry
         final Document doc = chatArea.getDocument();
 
         doc.insertString( doc.getLength(), getFormattedTimestamp() + message + "\n", getStyle() );
-        chatArea.setCaretPosition( doc.getLength() );
+        // Enabling the 'setCaretPosition' line below causes Spark to freeze (often, not always) when trying to print the subject of a chatroom that's just being loaded.
+        // chatArea.setCaretPosition( doc.getLength() );
     }
 }

--- a/core/src/main/java/org/jivesoftware/spark/ui/HorizontalLineEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/HorizontalLineEntry.java
@@ -44,6 +44,7 @@ public class HorizontalLineEntry extends TranscriptWindowEntry
 
         chatArea.insertComponent( new JSeparator() );
         doc.insertString(doc.getLength(), "\n", null );
-        chatArea.setCaretPosition(doc.getLength());
+        // Enabling the 'setCaretPosition' line below causes Spark to freeze (often, not always) when trying to print the subject of a chatroom that's just being loaded.
+        // chatArea.setCaretPosition( doc.getLength() );
     }
 }

--- a/core/src/main/java/org/jivesoftware/spark/ui/MessageEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/MessageEntry.java
@@ -209,7 +209,8 @@ public class MessageEntry extends TimeStampedEntry
                 }
             }
 
-        chatArea.setCaretPosition( doc.getLength() );
+        // Enabling the 'setCaretPosition' line below causes Spark to freeze (often, not always) when trying to print the subject of a chatroom that's just being loaded.
+        // chatArea.setCaretPosition( doc.getLength() );
     }
 
     protected void insertFragment(ChatArea chatArea, String fragment, MutableAttributeSet style) throws BadLocationException {

--- a/core/src/main/java/org/jivesoftware/spark/ui/StartOfDayEntry.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/StartOfDayEntry.java
@@ -61,6 +61,7 @@ public class StartOfDayEntry extends TranscriptWindowEntry
 
         final Document doc = chatArea.getDocument();
         doc.insertString(doc.getLength(), startOfDayMessage + '\n', STYLE );
-        chatArea.setCaretPosition(doc.getLength());
+        // Enabling the 'setCaretPosition' line below causes Spark to freeze (often, not always) when trying to print the subject of a chatroom that's just being loaded.
+        // chatArea.setCaretPosition( doc.getLength() );
     }
 }


### PR DESCRIPTION
This fixes an issue where repeatedly setting the caret position when populating a chat room with historic messages freezes the UI completely.