### PR TITLE
Fix Maven build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>com.install4j</groupId>
             <artifactId>install4j-runtime</artifactId>
-            <version>10.0.4</version>
+            <version>10.0.8</version>
         </dependency>
 
         <dependency>
@@ -294,10 +294,6 @@
     </dependencies>
     
     <repositories>
-        <repository>
-            <id>maven-snapshots-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
         <repository>
             <id>ej-technologies</id>
             <url>https://maven.ej-technologies.com/repository/</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,6 +132,21 @@
             <version>${dependency.smack.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-sasl-javax</artifactId>
+            <version>${dependency.smack.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-xmlparser</artifactId>
+            <version>${dependency.smack.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.igniterealtime.smack</groupId>
+            <artifactId>smack-core</artifactId>
+            <version>${dependency.smack.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.igniterealtime.spark</groupId>
             <artifactId>emoticons</artifactId>
             <version>${project.version}</version>
@@ -164,6 +179,21 @@
             <type>zip</type>
         </dependency>
         <dependency>
+            <groupId>org.minidns</groupId>
+            <artifactId>minidns-core</artifactId>
+            <version>1.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jxmpp</groupId>
+            <artifactId>jxmpp-core</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jxmpp</groupId>
+            <artifactId>jxmpp-jid</artifactId>
+            <version>1.0.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
             <version>2.1.4</version>
@@ -172,6 +202,11 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
             <version>5.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>5.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -187,6 +222,11 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
+            <version>5.12.1</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
             <version>5.12.1</version>
         </dependency>
 


### PR DESCRIPTION
Currently the build is broken (surprise):


```
The POM for org.minidns:minidns-core:jar:1.0.3-SNAPSHOT is missing, no dependency information available
```

You may not see the error because the dependency is in your maven local .m2 repository. So you can reproduce this be removing it from local cache: `rm -fr ~/.m2/repository/org/minidns/`.

The problem is complicated here is that the spark-core declares a dependency to the minidns as a range: `[1.0.0, 1.0.999]`
https://github.com/igniterealtime/Smack/blob/master/build.gradle#L149C21-L149C37

This is dangerous to use in libraries. So the Maven tries to find all versions of the dependency. And here comes the second problem: the pom.xml has two additional repos:

```
    <repositories>
        <repository>
            <id>maven-snapshots-repo</id>
            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
        </repository>
        <repository>
            <id>ej-technologies</id>
            <url>https://maven.ej-technologies.com/repository/</url>
        </repository>
    </repositories>
```

The Maven goes into the maven-snapshots-repo and tries to resolve the 1.0.3-SNAPSHOT which is not exists there but it was referenced from some other dependency. In fact the Spark dosn't use snapshot versions (and it shouldn't) so the simplest solution is to just remove the maven-snapshots-repo as unused. It looks like this fixed the build.

Additionally it would be better to not use the range versions in the Smack but instead stick to the latest available today.

I also made the `mvn dependency:analyze-only` to see that some dependency is used in a compile time but it actually comes transitionally and once the intermediate dependency removes the dependency then the build become broken. So I added those dependencies explicitly to the pom.xml



