### PR TITLE
SPARK-2281 Fix menu "View client version" and add notification window

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/JabberVersion.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/JabberVersion.java
@@ -32,11 +32,7 @@ import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.settings.JiveInfo;
 import org.jivesoftware.resource.Res;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JComponent;
-import javax.swing.JPopupMenu;
-import javax.swing.KeyStroke;
+import javax.swing.*;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
@@ -133,12 +129,22 @@ public class JabberVersion implements Plugin {
     }
 
     private void viewClient() {
+        final JTextField field = new JTextField();
         final ContactList contactList = SparkManager.getWorkspace().getContactList();
         Collection<ContactItem> selectedUsers = contactList.getSelectedUsers();
         if (selectedUsers.size() == 1) {
-            ContactItem item = (ContactItem)selectedUsers.toArray()[0];
-            Presence presence = item.getPresence();
-            final String jid = presence.getFrom().toString();
+            final ContactItem item = (ContactItem)selectedUsers.toArray()[0];
+            final Presence presence = item.getPresence();
+            final String jid;
+            try {
+                 jid = presence.getFrom().toString();
+            }catch (NullPointerException e){
+                JOptionPane.showMessageDialog(field,
+                    item.getAlias() + " " +Res.getString("user.has.signed.off"),
+                    Res.getString("title.notification"),
+                    JOptionPane.INFORMATION_MESSAGE);
+                return;
+            }
             SwingWorker worker = new SwingWorker() {
                 @Override
 				public Object construct() {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/VersionViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/VersionViewer.java
@@ -19,8 +19,6 @@ import org.jivesoftware.resource.Res;
 import org.jivesoftware.resource.SparkRes;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.IQ;
-import org.jivesoftware.smack.packet.IqData;
-import org.jivesoftware.smack.packet.StanzaFactory;
 import org.jivesoftware.smackx.time.packet.Time;
 import org.jivesoftware.smackx.iqversion.packet.Version;
 import org.jivesoftware.spark.SparkManager;
@@ -95,15 +93,9 @@ public class VersionViewer {
         cards.add(dataCard);
 
         final XMPPConnection connection = SparkManager.getConnection();
-
-        StanzaFactory stanzaFactory = connection.getStanzaFactory();
-        IqData versionIqData = stanzaFactory.buildIqData().ofType(IQ.Type.get);
-        IqData timeIqData = stanzaFactory.buildIqData().ofType(IQ.Type.get);
-
         // Load Version
         final Version versionRequest = new Version();
-        versionRequest.setType(versionIqData.getType());
-        versionRequest.setStanzaId(versionIqData.getStanzaId());
+        versionRequest.setType(IQ.Type.get);
         versionRequest.setTo(jid);
 
         connection.sendIqRequestAsync(versionRequest)
@@ -121,8 +113,7 @@ public class VersionViewer {
 
         // Time
         final Time time = new Time();
-        time.setType(timeIqData.getType());
-        time.setStanzaId(timeIqData.getStanzaId());
+        time.setType(IQ.Type.get);
         time.setTo(jid);
 
         connection.sendIqRequestAsync(time)


### PR DESCRIPTION
After upgrading from Smack 4.3.X to Smack 4.4.X, the "View client version" menu does not work. 

Now menu is working
![2022-08-22_19-27-13](https://user-images.githubusercontent.com/71222850/185975859-39f68c9d-e416-4308-bb24-281fde991736.png)

And also if User is offline(NPE is thrown) i think we should catch this exception and show Information message.
![2022-08-22_19-27-32](https://user-images.githubusercontent.com/71222850/185977098-2f5390a1-aed3-4b2f-9ff6-327cb5e995ba.png)
 