### PR TITLE
docbook/installation-debian.sgml: improve commands and ru translation

### DIFF
--- a/core/src/docbook/installation-debian.sgml
+++ b/core/src/docbook/installation-debian.sgml
@@ -1,17 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<section id="installation-debian" revision="1">	
+<section id="installation-debian" revision="2">	
     <title>
     		<phrase lang="en">Install Spark on Debian/Ubuntu</phrase>	
+    		<phrase lang="ru">Установка Spark на Debian/Ubuntu</phrase>	
 	</title>
 	
 	<para>
 		<phrase lang="en">
-			For Ubuntu/Debian System use the Spark Debian Package. 
-			To install Spark execute the follow commands as root:
+			For Debian/Ubuntu Systems use the Spark Debian Package.
+			You can download it from <a href="https://github.com/igniterealtime/Spark/releases">GitHub Releases page</a>.
+			Pick the latest release and download the <em>.deb</em> file. You can copy its link and download with <em>wget</em> command:
+		</phrase>
+		<phrase lang="ru">
+			Для ОС Debian/Ubuntu используйте Debian пакет Spark.
+			Вы можете скачать его со <a href="https://github.com/igniterealtime/Spark/releases">страницы релизов на GitHub</a>.
+			Выберите последний релиз и скачайте файл <em>.deb</em>. Вы можете скопировать его ссылку и скачать командой <em>wget</em>:
 		</phrase>
 		<command>
-				apt-get install java-6-sun
-				dpkg -i spark_X.X.X_all.deb
+				wget https://github.com/igniterealtime/Spark/releases/download/v3.0.2/spark_3_0_2.deb
+		</command>		
+		<phrase lang="en">
+			You also need to install Java Runtime (JRE).
+			You may already have it so check with the <em>java -version</em> command.
+            If it's not installed you can install the default JRE (LTS version 11, 17 etc.): 
+		</phrase>
+		<phrase lang="ru">
+			Вам также нужно установить Java Runtime (JRE).
+			Вы можете уже иметь её поэтому проверьте командой <em>java -version</em>.
+            Если всё же не установлена вы можете установить JRE по умолчанию (LTS версия 11, 17 итд.): 
+		</phrase>
+		<command>
+				sudo apt install default-jre
+		</command>		
+		<phrase lang="en">
+			To install Spark execute the follow command:
+		</phrase>
+		<phrase lang="ru">
+			Для установки Spark выполните следущую команду:
+		</phrase>
+		<command>
+				sudo apt install ./spark_*.deb
 		</command>		
 	</para>
 </section>


### PR DESCRIPTION
Instead of the old Sun Java use the default-jre package. Add a link to GitHub Releases page from which to get the deb package. Add wget command to download.
Use apt to install the package: it will also install dependencies (none for now but for a future). Add Russian translation.

The .deb file can be improved and just declare own dependency to the JRE.