### PR TITLE
SPARK-2322 Raise the minimum requirements for plugins

### DIFF
--- a/plugins/apple/src/main/plugin-metadata/plugin.xml
+++ b/plugins/apple/src/main/plugin-metadata/plugin.xml
@@ -6,8 +6,8 @@
     <homePage>http://www.jivesoftware.com</homePage>
     <email>9posdorf@informatik.uni-hamburg.de</email>
     <class>com.jivesoftware.spark.plugin.apple.ApplePlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
 	<os>Mac</os>
-	<java>1.7.0</java>
+	<java>1.8.0</java>
 </plugin>
 

--- a/plugins/battleships/src/main/plugin-metadata/plugin.xml
+++ b/plugins/battleships/src/main/plugin-metadata/plugin.xml
@@ -6,7 +6,7 @@
     <author>Wolf Posdorfer</author>
     <homePage>http://www.jivesoftware.com</homePage>
     <email>9posdorf@informatik.uni-hamburg.de</email>
-    <minSparkVersion>2.7.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Windows,Linux,Mac</os>
-    <java>1.7.0</java>
+    <java>1.8.0</java>
 </plugin>

--- a/plugins/fastpath/src/main/plugin-metadata/plugin.xml
+++ b/plugins/fastpath/src/main/plugin-metadata/plugin.xml
@@ -6,6 +6,6 @@
     <email>spark@jivesoftware.com</email>
     <homePage>http://www.jivesoftware.com</homePage>
     <class>org.jivesoftware.fastpath.FastpathPlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
-    <java>1.7.0</java>
+    <minSparkVersion>3.0.0</minSparkVersion>
+    <java>1.8.0</java>
 </plugin>

--- a/plugins/fileupload/src/main/plugin-metadata/plugin.xml
+++ b/plugins/fileupload/src/main/plugin-metadata/plugin.xml
@@ -6,7 +6,7 @@
     <homePage>http://igniterealtime.org</homePage>
     <email>support@igniterealtime.org</email>
     <class>org.jivesoftware.spark.plugin.fileupload.SparkFileUploadPlugin</class>
-    <minSparkVersion>2.0.0.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Windows,Linux,Mac</os>
-    <java>1.7.0</java>    
+    <java>1.8.0</java>
 </plugin>

--- a/plugins/flashing/src/main/plugin-metadata/plugin.xml
+++ b/plugins/flashing/src/main/plugin-metadata/plugin.xml
@@ -7,7 +7,7 @@
     <homePage>http://www.igniterealtime.org</homePage>
     <email>michael-will@gmx.net</email>
     <class>org.jivesoftware.spark.plugin.flashing.FlashingPlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Windows</os>
-    <java>1.7.0</java>
+    <java>1.8.0</java>
 </plugin>

--- a/plugins/growl/src/main/plugin-metadata/plugin.xml
+++ b/plugins/growl/src/main/plugin-metadata/plugin.xml
@@ -6,7 +6,7 @@
     <homePage>http://www.jivesoftware.com</homePage>
     <email>9posdorf@informatik.uni-hamburg.de</email>
     <class>com.jivesoftware.spark.plugin.growl.GrowlPlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Mac,Windows</os>
-    <java>1.7.0</java>
+    <java>1.8.0</java>
 </plugin>

--- a/plugins/jingle/src/main/plugin-metadata/plugin.xml
+++ b/plugins/jingle/src/main/plugin-metadata/plugin.xml
@@ -6,7 +6,7 @@
     <homePage>http://www.jivesoftware.org</homePage>
     <email>derek@jivesoftware.com</email>
     <class>org.jivesoftware.sparkplugin.JinglePlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Windows,mac,linux</os>
-    <java>1.7.0</java>
+    <java>1.8.0</java>
 </plugin>

--- a/plugins/meet/src/main/plugin-metadata/plugin.xml
+++ b/plugins/meet/src/main/plugin-metadata/plugin.xml
@@ -6,7 +6,7 @@
     <homePage>http://igniterealtime.org</homePage>
     <email>support@igniterealtime.org</email>
     <class>org.jivesoftware.spark.plugin.ofmeet.SparkMeetPlugin</class>
-    <minSparkVersion>2.0.0.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Windows,Linux,Mac</os>
-    <java>1.7.0</java>    
+    <java>1.8.0</java>
 </plugin>

--- a/plugins/otr/src/main/plugin-metadata/plugin.xml
+++ b/plugins/otr/src/main/plugin-metadata/plugin.xml
@@ -6,8 +6,8 @@
     <author>Holger Bergunde</author>
     <homePage>http://www.stytrix.de</homePage>
     <email>holger@bergunde.de</email>
-    <minSparkVersion>2.7.0</minSparkVersion>
-    <java>1.7.0</java>
+    <minSparkVersion>3.0.0</minSparkVersion>
+    <java>1.8.0</java>
     <class>org.jivesoftware.spark.otrplug.OTRPlugin</class>
     <os>Windows,Linux,Mac</os>
 </plugin>

--- a/plugins/reversi/src/main/plugin-metadata/plugin.xml
+++ b/plugins/reversi/src/main/plugin-metadata/plugin.xml
@@ -7,7 +7,7 @@
     <homePage>http://www.jivesoftware.org</homePage>
     <email>plugins@jivesoftware.org</email>
     <class>org.jivesoftware.game.reversi.ReversiPlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
-    <java>1.7.0</java>
+    <minSparkVersion>3.0.0</minSparkVersion>
+    <java>1.8.0</java>
 </plugin>
 

--- a/plugins/sip/src/main/plugin-metadata/plugin.xml
+++ b/plugins/sip/src/main/plugin-metadata/plugin.xml
@@ -7,8 +7,8 @@
     <homePage>http://www.jivesoftware.org</homePage>
     <email>thiago@jivesoftware.com</email>
     <class>org.jivesoftware.sparkplugin.SoftPhonePlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Windows,Mac,Linux</os>
-    <java>1.7.0</java>
+    <java>1.8.0</java>
 </plugin>
 

--- a/plugins/spelling/src/main/plugin-metadata/plugin.xml
+++ b/plugins/spelling/src/main/plugin-metadata/plugin.xml
@@ -7,8 +7,8 @@
     <homePage>http://www.igniterealtime.org</homePage>
     <email>michael-will@gmx.net</email>
     <class>org.jivesoftware.spellchecker.SpellcheckerPlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Windows,Mac,Linux</os>
-    <java>1.7.0</java>
+    <java>1.8.0</java>
 </plugin>
 

--- a/plugins/systemtray/src/main/plugin-metadata/plugin.xml
+++ b/plugins/systemtray/src/main/plugin-metadata/plugin.xml
@@ -7,7 +7,7 @@
     <homePage>http://www.jivesoftware.com</homePage>
     <email>derek@jivesoftware.com</email>
     <class>org.jivesoftware.spark.plugins.SystemTrayPlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
-    <java>1.7.0</java>
+    <minSparkVersion>3.0.0</minSparkVersion>
+    <java>1.8.0</java>
 </plugin>
 

--- a/plugins/tictactoe/src/main/plugin-metadata/plugin.xml
+++ b/plugins/tictactoe/src/main/plugin-metadata/plugin.xml
@@ -6,7 +6,7 @@
     <author>Wolf Posdorfer</author>
     <homePage>http://www.jivesoftware.com</homePage>
     <email>9posdorf@informatik.uni-hamburg.de</email>
-    <minSparkVersion>2.7.0</minSparkVersion>
+    <minSparkVersion>3.0.0</minSparkVersion>
     <os>Windows,Linux,Mac</os>
-    <java>1.7.0</java>
+    <java>1.8.0</java>
 </plugin>

--- a/plugins/transferguard/src/main/plugin-metadata/plugin.xml
+++ b/plugins/transferguard/src/main/plugin-metadata/plugin.xml
@@ -7,7 +7,7 @@
     <homePage>http://www.jivesoftware.org</homePage>
     <email>pete@jivesoftware.com</email>
     <class>org.jivesoftware.spark.plugins.transfersettings.FileTransferSettingsPlugin</class>
-    <minSparkVersion>2.7.0</minSparkVersion>
-    <java>1.7.0</java>
+    <minSparkVersion>3.0.0</minSparkVersion>
+    <java>1.8.0</java>
 </plugin>
 

--- a/plugins/translator/src/main/plugin-metadata/plugin.xml
+++ b/plugins/translator/src/main/plugin-metadata/plugin.xml
@@ -7,6 +7,6 @@
     <author>Jive Software</author>
     <homePage>http://www.jivesoftware.com</homePage>
     <email>spark@jivesoftware.com</email>
-    <minSparkVersion>2.7.0</minSparkVersion>
-    <java>1.7.0</java>
+    <minSparkVersion>3.0.0</minSparkVersion>
+    <java>1.8.0</java>
 </plugin>


### PR DESCRIPTION
Spark supports Java 8 and above.
Starting with Spark 3.0.0, translations are no longer distorted(with java 9 and above), we need to build on this version