### PR TITLE
SPARK-2250 Incorrect display of the name if the contact is not in the list of users.

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -802,15 +802,10 @@ public class ChatRoomImpl extends ChatRoom {
     					nickname = personalNickname;
     				}
     				else {
-    				    Resourcepart resourcepart = message.getFrom().getResourceOrNull();
-    				    if (resourcepart == null) {
-    				        Localpart localpart = message.getFrom().getLocalpartOrNull();
-    				        if (localpart != null) {
+                        Localpart localpart = message.getFrom().getLocalpartOrNull();
+                        if (localpart != null) {
     				            nickname = localpart.toString();
-    				        }
-    				    } else {
-    				        nickname = resourcepart.toString();
-    				    }
+                        }
     				}
     			}
 


### PR DESCRIPTION
If the contact is not in our list then we should show it's LocalPart and not ResourcePart.