### PR TITLE
SPARK-2310 MacOS doesn't use Look and Feal FlatLaf

### DIFF
--- a/core/src/main/java/org/jivesoftware/resource/Default.java
+++ b/core/src/main/java/org/jivesoftware/resource/Default.java
@@ -73,7 +73,6 @@ public class Default {
     public static final String FRAME_IMAGE = "FRAME_IMAGE";
     public static final String LOOK_AND_FEEL_DISABLED = "LOOK_AND_FEEL_DISABLED";
     public static final String DEFAULT_LOOK_AND_FEEL = "DEFAULT_LOOK_AND_FEEL";
-    public static final String DEFAULT_LOOK_AND_FEEL_MAC = "DEFAULT_LOOK_AND_FEEL_MAC";
     public static final String INSTALL_PLUGINS_DISABLED = "INSTALL_PLUGINS_DISABLED";
     public static final String UNINSTALL_PLUGINS_DISABLED = "UNINSTALL_PLUGINS_DISABLED";
     public static final String ADVANCED_DISABLED = "ADVANCED_DISABLED";

--- a/core/src/main/java/org/jivesoftware/spark/ui/themes/LookAndFeelManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/themes/LookAndFeelManager.java
@@ -107,7 +107,7 @@ public class LookAndFeelManager {
     private static String getLookandFeel(LocalPreferences preferences) {
         String result;
 
-        String whereToLook = Spark.isMac() ? Default.DEFAULT_LOOK_AND_FEEL_MAC : Default.DEFAULT_LOOK_AND_FEEL;
+        String whereToLook = Default.DEFAULT_LOOK_AND_FEEL;
 
         if (!Default.getBoolean(Default.LOOK_AND_FEEL_DISABLED)) {
             result = preferences.getLookAndFeel();

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
@@ -958,8 +958,7 @@ public class LocalPreferences {
     public String getLookAndFeel() {
 	String defaultstring;
 	try {
-	    defaultstring = Spark.isMac() ? Default.getString(Default.DEFAULT_LOOK_AND_FEEL_MAC)
-		    : Default.getString(Default.DEFAULT_LOOK_AND_FEEL);
+	    defaultstring = Default.getString(Default.DEFAULT_LOOK_AND_FEEL);
 	} catch (Exception e) {
 	    defaultstring = UIManager.getSystemLookAndFeelClassName();
 	}

--- a/core/src/main/resources/default.properties
+++ b/core/src/main/resources/default.properties
@@ -318,7 +318,6 @@ CHANGE_COLORS_DISABLED =
 # Changes the Default Look&Feel, if empty it will load the SystemSkin
 # Default Spark skin is org.jivesoftware.spark.ui.themes.lafs.SparkLightLaf
 DEFAULT_LOOK_AND_FEEL = org.jivesoftware.spark.ui.themes.lafs.SparkLightLaf
-DEFAULT_LOOK_AND_FEEL_MAC =
 
 # tabs are placed on bottom by default. if set to true will be placed on top
 TABS_PLACEMENT_TOP =


### PR DESCRIPTION
When testing MacOS, it does not use FlatLaf. Many elements are displayed only in FlatLaf (text when entering a log / password / domain), we should use only it.

The developer of FlatLaf tells us that we are using a different theme.

https://github.com/JFormDesigner/FlatLaf/issues/617