### PR TITLE
SPARK-2295 Unable to create an account through Spark

### DIFF
--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -231,6 +231,7 @@ public class AccountCreationWizard extends JPanel {
                 try {
                     Localpart localpart = Localpart.from(getUsername());
                     final AccountManager accountManager = AccountManager.getInstance(connection);
+                    accountManager.sensitiveOperationOverInsecureConnection(true);
                     accountManager.createAccount(localpart, getPassword());
                 }
                 catch (XMPPException | SmackException | InterruptedException | XmppStringprepException e) {


### PR DESCRIPTION
The new version of Smack 4.4.X requires an allow flag to be specified otherwise an exception is thrown