### PR TITLE
[core] Fix VCardUpdateExtension.Provider

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/ext/VCardUpdateExtension.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/ext/VCardUpdateExtension.java
@@ -65,25 +65,24 @@ public class VCardUpdateExtension implements ExtensionElement {
         }
 
         @Override
-        public VCardUpdateExtension parse(XmlPullParser parser, int i, XmlEnvironment xmlEnvironment)
+        public VCardUpdateExtension parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment)
                 throws XmlPullParserException, IOException {
             final VCardUpdateExtension result = new VCardUpdateExtension();
 
             while ( true )
             {
                 parser.next();
-                String elementName = parser.getName();
                 switch ( parser.getEventType() )
                 {
                     case START_ELEMENT:
-                        if ( "photo".equals( elementName ) )
+                        if ( "photo".equals( parser.getName() ) )
                         {
                             result.setPhotoHash( parser.nextText() );
                         }
                         break;
 
                     case END_ELEMENT:
-                        if ( ELEMENT_NAME.equals( elementName ) )
+                        if ( parser.getDepth() == initialDepth )
                         {
                             return result;
                         }


### PR DESCRIPTION
Fixes

java.lang.IllegalStateException: Illegal to call getName() when event type is CHARACTERS. Valid states are START_ELEMENT, END_ELEMENT
at com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.getName(XMLStreamReaderImpl.java:938)
	at org.jivesoftware.smack.xml.stax.StaxXmlPullParser.getQName(StaxXmlPullParser.java:123)
	at org.jivesoftware.smack.xml.stax.StaxXmlPullParser.getName(StaxXmlPullParser.java:117)
	at org.jivesoftware.sparkimpl.profile.ext.VCardUpdateExtension$Provider.parse(VCardUpdateExtension.java:75)
	at org.jivesoftware.sparkimpl.profile.ext.VCardUpdateExtension$Provider.parse(VCardUpdateExtension.java:62)
	at org.jivesoftware.smack.provider.Provider.parse(Provider.java:53)
	at org.jivesoftware.smack.util.PacketParserUtils.parseExtensionElement(PacketParserUtils.java:834)
	at org.jivesoftware.smack.util.PacketParserUtils.parsePresence(PacketParserUtils.java:477)
	at org.jivesoftware.smack.util.PacketParserUtils.parseStanza(PacketParserUtils.java:115)
	at org.jivesoftware.smack.AbstractXMPPConnection.parseAndProcessStanza(AbstractXMPPConnection.java:1457)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection.access$1000(XMPPTCPConnection.java:130)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.parsePackets(XMPPTCPConnection.java:969)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader.access$700(XMPPTCPConnection.java:913)
	at org.jivesoftware.smack.tcp.XMPPTCPConnection$PacketReader$1.run(XMPPTCPConnection.java:936)
	at java.lang.Thread.run(Thread.java:748)