### PR TITLE
Improve error message when failing to join MUC

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceUtils.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceUtils.java
@@ -203,7 +203,9 @@ public class ConferenceUtils {
                     error = ( (XMPPException.XMPPErrorException) ex ).getStanzaError();
                 }
 
-                final String errorText = ConferenceUtils.getReason( error );
+                String errorText = Res.getString("title.join.conference.room");
+                if (groupChat.getRoom() != null) { errorText += " " + groupChat.getRoom();  }
+                errorText += ": " + ConferenceUtils.getReason( error );
                 errors.add( errorText );
             }
         }

--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/JoinRoomSwingWorker.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/JoinRoomSwingWorker.java
@@ -206,7 +206,10 @@ public class JoinRoomSwingWorker extends SwingWorker
                 }
             }
 
-            final String errorText = ConferenceUtils.getReason( error );
+            String errorText = Res.getString("title.join.conference.room");
+            errorText += " " + roomJID;
+            errorText += ": " + ConferenceUtils.getReason( error );
+
             errors.add( errorText );
             return null;
         }


### PR DESCRIPTION
When joining a MUC fails, an error message is shown. That message should include a reference to the server that is causing the error.