### PR TITLE
SPARK-2241: Allow SoundPreferences class to be deserialized

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/preference/sounds/SoundPreference.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/preference/sounds/SoundPreference.java
@@ -371,6 +371,7 @@ public class SoundPreference implements Preference {
     private XStream getXStream() {
         if (xstream == null) {
             xstream = new XStream();
+            xstream.allowTypes(new Class[]{SoundPreferences.class});
             xstream.alias("sounds", SoundPreferences.class);
         }
         return xstream;


### PR DESCRIPTION
The XStream library that takes care of deserializing XML data to a class instance needs to be configured to allow certain classes to be instantiated.