### PR TITLE
SPARK-2340 refactoring: GraphicUtils.scaleImageIcon(): scale only if needed

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/util/GraphicUtils.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/GraphicUtils.java
@@ -712,32 +712,24 @@ public final class GraphicUtils {
     }
 
     /**
-     * Returns a scaled down image if the height or width is smaller than the
-     * image size.
-     * 
-     * @param icon
-     *            the image icon.
-     * @param newHeight
-     *            the preferred height.
-     * @param newWidth
-     *            the preferred width.
+     * Returns a scaled down image if the height or width is smaller than the image size.
+     *
+     * @param icon      the image icon.
+     * @param newHeight the preferred height.
+     * @param newWidth  the preferred width.
      * @return the icon.
      */
-    public static ImageIcon scaleImageIcon(ImageIcon icon, int newHeight,
-	    int newWidth) {
-	Image img = icon.getImage();
-	int height = icon.getIconHeight();
-	int width = icon.getIconWidth();
-
-	if (height > newHeight) {
-	    height = newHeight;
-	}
-
-	if (width > newWidth) {
-	    width = newWidth;
-	}
-	img = img.getScaledInstance(width, height, Image.SCALE_SMOOTH);
-	return new ImageIcon(img);
+    public static ImageIcon scaleImageIcon(ImageIcon icon, int newHeight, int newWidth) {
+        int height = icon.getIconHeight();
+        int width = icon.getIconWidth();
+        if (height > newHeight) {
+            height = newHeight;
+        }
+        if (width > newWidth) {
+            width = newWidth;
+        }
+        Image img = icon.getImage().getScaledInstance(width, height, Image.SCALE_SMOOTH);
+        return new ImageIcon(img);
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/spark/util/GraphicUtils.java
+++ b/core/src/main/java/org/jivesoftware/spark/util/GraphicUtils.java
@@ -722,11 +722,17 @@ public final class GraphicUtils {
     public static ImageIcon scaleImageIcon(ImageIcon icon, int newHeight, int newWidth) {
         int height = icon.getIconHeight();
         int width = icon.getIconWidth();
+        boolean resize = false;
         if (height > newHeight) {
             height = newHeight;
+            resize = true;
         }
         if (width > newWidth) {
             width = newWidth;
+            resize = true;
+        }
+        if (!resize) {
+            return icon;
         }
         Image img = icon.getImage().getScaledInstance(width, height, Image.SCALE_SMOOTH);
         return new ImageIcon(img);


### PR DESCRIPTION
Avoid allocation `new ImageIcon(img)` when the image can be used as is without scaling.
The scaleImageIcon is called on each contact popup so if we can optimize it a little bit that would be good.
The resulted image is not modified anywhere after so it's safe to return the original image.
