### PR TITLE
SPARK-2076 Contact list font size setting should be applied to groups…

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/component/panes/CollapsibleTitlePane.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/panes/CollapsibleTitlePane.java
@@ -19,6 +19,8 @@ import org.jivesoftware.resource.SparkRes;
 import org.jivesoftware.spark.util.ColorUtil;
 import org.jivesoftware.spark.util.GraphicUtils;
 import org.jivesoftware.spark.util.log.Log;
+import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
+import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -61,11 +63,14 @@ public class CollapsibleTitlePane extends BaseCollapsibleTitlePane {
 
     private Image backgroundImage;
 
+    private final int fontSize;
+
     public CollapsibleTitlePane() {
         setLayout(new GridBagLayout());
 
         titleColor = new Color(33, 93, 198);
-        Font titleFont = new Font("Dialog", Font.BOLD, 11);
+        fontSize = SettingsManager.getLocalPreferences().getContactListFontSize();
+        Font titleFont = new Font("Dialog", Font.BOLD, fontSize);
 
         // Initialize color
         startColor = new Color(238,242,253);

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactGroup.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactGroup.java
@@ -46,6 +46,8 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
     private final List<ContactGroupListener> listeners = new ArrayList<>();
     private final List<ContactItem> offlineContacts = new ArrayList<>();
 
+    private final int fontSize;
+
     private String groupName;
     private final DefaultListModel<ContactItem> model;
     private final JList<? extends ContactItem> contactItemList;
@@ -81,6 +83,8 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
         preferences = SettingsManager.getLocalPreferences();
 
         setTitle(getGroupTitle(groupName));
+
+        fontSize = preferences.getContactListFontSize();
 
         // Use JPanel Renderer
         contactItemList.setCellRenderer(new JContactItemRenderer());
@@ -150,7 +154,7 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
             }
         });
 
-        noContacts.getNicknameLabel().setFont(new Font("Dialog", Font.PLAIN, 11));
+        noContacts.getNicknameLabel().setFont(new Font("Dialog", Font.PLAIN, fontSize));
         noContacts.getNicknameLabel().setForeground(Color.GRAY);
         model.addElement(noContacts);
 


### PR DESCRIPTION
Currently "Contact List Font Size" setting affects only names of the contacts, but groups names stay the same, which can be too small for some users. This setting should be applied to names of the groups as well.