### PR TITLE
SPARK-2292 Improve the log window

### DIFF
--- a/core/src/main/java/org/jivesoftware/MainWindow.java
+++ b/core/src/main/java/org/jivesoftware/MainWindow.java
@@ -28,10 +28,12 @@ import org.jivesoftware.smack.packet.Presence;
 import org.jivesoftware.spark.SparkManager;
 import org.jivesoftware.spark.ui.ChatFrame;
 import org.jivesoftware.spark.ui.RawPacketSender;
+import org.jivesoftware.spark.ui.TranscriptWindow;
 import org.jivesoftware.spark.util.*;
 import org.jivesoftware.spark.util.SwingWorker;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.plugin.alerts.InputTextAreaDialog;
+import org.jivesoftware.sparkimpl.plugin.filetransfer.transfer.Downloads;
 import org.jivesoftware.sparkimpl.plugin.layout.LayoutSettingsManager;
 import org.jivesoftware.sparkimpl.plugin.manager.Enterprise;
 import org.jivesoftware.sparkimpl.settings.JiveInfo;
@@ -836,16 +838,45 @@ public final class MainWindow extends ChatFrame implements ActionListener {
         pane.setFont(new Font("Dialog", Font.PLAIN, 12));
         pane.setEditable(false);
         pane.setText(errorLogs);
+        
+        final JButton copyButton = new JButton(Res.getString("button.copy.to.clipboard"));
+        copyButton.setIcon(SparkRes.getImageIcon(SparkRes.COPY_16x16));
+        final JButton openFolder = new JButton(Res.getString("open.folder"));
+        openFolder.setIcon(SparkRes.getImageIcon(SparkRes.FOLDER));
+
+        final JPanel panel = new JPanel();
+        panel.add(openFolder, BorderLayout.LINE_START);
+        panel.add(copyButton, BorderLayout.LINE_END);
 
         frame.add(new JScrollPane(pane), BorderLayout.CENTER);
+        frame.add(panel, BorderLayout.SOUTH);
 
-        final JButton copyButton = new JButton(Res.getString("button.copy.to.clipboard"));
-        frame.add(copyButton, BorderLayout.SOUTH);
 
         copyButton.addActionListener( e -> {
             SparkManager.setClipboard(errorLogs);
             copyButton.setEnabled(false);
         } );
+
+        openFolder.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseEntered(MouseEvent e) {
+                openFolder.setCursor(new Cursor(Cursor.HAND_CURSOR));
+            }
+
+            @Override
+            public void mouseExited(MouseEvent e) {
+                openFolder.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+            }
+
+            @Override
+            public void mousePressed(MouseEvent event) {
+                try {
+                    Desktop.getDesktop().open(Spark.getLogDirectory());
+                } catch (IOException e) {
+                    Log.error("An error occurred while trying to open logs file: " + Spark.getLogDirectory(), e);
+                }
+            }
+        });
 
         frame.pack();
         frame.setSize(530, 500);


### PR DESCRIPTION
I think we need to add additional buttons to the log window so that users can quickly find the folder with logs or copy the log with errors.

![2022-09-25_20-33-17](https://user-images.githubusercontent.com/71222850/192157285-4f94787e-0335-4eea-82ba-f970b03107ea.png)
