### PR TITLE
SPARK-2293 Update FlatLaf to 2.5

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -238,7 +238,7 @@
         <dependency>
         <groupId>com.formdev</groupId>
         <artifactId>flatlaf</artifactId>
-        <version>2.4</version>
+        <version>2.5</version>
         <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
The latest update contains a fix for the behavior of the show password button if the field is disabled.