### PR TITLE
SPARK-2279 SPARK-2280 Add clear button for Login text field and eye button to show password

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -238,7 +238,7 @@
         <dependency>
         <groupId>com.formdev</groupId>
         <artifactId>flatlaf</artifactId>
-        <version>1.6.5</version>
+        <version>2.4</version>
         <type>jar</type>
         </dependency>
         <dependency>

--- a/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
+++ b/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
@@ -269,6 +269,10 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
         cbAnonymous.setSelected(localPref.isLoginAnonymously());
         tfUsername.setEnabled(!cbAnonymous.isSelected());
         tfPassword.setEnabled(!cbAnonymous.isSelected());
+        //Add clear button for username,password and domain field
+        tfUsername.putClientProperty("JTextField.showClearButton",true);
+        tfDomain.putClientProperty("JTextField.showClearButton",true);
+        tfPassword.putClientProperty("JTextField.showClearButton",true);
         useSSO(localPref.isSSOEnabled());
         if (cbAutoLogin.isSelected()) {
             TaskEngine.getInstance().submit(this::login);

--- a/core/src/main/java/org/jivesoftware/spark/ui/themes/LookAndFeelManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/themes/LookAndFeelManager.java
@@ -221,6 +221,9 @@ public class LookAndFeelManager {
             UIManager.put("TabbedPane.showTabSeparators", true);
             UIManager.put("TabbedPane.hasFullBorder", true);
             UIManager.put("TabbedPane.underlineColor", new Color(242, 159, 97));
+            UIManager.put("TitlePane.unifiedBackground",false);
+            // Add "eye" button to show password for all passwordField
+            UIManager.put("PasswordField.showRevealButton",true);
             
             UIManager.setLookAndFeel(new SparkLightLaf());
             FlatLaf.updateUILater();


### PR DESCRIPTION
In the latest versions of FlatLaf [CLICK](https://github.com/JFormDesigner/FlatLaf/pull/442), it's possible to add a clear and show password button to the field. I think we should use this.

![image](https://user-images.githubusercontent.com/71222850/185791770-c482eeb3-6fea-422c-a007-b81ad75411f7.png)
