### PR TITLE
SPARK-2269 Incorrect handling of carbons

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -536,15 +536,25 @@ public class ChatRoomImpl extends ChatRoom {
                         {
                             if ( carbon.getDirection() == CarbonExtension.Direction.received )
                             {
-                                // This is a stanza that we received from someone on one of our other clients.
-                                setParticipantJID(forwardedStanza.getFrom());
-                                insertMessage( forwardedStanza );
+                                if ((forwardedStanza.getFrom().equals(getJid()) && privateChat) || //private chat from MUC, match the full JID
+                                    (forwardedStanza.getFrom().asBareJid().equals(getJid().asBareJid()) && !privateChat)) //person to person chat, match bare jids
+                                {
+                                    // This is a stanza that we received from someone on one of our other clients.
+                                    setParticipantJID(forwardedStanza.getFrom());
+                                    insertMessage( forwardedStanza );
+                                }
+
                             }
                             else
                             {
-                                // This is a stanza that one of our own clients sent.
-                                setParticipantJID(forwardedStanza.getTo());
-                                displaySendMessage( forwardedStanza );
+                                if ((forwardedStanza.getTo().equals(getJid()) && privateChat) || //private chat from MUC, match full JID
+                                    (forwardedStanza.getTo().asBareJid().equals(getJid().asBareJid()) && !privateChat)) //person to person chat, match bare jids
+                                {
+                                    // This is a stanza that one of our own clients sent.
+                                    setParticipantJID(forwardedStanza.getTo());
+                                    displaySendMessage( forwardedStanza );
+                                }
+
                             }
                             showTyping( false );
                         }


### PR DESCRIPTION
[Alex Matthews](https://discourse.igniterealtime.org/u/qoole/summary) provided a fix for this problem. I tested it on two different devices and now the message comes to the correct tab and not to everyone

https://discourse.igniterealtime.org/t/muc-private-messages-all-other-tabs-being-taken-over-when-signed-in-to-multiple-sessions/91623?u=ilyahlevnoy