### PR TITLE
SPARK-2115 SPARK-2295 Allow change password for unsecurity connection

### DIFF
--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -218,6 +218,7 @@ public class AccountCreationWizard extends JPanel {
 
         final SwingWorker worker = new SwingWorker() {
             StanzaError.Condition condition = null;
+            String th;
 
 
             @Override
@@ -227,6 +228,7 @@ public class AccountCreationWizard extends JPanel {
                     connection = getConnection();
                 }
                 catch (SmackException | IOException | XMPPException e) {
+                    th = e.getCause().getMessage();
                     return e;
                 }
                 try {
@@ -254,7 +256,8 @@ public class AccountCreationWizard extends JPanel {
                     if (ui.isShowing()) {
                         createAccountButton.setEnabled(true);
                         UIManager.put("OptionPane.okButtonText", Res.getString("ok"));
-                        JOptionPane.showMessageDialog(ui, Res.getString("message.connection.failed", getServer()), Res.getString("title.create.problem"), JOptionPane.ERROR_MESSAGE);
+                        JOptionPane.showMessageDialog(ui, Res.getString("message.connection.failed", getServer())
+                            + "\n" + th, Res.getString("title.create.problem"), JOptionPane.ERROR_MESSAGE);
                         createAccountButton.setEnabled(true);
                     }
                     return;

--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -231,7 +231,6 @@ public class AccountCreationWizard extends JPanel {
                 try {
                     Localpart localpart = Localpart.from(getUsername());
                     final AccountManager accountManager = AccountManager.getInstance(connection);
-                    accountManager.sensitiveOperationOverInsecureConnection(true);
                     accountManager.createAccount(localpart, getPassword());
                 }
                 catch (XMPPException | SmackException | InterruptedException | XmppStringprepException e) {

--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -33,6 +33,7 @@ import org.jivesoftware.spark.util.SwingWorker;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.certificates.SparkSSLSocketFactory;
 import org.jivesoftware.sparkimpl.certificates.SparkSSLContextCreator;
+import org.jivesoftware.sparkimpl.certificates.SparkTrustManager;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jxmpp.jid.parts.Localpart;
@@ -361,6 +362,7 @@ public class AccountCreationWizard extends JPanel {
                 SSLContext context = SparkSSLContextCreator.setUpContext(SparkSSLContextCreator.Options.ONLY_SERVER_SIDE);
                 builder.setSslContextFactory(() -> { return context; });
                 builder.setSecurityMode( securityMode );
+                builder.setCustomX509TrustManager(new SparkTrustManager());
             } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
                 Log.warning("Couldnt establish secured connection", e);
             }

--- a/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
+++ b/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
@@ -95,6 +95,7 @@ import org.jivesoftware.smack.util.DNSUtil;
 import org.jivesoftware.smack.util.TLSUtils;
 import org.jivesoftware.smackx.carbons.CarbonManager;
 import org.jivesoftware.smackx.chatstates.ChatStateManager;
+import org.jivesoftware.smackx.iqregister.AccountManager;
 import org.jivesoftware.spark.PluginManager;
 import org.jivesoftware.spark.SessionManager;
 import org.jivesoftware.spark.SparkManager;
@@ -160,6 +161,10 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
         initComponents();
 
         localPref = SettingsManager.getLocalPreferences();
+
+        //SPARK-2115 SPARK-2295 Allow account creation or password changes over an insecure (e.g. unencrypted) connections.
+        AccountManager.sensitiveOperationOverInsecureConnectionDefault(true);
+
         init();
         // Check if upgraded needed.
         try {


### PR DESCRIPTION
I think if the user has chosen an insecure connection, then we should allow him to change his password in Spark. 