### PR TITLE
Fix conference browser

### DIFF
--- a/core/src/main/resources/i18n/spark_i18n.properties
+++ b/core/src/main/resources/i18n/spark_i18n.properties
@@ -483,6 +483,7 @@ message.close.stale.chats = Close stale chats
 message.close.this.chat = Close this chat
 message.close.unread.window = You have unread messages, are you sure you want to close the window?
 message.conference.info.error = Unable to retrieve conference information, please try back later
+message.conference.rooms.unsupported=Rooms listing unsupported or unavailable
 message.conference.service.error = Unable to locate the conference service
 message.confirm.destruction.of.room = Destroying the room removes all users from the room, continue?
 message.confirmation.password.error = Specify a confirmation password


### PR DESCRIPTION
I tested conferences browser with the yax.im (the latest stable release of Prasody) and had an error when tried to get list of rooms for `ircnet.yax.im` service:

```
SEVERE: Unable to retrieve list of rooms.
org.jivesoftware.smack.XMPPException$XMPPErrorException: XMPP error reply received from ircnet.yax.im: XMPPError: feature-not-implemented - cancel
	at org.jivesoftware.smack.XMPPException$XMPPErrorException.ifHasErrorThenThrow(XMPPException.java:171)
	at org.jivesoftware.smack.XMPPException$XMPPErrorException.ifHasErrorThenThrow(XMPPException.java:165)
	at org.jivesoftware.smack.StanzaCollector.nextResultOrThrow(StanzaCollector.java:284)
	at org.jivesoftware.smack.StanzaCollector.nextResultOrThrow(StanzaCollector.java:228)
	at org.jivesoftware.smackx.disco.ServiceDiscoveryManager.discoverItems(ServiceDiscoveryManager.java:645)
	at org.jivesoftware.smackx.disco.ServiceDiscoveryManager.discoverItems(ServiceDiscoveryManager.java:622)
	at org.jivesoftware.smackx.muc.MultiUserChatManager.getRoomsHostedBy(MultiUserChatManager.java:453)
	at org.jivesoftware.spark.ui.conferences.ConferenceRoomBrowser$6.run(ConferenceRoomBrowser.java:506)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:317)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```
So here I added an ignore for such errors.


When I tried to get open the `chat.yax.im` I saw a lot of errors in logs like:

```
java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.toString()" because "this.val$roomName" is null
	at org.jivesoftware.spark.ui.conferences.ConferenceRoomBrowser$10.construct(ConferenceRoomBrowser.java:942)
	at org.jivesoftware.spark.util.SwingWorker.lambda$new$0(SwingWorker.java:139)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

Some rooms doesn't have a name. For some reason just changing the roomName param to String helped. Can't say why, but anyway this change makes code easier to understand.