### PR TITLE
SPARK-2182 Switches to using hostname as resource after a re-login

### DIFF
--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -1119,16 +1119,16 @@ public class LoginDialog {
                     connection.login();
                 } else {
                     String resource = localPref.getResource();
-                    if (Default.getBoolean(Default.HOSTNAME_AS_RESOURCE) || localPref.isUseHostnameAsResource()) {
+                    if (Default.getBoolean(Default.USE_HOSTNAME_AS_RESOURCE) || localPref.isUseHostnameAsResource()) {
                         try {
                             resource = InetAddress.getLocalHost().getHostName();
                         } catch (UnknownHostException e) {
                             Log.warning("Cannot set hostname as resource - unable to retrieve hostname.", e);
                         }
-                    } else if (Default.getBoolean(Default.VERSION_AS_RESOURCE) || localPref.isUseVersionAsResource()) {
+                    } else if (Default.getBoolean(Default.USE_VERSION_AS_RESOURCE) || localPref.isUseVersionAsResource()) {
                         resource = JiveInfo.getName() + " " + JiveInfo.getVersion();
                     }
-
+                    
                     Resourcepart resourcepart = Resourcepart.from(modifyWildcards(resource).trim());
                     connection.login(getLoginUsername(), getLoginPassword(), resourcepart);
                 }
@@ -1597,8 +1597,10 @@ public class LoginDialog {
         localPref.setInvisibleLogin(Enterprise.containsFeature(Enterprise.INVISIBLE_LOGIN_FEATURE));
         localPref.setAnonymousLogin(Enterprise.containsFeature(Enterprise.ANONYMOUS_LOGIN_FEATURE));
         localPref.setPswdAutologin(Enterprise.containsFeature(Enterprise.SAVE_PASSWORD_FEATURE));
-        localPref.setUseHostnameAsResource(Enterprise.containsFeature(Enterprise.HOSTNAME_AS_RESOURCE_FEATURE));
-        localPref.setUseVersionAsResource(Enterprise.containsFeature(Enterprise.VERSION_AS_RESOURCE_FEATURE));
+        if (Enterprise.containsFeature(Enterprise.HOSTNAME_AS_RESOURCE_FEATURE) != Enterprise.containsFeature(Enterprise.VERSION_AS_RESOURCE_FEATURE)) {
+            localPref.setUseHostnameAsResource(Enterprise.containsFeature(Enterprise.HOSTNAME_AS_RESOURCE_FEATURE));
+            localPref.setUseVersionAsResource(Enterprise.containsFeature(Enterprise.VERSION_AS_RESOURCE_FEATURE));
+        }
     }
 
     private void initAdvancedDefaults() {

--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -1612,7 +1612,7 @@ public class LoginDialog {
         localPref.setProxyEnabled(localPref.isProxyEnabled());
         //  localPref.setProxyPassword("");
         //  localPref.setProxyUsername("");
-        localPref.setResource("Spark");
+        localPref.setResource(localPref.getResource());
         localPref.setSaslGssapiSmack3Compatible(localPref.isSaslGssapiSmack3Compatible());
         localPref.setSSL(localPref.isSSL());
         localPref.setSecurityMode(localPref.getSecurityMode());

--- a/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
+++ b/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
@@ -1652,7 +1652,7 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
         localPref.setProxyEnabled(localPref.isProxyEnabled());
         //  localPref.setProxyPassword("");
         //  localPref.setProxyUsername("");
-        localPref.setResource("Spark");
+        localPref.setResource(localPref.getResource());
         localPref.setSaslGssapiSmack3Compatible(localPref.isSaslGssapiSmack3Compatible());
         localPref.setSSL(localPref.isSSL());
         localPref.setSecurityMode(localPref.getSecurityMode());

--- a/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
+++ b/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
@@ -1215,13 +1215,13 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
                 connection.login();
             } else {
                 String resource = localPref.getResource();
-                if (Default.getBoolean(Default.HOSTNAME_AS_RESOURCE) || localPref.isUseHostnameAsResource()) {
+                if (Default.getBoolean(Default.USE_HOSTNAME_AS_RESOURCE) || localPref.isUseHostnameAsResource()) {
                     try {
                         resource = InetAddress.getLocalHost().getHostName();
                     } catch (UnknownHostException e) {
                         Log.warning("Cannot set hostname as resource - unable to retrieve hostname.", e);
                     }
-                } else if (Default.getBoolean(Default.VERSION_AS_RESOURCE) || localPref.isUseVersionAsResource()) {
+                } else if (Default.getBoolean(Default.USE_VERSION_AS_RESOURCE) || localPref.isUseVersionAsResource()) {
                     resource = JiveInfo.getName() + " " + JiveInfo.getVersion();
                 }
 
@@ -1637,8 +1637,10 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
         localPref.setInvisibleLogin(Enterprise.containsFeature(Enterprise.INVISIBLE_LOGIN_FEATURE));
         localPref.setAnonymousLogin(Enterprise.containsFeature(Enterprise.ANONYMOUS_LOGIN_FEATURE));
         localPref.setPswdAutologin(Enterprise.containsFeature(Enterprise.SAVE_PASSWORD_FEATURE));
-        localPref.setUseHostnameAsResource(Enterprise.containsFeature(Enterprise.HOSTNAME_AS_RESOURCE_FEATURE));
-        localPref.setUseVersionAsResource(Enterprise.containsFeature(Enterprise.VERSION_AS_RESOURCE_FEATURE));
+        if (Enterprise.containsFeature(Enterprise.HOSTNAME_AS_RESOURCE_FEATURE) != Enterprise.containsFeature(Enterprise.VERSION_AS_RESOURCE_FEATURE)) {
+            localPref.setUseHostnameAsResource(Enterprise.containsFeature(Enterprise.HOSTNAME_AS_RESOURCE_FEATURE));
+            localPref.setUseVersionAsResource(Enterprise.containsFeature(Enterprise.VERSION_AS_RESOURCE_FEATURE));
+        }
     }
 
     private void initAdvancedDefaults() {

--- a/core/src/main/java/org/jivesoftware/resource/Default.java
+++ b/core/src/main/java/org/jivesoftware/resource/Default.java
@@ -92,8 +92,6 @@ public class Default {
     public static final String USER_DIRECTORY_WINDOWS = "USER_DIRECTORY_WINDOWS";
     public static final String USER_DIRECTORY_LINUX = "USER_DIRECTORY_LINUX";
     public static final String USER_DIRECTORY_MAC = "USER_DIRECTORY_MAC";
-    public static final String HOSTNAME_AS_RESOURCE = "HOSTNAME_AS_RESOURCE";
-    public static final String VERSION_AS_RESOURCE = "VERSION_AS_RESOURCE";
     public static final String HISTORY_DISABLED = "HISTORY_DISABLED";
     public static final String HIDE_HISTORY_SETTINGS = "HIDE_HISTORY_SETTINGS";
     public static final String HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN = "HIDE_SAVE_PASSWORD_AND_AUTO_LOGIN";

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/GeneralLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/GeneralLoginSettingsPanel.java
@@ -92,7 +92,7 @@ class GeneralLoginSettingsPanel extends JPanel implements ActionListener
 
         add( connectionPanel, new GridBagConstraints( 0, 1, 3, 1, 1.0, 0.0, NORTHWEST, BOTH, DEFAULT_INSETS, 0, 0 ) );
 
-        if ( Default.getBoolean( Default.HOSTNAME_AS_RESOURCE ) == Default.getBoolean( Default.VERSION_AS_RESOURCE ) )
+        if ( Default.getBoolean( Default.USE_VERSION_AS_RESOURCE ) == Default.getBoolean( Default.USE_VERSION_AS_RESOURCE ) )
         {
             add( resourceLabel,            new GridBagConstraints( 0, 2, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 0, 0 ) );
             add( resourceField,            new GridBagConstraints( 1, 2, 1, 1, 0.0, 0.0, WEST, NONE, DEFAULT_INSETS, 100, 0 ) );

--- a/core/src/main/resources/default.properties
+++ b/core/src/main/resources/default.properties
@@ -35,8 +35,8 @@ ADVANCED_DISABLED =
 
 # Force using hostname or version as a resource (both are "false" by default; only one can be
 # "true" at a time; if both are "true", then hostname will be used as a resource)
-HOSTNAME_AS_RESOURCE = false
-VERSION_AS_RESOURCE = false
+USE_HOSTNAME_AS_RESOURCE = false
+USE_VERSION_AS_RESOURCE = false
 
 # When enabled, it removes history from the chat window and doesn't save history into transcript files. Also removes history
 # settings from the preferences, removes history button from the chat window and contact's history context menu.
@@ -61,8 +61,6 @@ MUTUAL_AUTH_DISABLED = false
 # General
 HOST_AND_PORT_CONFIGURED = false
 XMPP_PORT = 5222
-USE_HOSTNAME_AS_RESOURCE = false
-USE_VERSION_AS_RESOURCE = false
 TIME_OUT = 10
 COMPRESSION_ENABLED = false
 DEBUGGER_ENABLED = false


### PR DESCRIPTION
There are three problems with SPARK-2182:
1) If ClientControl is not installed on the Openfire server then the HOSTNAME_AS_RESOURCE_FEATURE and VERSION_AS_RESOURCE_FEATURE values ​​are always "true"! To avoid this, you need to compare these values ​​that they are not equal to each other.
2) There are 4 parameters, it's confusing, there should be two. Either HOSTNAME_AS_RESOURCE and VERSION_AS_RESOURCE or USE_HOSTNAME_AS_RESOURCE and USE_VERSION_AS_RESOURCE.
3) Resource name after reconnect is reset to "Spark". The resource must not be hard-coded. you need to use "get" to get the name of the resource.

After applying this PR, I see that by default my resource name is "Spark" and if I choose "Version as resource" or "Hostname as resource" then it works. =)
