### PR TITLE
SPARK-2128 SPARK-2160 Fix lang for java 8-17

### DIFF
--- a/core/src/main/java/org/jivesoftware/resource/Res.java
+++ b/core/src/main/java/org/jivesoftware/resource/Res.java
@@ -18,7 +18,6 @@ package org.jivesoftware.resource;
 import org.jivesoftware.spark.PluginRes;
 import org.jivesoftware.spark.util.log.Log;
 
-import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -36,16 +35,13 @@ public class Res {
     }
 
     static {
-        prb = (PropertyResourceBundle)ResourceBundle.getBundle("i18n/spark_i18n");
+        prb = (PropertyResourceBundle)ResourceBundle.getBundle("i18n/spark_i18n", new UTF8Control());
     }
 
     public static String getString(String propertyName) {
         try {
             String pluginString = PluginRes.getI18nRes(propertyName);
-            /* Revert to this code after Spark is moved to Java 11 or newer
             return pluginString != null ? pluginString : prb.getString(propertyName);
-            */
-            return pluginString != null ? pluginString : new String(prb.getString(propertyName).getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
         }
         catch (Exception e) {
             Log.error(e);
@@ -57,14 +53,8 @@ public class Res {
     public static String getString(String propertyName, Object... obj) {
         String pluginString = PluginRes.getI18nRes(propertyName);
         String str;
-        /* Revert to this code after Spark is moved to Java 11 or newer
-        str = pluginString != null ? pluginString : prb.getString(propertyName);
-        if (str == null) {
-            return propertyName;
-        }
-        */
         try {
-			str = pluginString != null ? pluginString : new String(prb.getString(propertyName).getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+            str = pluginString != null ? pluginString : prb.getString(propertyName);
 			if (str == null) {
 				return propertyName;
 			}

--- a/core/src/main/java/org/jivesoftware/resource/UTF8Control.java
+++ b/core/src/main/java/org/jivesoftware/resource/UTF8Control.java
@@ -1,0 +1,45 @@
+package org.jivesoftware.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
+public class UTF8Control extends ResourceBundle.Control {
+    public ResourceBundle newBundle
+        (String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
+        throws IllegalAccessException, InstantiationException, IOException
+    {
+        // The below is a copy of the default implementation.
+        String bundleName = toBundleName(baseName, locale);
+        String resourceName = toResourceName(bundleName, "properties");
+        ResourceBundle bundle = null;
+        InputStream stream = null;
+        if (reload) {
+            URL url = loader.getResource(resourceName);
+            if (url != null) {
+                URLConnection connection = url.openConnection();
+                if (connection != null) {
+                    connection.setUseCaches(false);
+                    stream = connection.getInputStream();
+                }
+            }
+        } else {
+            stream = loader.getResourceAsStream(resourceName);
+        }
+        if (stream != null) {
+            try {
+                // Only this line is changed to make it to read properties files as UTF-8.
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, StandardCharsets.UTF_8));
+            } finally {
+                stream.close();
+            }
+        }
+        return bundle;
+    }
+}

--- a/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/FpRes.java
+++ b/plugins/fastpath/src/main/java/org/jivesoftware/fastpath/FpRes.java
@@ -15,9 +15,9 @@
  */
 package org.jivesoftware.fastpath;
 
+import org.jivesoftware.resource.UTF8Control;
 import org.jivesoftware.spark.util.log.Log;
 
-import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -32,15 +32,12 @@ public class FpRes {
     }
 
     static {
-        prb = (PropertyResourceBundle)ResourceBundle.getBundle("i18n/fastpath_i18n");
+        prb = (PropertyResourceBundle)ResourceBundle.getBundle("i18n/fastpath_i18n", new UTF8Control());
     }
 
     public static String getString(String propertyName) {
         try {
-            /* Revert to this code after Spark is moved to Java 11 or newer
             return prb.getString(propertyName);
-            */
-            return new String(prb.getString(propertyName).getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
         }
         catch (Exception e) {
             Log.error(e);

--- a/plugins/flashing/src/main/java/org/jivesoftware/spark/plugin/flashing/FlashingResources.java
+++ b/plugins/flashing/src/main/java/org/jivesoftware/spark/plugin/flashing/FlashingResources.java
@@ -15,25 +15,22 @@
  */
 package org.jivesoftware.spark.plugin.flashing;
 
-import java.nio.charset.StandardCharsets;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
+import org.jivesoftware.resource.UTF8Control;
 import org.jivesoftware.spark.util.log.Log;
 
 public class FlashingResources {
 	private static final PropertyResourceBundle prb;
 	
 	static {
-		prb = (PropertyResourceBundle)ResourceBundle.getBundle("i18n/flashing_i18n");
+		prb = (PropertyResourceBundle)ResourceBundle.getBundle("i18n/flashing_i18n", new UTF8Control());
 	}
 	
     public static String getString(String propertyName) {
         try {
-            /* Revert to this code after Spark is moved to Java 11 or newer
             return prb.getString(propertyName);
-            */
-            return new String(prb.getString(propertyName).getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
         }
         catch (Exception e) {
             Log.error(e);

--- a/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiRes.java
+++ b/plugins/reversi/src/main/java/org/jivesoftware/game/reversi/ReversiRes.java
@@ -1,5 +1,7 @@
 package org.jivesoftware.game.reversi;
 
+import org.jivesoftware.resource.UTF8Control;
+
 import java.net.URL;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -27,7 +29,7 @@ public class ReversiRes {
 	    private static final ClassLoader cl = ReversiRes.class.getClassLoader();
 
 	    static {
-	    	ReversiRes.prb = (PropertyResourceBundle) ResourceBundle.getBundle("reversi");
+	    	ReversiRes.prb = (PropertyResourceBundle) ResourceBundle.getBundle("reversi", new UTF8Control());
 	    }
 	    
 	    public static String getString(String propertyName) {

--- a/plugins/roar/src/main/java/org/jivesoftware/spark/roar/RoarResources.java
+++ b/plugins/roar/src/main/java/org/jivesoftware/spark/roar/RoarResources.java
@@ -1,9 +1,9 @@
 package org.jivesoftware.spark.roar;
 
-import java.nio.charset.StandardCharsets;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
+import org.jivesoftware.resource.UTF8Control;
 import org.jivesoftware.spark.util.log.Log;
 
 public class RoarResources {
@@ -11,15 +11,12 @@ public class RoarResources {
     private static final PropertyResourceBundle prb;
 
     static {
-	prb = (PropertyResourceBundle) ResourceBundle.getBundle("i18n/roar_i18n");
+	prb = (PropertyResourceBundle) ResourceBundle.getBundle("i18n/roar_i18n", new UTF8Control());
     }
 
     public static String getString(String propertyName) {
 	try {
-        /* Revert to this code after Spark is moved to Java 11 or newer
         return prb.getString(propertyName);
-        */
-	    return new String(prb.getString(propertyName).getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
 	} catch (Exception e) {
 	    Log.error(e);
 	    return propertyName;

--- a/plugins/spelling/src/main/java/org/jivesoftware/spellchecker/SpellcheckerResource.java
+++ b/plugins/spelling/src/main/java/org/jivesoftware/spellchecker/SpellcheckerResource.java
@@ -15,11 +15,11 @@
  */
 package org.jivesoftware.spellchecker;
 
-import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
+import org.jivesoftware.resource.UTF8Control;
 import org.jivesoftware.spark.util.log.Log;
 
 public class SpellcheckerResource {
@@ -28,15 +28,12 @@ public class SpellcheckerResource {
     static ClassLoader cl = SpellcheckerResource.class.getClassLoader();
 
     static {
-	prb = (PropertyResourceBundle) ResourceBundle.getBundle("i18n/spellchecker_i18n");
+	prb = (PropertyResourceBundle) ResourceBundle.getBundle("i18n/spellchecker_i18n", new UTF8Control());
     }
 
     public static String getString(String propertyName) {
         try {
-            /* Revert to this code after Spark is moved to Java 11 or newer
             return prb.getString(propertyName);
-            */
-            return new String(prb.getString(propertyName).getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
         }
         catch (Exception e) {
             Log.error(e);

--- a/plugins/tictactoe/src/main/java/tic/tac/toe/TTTRes.java
+++ b/plugins/tictactoe/src/main/java/tic/tac/toe/TTTRes.java
@@ -19,6 +19,7 @@ import java.text.MessageFormat;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
+import org.jivesoftware.resource.UTF8Control;
 import org.jivesoftware.spark.util.log.Log;
 
 /**
@@ -32,7 +33,7 @@ public class TTTRes {
     private static final PropertyResourceBundle prb;
 
     static {
-        prb = (PropertyResourceBundle) ResourceBundle.getBundle("i18n/tictactoe_i18n");
+        prb = (PropertyResourceBundle) ResourceBundle.getBundle("i18n/tictactoe_i18n", new UTF8Control());
     }
 
     public static String getString(String propertyName) {

--- a/plugins/transferguard/src/main/java/org/jivesoftware/spark/plugins/transfersettings/TGuardRes.java
+++ b/plugins/transferguard/src/main/java/org/jivesoftware/spark/plugins/transfersettings/TGuardRes.java
@@ -1,8 +1,9 @@
 package org.jivesoftware.spark.plugins.transfersettings;
 
-import java.nio.charset.StandardCharsets;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
+
+import org.jivesoftware.resource.UTF8Control;
 import org.jivesoftware.spark.util.log.Log;
 
 /**
@@ -19,15 +20,12 @@ public class TGuardRes {
 
     static {
         prb = (PropertyResourceBundle) ResourceBundle
-        		.getBundle("i18n/transferguard_i18n");
+        		.getBundle("i18n/transferguard_i18n", new UTF8Control());
     }
     
     public static String getString(String propertyName) {
     try {
-        /* Revert to this code after Spark is moved to Java 11 or newer
         return prb.getString(propertyName);
-        */
-        return new String(prb.getString(propertyName).getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
     } catch (Exception e) {
 	    Log.error(e);
 	    return propertyName;


### PR DESCRIPTION
stackoverflow suggest this way to fix utf-8 encoding.
It seems to work and now in java 8, 11, 15 the text is displayed fine.
I wonder if this might be a solution?

https://stackoverflow.com/questions/4659929/how-to-use-utf-8-in-resource-properties-with-resourcebundle

