### PR TITLE
Fix maven build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,9 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
+                <includes>
+                    <include>**/spark.properties</include>
+                </includes>
             </resource>
         </resources>
         <plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
     <description>The essentials of Spark, including the user interface and startup scripts, excluding most optional components</description>
 
     <properties>
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <bouncycastle.version>1.78.1</bouncycastle.version>
     </properties>
 
     <build>
@@ -225,17 +225,17 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-jdk15on</artifactId>
+            <artifactId>bctls-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -164,17 +164,17 @@
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.3</version>
+            <version>2.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.2.1</version>
+            <version>5.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.swinglabs.swingx</groupId>
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>net.coobird</groupId>
             <artifactId>thumbnailator</artifactId>
-            <version>0.4.18</version>
+            <version>0.4.20</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dependency.smack.version>4.4.6</dependency.smack.version>
+        <dependency.smack.version>4.4.8</dependency.smack.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Build failed with the message: 

    maven-resources-plugin:3.3.1 (default-resources) on project spark-core: filtering Spark/core/src/main/resources/jniwrap.dll to Spark/core/target/classes/jniwrap.dll failed with MalformedInputException: Input length = 1

This happens because the maven-resources-plugin tries to filter (e.g. replace variables) all files including the binary DLLs.
The only file that uses the filtering is the `spark.properties` so I added only it to the filtering.

Additionally I upgraded dependencies to a more stable versions. 