### PR TITLE
Fix NPE on contact popup

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1516,9 +1516,12 @@ public class ContactList extends JPanel implements ActionListener,
 
         String groupName = item.getGroupName();
         ContactGroup contactGroup = getContactGroup(groupName);
+        if (contactGroup == null) {
+            Log.error("Unable to get contact group for " + groupName);
+        }
 
         // Only show "Remove Contact From Group" if the user belongs to more than one group.
-        if (!contactGroup.isSharedGroup() && !contactGroup.isOfflineGroup() && contactGroup != getUnfiledGroup()) {
+        if (contactGroup != null && !contactGroup.isSharedGroup() && !contactGroup.isOfflineGroup() && contactGroup != getUnfiledGroup()) {
             Roster roster = Roster.getInstanceFor(SparkManager.getConnection());
             RosterEntry entry = roster.getEntry(item.getJid().asBareJid());
             if (entry != null) {
@@ -1559,7 +1562,9 @@ public class ContactList extends JPanel implements ActionListener,
 
         // See if we should disable the option to remove a contact
         if (!Default.getBoolean(Default.DISABLE_REMOVALS) && Enterprise.containsFeature(Enterprise.REMOVALS_FEATURE)) {
-            if (!contactGroup.isSharedGroup() && !isInSharedGroup) popup.add(removeAction);
+            if (contactGroup != null && !contactGroup.isSharedGroup() && !isInSharedGroup) {
+                popup.add(removeAction);
+            }
         }
 
         // See if we should disable the option to rename a contact


### PR DESCRIPTION
I can't reproduce the NPE but when I first tried the Spark I clicked on empty group or I received a test message that I sent from a phone or something like that. But I saved the log:

```
SEVERE: A ContactGroupListener (org.jivesoftware.spark.ui.ContactList[,0,0,498x330,layout=java.awt.BorderLayout,alignmentX=0.0,alignmentY=0.0,border=javax.swing.border.EmptyBorder@64e54fe9,flags=393,maximumSize=,minimumSize=,preferredSize=]) threw an exception while processing a 'showPopup' event for item: В этой группе нет контактов, которые в сети, event: java.awt.event.MouseEvent[MOUSE_PRESSED,(60,3),absolute(531,408),button=3,modifiers=Meta+Button3,extModifiers=Button3,clickCount=1] on javax.swing.JList[,0,0,498x16,alignmentX=0.0,alignmentY=0.0,border=com.formdev.flatlaf.ui.FlatEmptyBorder@2587d4ef,flags=33554728,maximumSize=,minimumSize=,preferredSize=,fixedCellHeight=-1,fixedCellWidth=-1,horizontalScrollIncrement=-1,selectionBackground=java.awt.Color[r=217,g=232,b=250],selectionForeground=java.awt.Color[r=0,g=0,b=0],visibleRowCount=8,layoutOrientation=0]
java.lang.NullPointerException: Cannot invoke "org.jivesoftware.spark.ui.ContactGroup.isSharedGroup()" because "contactGroup" is null
	at org.jivesoftware.spark.ui.ContactList.showPopup(ContactList.java:1523)
	at org.jivesoftware.spark.ui.ContactList.showPopup(ContactList.java:1478)
	at org.jivesoftware.spark.ui.ContactGroup.firePopupEvent(ContactGroup.java:693)
	at org.jivesoftware.spark.ui.ContactGroup.checkPopup(ContactGroup.java:644)
	at org.jivesoftware.spark.ui.ContactGroup.mousePressed(ContactGroup.java:610)
	at java.desktop/java.awt.AWTEventMulticaster.mousePressed(AWTEventMulticaster.java:288)
	at java.desktop/java.awt.AWTEventMulticaster.mousePressed(AWTEventMulticaster.java:287)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6618)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3398)
	at java.desktop/java.awt.Component.processEvent(Component.java:6386)
	at java.desktop/java.awt.Container.processEvent(Container.java:2266)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4996)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4948)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4572)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4516)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2780)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:775)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:747)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:744)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)

```

As far I remember I had one offline contact in the group `В этой группе нет контактов, которые в сети` (`In this group there are no online contacts`).

In the PR I tried to add places were the problem may occur: made the group search case insensitive, add the null check.