### PR TITLE
Revert SPARK-2216

### DIFF
--- a/core/src/main/resources/default.properties
+++ b/core/src/main/resources/default.properties
@@ -187,9 +187,9 @@ FILE_TRANSFER_WARNING_SIZE = -1
 FILE_TRANSFER_MAXIMUM_SIZE = -1
 
 # Force in-band bytestream only.
-FILE_TRANSFER_IBB_ONLY = false
+FILE_TRANSFER_IBB_ONLY = true
 
-# Automatically accept file transfer offers from people that have presence subscribtion
+# Automatically accept file transfer offers from people that have presence subscription
 FILE_TRANSFER_AUTO_ACCEPT_PRESENCE = false
 
 #################################################


### PR DESCRIPTION
Since [SPARK-2209](https://igniterealtime.atlassian.net/browse/SPARK-2209) is fixed, I think IBB should be enabled by default because it transfers files better.