### PR TITLE
Linux and MacOs can useFileUploadPlugin and SparkMeetPlugin

### DIFF
--- a/plugins/fileupload/src/main/plugin-metadata/plugin.xml
+++ b/plugins/fileupload/src/main/plugin-metadata/plugin.xml
@@ -7,6 +7,6 @@
     <email>support@igniterealtime.org</email>
     <class>org.jivesoftware.spark.plugin.fileupload.SparkFileUploadPlugin</class>
     <minSparkVersion>2.0.0.0</minSparkVersion>
-    <os>Windows</os>
+    <os>Windows,Linux,Mac</os>
     <java>1.7.0</java>    
 </plugin>

--- a/plugins/meet/src/main/plugin-metadata/plugin.xml
+++ b/plugins/meet/src/main/plugin-metadata/plugin.xml
@@ -7,6 +7,6 @@
     <email>support@igniterealtime.org</email>
     <class>org.jivesoftware.spark.plugin.ofmeet.SparkMeetPlugin</class>
     <minSparkVersion>2.0.0.0</minSparkVersion>
-    <os>Windows</os>
+    <os>Windows,Linux,Mac</os>
     <java>1.7.0</java>    
 </plugin>


### PR DESCRIPTION
@deleolajide Thank you very much for these plugins.
I see that they can work on different platforms.
I think we should enable them on Linux and MacOS.

Tested with Linux Ubuntu 
![image](https://user-images.githubusercontent.com/71222850/196409335-84a4acb8-0a56-4e21-bc48-a8b9617ccd35.png)
