### PR TITLE
SPARK-2214 Replace depricated method "install"

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/themes/lafs/SparkLightLaf.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/themes/lafs/SparkLightLaf.java
@@ -14,7 +14,7 @@ import com.formdev.flatlaf.FlatLightLaf;
  */
 public class SparkLightLaf extends FlatLightLaf {
 
-    public static boolean install() {
+    public static boolean setup() {
         return setup(new SparkLightLaf());
     }
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/themes/lafs/SparkLightLaf.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/themes/lafs/SparkLightLaf.java
@@ -15,7 +15,7 @@ import com.formdev.flatlaf.FlatLightLaf;
 public class SparkLightLaf extends FlatLightLaf {
 
     public static boolean install() {
-        return install(new SparkLightLaf());
+        return setup(new SparkLightLaf());
     }
 
     @Override


### PR DESCRIPTION
Renamed Flat*Laf.install() methods to Flat*Laf.setup() to avoid confusion
with UIManager.installLookAndFeel(LookAndFeelInfo info). The old
Flat*Laf.install() methods are still there, but marked as deprecated. They
will be removed in a future version.

https://github.com/JFormDesigner/FlatLaf/releases/tag/1.2