### PR TITLE
SPARK-2250 SPARK-2223 Incorrect Display name and load MUC History

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/rooms/ChatRoomImpl.java
@@ -788,7 +788,7 @@ public class ChatRoomImpl extends ChatRoom {
     			return;
     		}
 
-    		final ChatTranscript chatTranscript = ChatTranscripts.getCurrentChatTranscript(getParticipantJID());
+            final ChatTranscript chatTranscript = ChatTranscripts.getCurrentChatTranscript(getJid());
     		final String personalNickname = SparkManager.getUserManager().getNickname();
 
     		for (HistoryMessage message : chatTranscript.getMessages()) {
@@ -803,13 +803,19 @@ public class ChatRoomImpl extends ChatRoom {
     				}
     				else {
     				    Resourcepart resourcepart = message.getFrom().getResourceOrNull();
+                        Localpart localpart = message.getFrom().getLocalpartOrNull();
     				    if (resourcepart == null) {
-    				        Localpart localpart = message.getFrom().getLocalpartOrNull();
     				        if (localpart != null) {
     				            nickname = localpart.toString();
     				        }
     				    } else {
-    				        nickname = resourcepart.toString();
+                            if(!message.getFrom().getDomain().toString().equals(localPreferences.getServer())){
+                                nickname = resourcepart.toString();
+                            } else {
+                                if(localpart != null){
+                                    nickname = localpart.toString();
+                                }
+                            }
     				    }
     				}
     			}

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscriptPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscriptPlugin.java
@@ -57,6 +57,8 @@ import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityJid;
+import org.jxmpp.jid.Jid;
 
 /**
  * The <code>ChatTranscriptPlugin</code> is responsible for transcript handling within Spark.
@@ -67,7 +69,7 @@ public class ChatTranscriptPlugin implements ChatRoomListener {
 
     private final SimpleDateFormat notificationDateFormatter;
     private final SimpleDateFormat messageDateFormatter;
-    private final HashMap<EntityBareJid, Message> lastMessage = new HashMap<>();
+    private final HashMap<EntityJid, Message> lastMessage = new HashMap<>();
     private JDialog Frame;
     private HistoryTranscript transcript = null;
     /**
@@ -222,7 +224,17 @@ public class ChatTranscriptPlugin implements ChatRoomListener {
             return;
         }
 
-        final EntityBareJid jid = room.getBareJid();
+        EntityJid jid = room.getJid();
+
+        //If this it a MUC then don't persist this chat.
+        if(jid.hasNoResource() && !jid.getDomain().toString().equals(pref.getServer())){
+            return;
+        }
+
+        //If this is a one-to-one chat( "user@domain.local" )
+        if(jid.hasResource() && jid.getDomain().toString().equals(pref.getServer())){
+            jid = room.getBareJid();
+        }
 
         final List<Message> transcripts = room.getTranscripts();
         ChatTranscript transcript = new ChatTranscript();

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
@@ -70,7 +70,7 @@ public final class ChatTranscripts {
      * @param jid        the jid of the user.
      * @param transcript the ChatTranscript.
      */
-    public static void appendToTranscript(EntityBareJid jid, ChatTranscript transcript) {
+    public static void appendToTranscript(Jid jid, ChatTranscript transcript) {
     	final File transcriptFile = getTranscriptFile(jid);
 
        	if (!Default.getBoolean(Default.HISTORY_DISABLED) && Enterprise.containsFeature(Enterprise.HISTORY_TRANSCRIPTS_FEATURE)) {
@@ -223,7 +223,6 @@ public final class ChatTranscripts {
      * @return the settings file.
      */
     public static File getTranscriptFile(Jid jid) {
-        //replace with Jid.asUrlEncodedString() when available
         return new File(SparkManager.getUserDirectory(), "transcripts/" + jid.asUnescapedString() + ".xml");
     }
 
@@ -234,7 +233,6 @@ public final class ChatTranscripts {
      * @return the current transcript file.
      */
     public static File getCurrentHistoryFile(Jid jid) {
-        //replace with Jid.asUrlEncodedString() when available
         return new File(SparkManager.getUserDirectory(), "transcripts/" + jid.asUnescapedString() + "_current.xml");
     }
 


### PR DESCRIPTION
1.We must use JID(fullname) for save and load history
2.When loading history we must use for name:
a)LocalPart for contacts that are not in user list.
b)ResourcePart for private messages in MUC
3.Jid.asUrlEncodedString() path is not displayed correctly