### PR TITLE
SPARK-2339 Make showOfflineUsers true by default

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
@@ -727,7 +727,7 @@ public class LocalPreferences {
 	}
 
 	public boolean isOfflineUsersShown() {
-		return getBoolean("showOfflineUsers", false);
+		return getBoolean("showOfflineUsers", true);
 	}
 
 	public void setOfflineUsersShown(boolean shown) {


### PR DESCRIPTION
From the [Modern XMPP Client design guidelines](https://docs.modernxmpp.org/client/design/#contact-list):

> The client MUST display offline contacts by default

All existing settings will be keep because stored in properties. The change applied only for new profiles.

