### PR TITLE
SPARK-2299 replace depricated installer for MacOS

### DIFF
--- a/distribution/src/installer/spark.install4j
+++ b/distribution/src/installer/spark.install4j
@@ -819,28 +819,28 @@ return console.askYesNo(message, true);
       </exclude>
       <jreBundle jreBundleSource="none" />
     </linuxDeb>
-    <macos name="Mac OS X Single Bundle" id="145" launcherId="4">
+    <macosArchive name="MacOS Single Bundle Archive" id="213" launcherId="4">
       <exclude>
+        <entry location="bin/startup.bat" />
+        <entry location="lib/linux" />
         <entry location="lib/linux64" />
         <entry location="lib/windows" />
         <entry location="lib/windows64" />
-        <entry location="lib/linux" />
         <entry location="plugins/flashing.jar" />
-        <entry location="bin/startup.bat" />
       </exclude>
       <jreBundle jreBundleSource="none" />
-    </macos>
-    <macos name="Mac OS X Single Bundle (with JRE)" id="183" mediaFileName="spark_${compiler:sys.version}-with-jre" launcherId="4">
+    </macosArchive>
+    <macosArchive name="MacOS Single Bundle Archive (with JRE)" id="217" mediaFileName="spark_${compiler:sys.version}-with-jre" launcherId="4">
       <exclude>
+        <entry location="bin/startup.bat" />
+        <entry location="lib/linux" />
         <entry location="lib/linux64" />
         <entry location="lib/windows" />
         <entry location="lib/windows64" />
-        <entry location="lib/linux" />
         <entry location="plugins/flashing.jar" />
-        <entry location="bin/startup.bat" />
       </exclude>
       <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-1.8.0_202" />
-    </macos>
+    </macosArchive>
   </mediaSets>
   <buildIds buildAll="false">
     <mediaSet refId="198" />


### PR DESCRIPTION
macOS single bundle is deprecated. This media file type is deprecated because of signature requirements in modern macOS versions. Use the single bundle archive instead and configure a setup application in the media wizard that is run the first time the user starts the application.
[install4j Help - Media files](https://www.ej-technologies.com/resources/install4j/help/doc/concepts/mediaFiles.html)
https://igniterealtime.atlassian.net/browse/SPARK-2299