### PR TITLE
SPARK-2338 Refactor: rename the confusing "Old SSL" to "Direct TLS"

### DIFF
--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -363,7 +363,22 @@ public class AccountCreationWizard extends JPanel {
         {
             builder.setHost( localPreferences.getXmppHost() );
         }
-        
+        configureConnectionTls(builder, securityMode, useDirectTls, hostPortConfigured, serverName);
+
+        final XMPPTCPConnectionConfiguration configuration = builder.build();
+
+        final AbstractXMPPConnection connection = new XMPPTCPConnection( configuration );
+        connection.setParsingExceptionCallback( new ExceptionLoggingCallback() );
+        try {
+            connection.connect();
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+
+        return connection;
+    }
+
+    private void configureConnectionTls(XMPPTCPConnectionConfiguration.Builder builder, ConnectionConfiguration.SecurityMode securityMode, boolean useDirectTls, boolean hostPortConfigured, String serverName) throws SmackException.SmackMessageException {
         if (securityMode != ConnectionConfiguration.SecurityMode.disabled) {
             if (!useDirectTls) {
                 // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
@@ -398,18 +413,6 @@ public class AccountCreationWizard extends JPanel {
                 builder.setSecurityMode( ConnectionConfiguration.SecurityMode.ifpossible );
             }
         }
-
-        final XMPPTCPConnectionConfiguration configuration = builder.build();
-
-        final AbstractXMPPConnection connection = new XMPPTCPConnection( configuration );
-        connection.setParsingExceptionCallback( new ExceptionLoggingCallback() );
-        try {
-            connection.connect();
-        } catch (InterruptedException e) {
-            throw new IllegalStateException(e);
-        }
-
-        return connection;
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -347,7 +347,7 @@ public class AccountCreationWizard extends JPanel {
         }
 
         ConnectionConfiguration.SecurityMode securityMode = localPreferences.getSecurityMode();
-        boolean useOldSSL = localPreferences.isSSL();
+        boolean useDirectTls = localPreferences.isDirectTls();
         boolean hostPortConfigured = localPreferences.isHostAndPortConfigured();
 
         final XMPPTCPConnectionConfiguration.Builder builder = XMPPTCPConnectionConfiguration.builder()
@@ -362,7 +362,7 @@ public class AccountCreationWizard extends JPanel {
             builder.setHost( localPreferences.getXmppHost() );
         }
         
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useOldSSL) {
+        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useDirectTls) {
             // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
             // plain connections which is 5222.
             try {
@@ -375,7 +375,7 @@ public class AccountCreationWizard extends JPanel {
             }
         }
         
-        if ( securityMode != ConnectionConfiguration.SecurityMode.disabled && useOldSSL )
+        if ( securityMode != ConnectionConfiguration.SecurityMode.disabled && useDirectTls )
         {
             if (!hostPortConfigured) {
                 // SMACK 4.1.9 does not support XEP-0368, and does not apply a port change, if the host is not changed too.

--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -364,40 +364,39 @@ public class AccountCreationWizard extends JPanel {
             builder.setHost( localPreferences.getXmppHost() );
         }
         
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useDirectTls) {
-            // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
-            // plain connections which is 5222.
-            SparkSSLContextCreator.Options options = ONLY_SERVER_SIDE;
-            try {
-                SSLContext context = SparkSSLContextCreator.setUpContext(options);
-                builder.setSslContextFactory(() -> context);
-                builder.setSecurityMode( securityMode );
-                builder.setCustomX509TrustManager(new SparkTrustManager());
-            } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
-                Log.warning("Could not establish secured connection", e);
-            }
-        }
-        
-        if ( securityMode != ConnectionConfiguration.SecurityMode.disabled && useDirectTls )
-        {
-            if (!hostPortConfigured) {
-                // SMACK 4.1.9 does not support XEP-0368, and does not apply a port change, if the host is not changed too.
-                // Here, we force the host to be set (by doing a DNS lookup), and force the port to 5223 (which is the
-                // default 'old-style' SSL port).
-                DnsName serverNameDnsName = DnsName.from(serverName);
-                java.util.List<InetAddress> resolvedAddresses = DNSUtil.getDNSResolver().lookupHostAddress(serverNameDnsName, null, DnssecMode.disabled);
-                if (resolvedAddresses.isEmpty()) {
-                    throw new SmackException.SmackMessageException("Could not resolve " + serverNameDnsName);
+        if (securityMode != ConnectionConfiguration.SecurityMode.disabled) {
+            if (!useDirectTls) {
+                // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
+                // plain connections which is 5222.
+                SparkSSLContextCreator.Options options = ONLY_SERVER_SIDE;
+                try {
+                    SSLContext context = SparkSSLContextCreator.setUpContext(options);
+                    builder.setSslContextFactory(() -> context);
+                    builder.setSecurityMode(securityMode);
+                    builder.setCustomX509TrustManager(new SparkTrustManager());
+                } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
+                    Log.warning("Could not establish secured connection", e);
                 }
-                builder.setHost( resolvedAddresses.get( 0 ).getHostName() );
-                builder.setPort( 5223 );
+            } else { // useDirectTls
+                if (!hostPortConfigured) {
+                    // SMACK 4.1.9 does not support XEP-0368, and does not apply a port change, if the host is not changed too.
+                    // Here, we force the host to be set (by doing a DNS lookup), and force the port to 5223 (which is the
+                    // default 'old-style' SSL port).
+                    DnsName serverNameDnsName = DnsName.from(serverName);
+                    java.util.List<InetAddress> resolvedAddresses = DNSUtil.getDNSResolver().lookupHostAddress(serverNameDnsName, null, DnssecMode.disabled);
+                    if (resolvedAddresses.isEmpty()) {
+                        throw new SmackException.SmackMessageException("Could not resolve " + serverNameDnsName);
+                    }
+                    builder.setHost( resolvedAddresses.get( 0 ).getHostName() );
+                    builder.setPort( 5223 );
+                }
+                SparkSSLContextCreator.Options options = ONLY_SERVER_SIDE;
+                builder.setSocketFactory( new SparkSSLSocketFactory(options) );
+                // SMACK 4.1.9  does not recognize an 'old-style' SSL socket as being secure, which will cause a failure when
+                // the 'required' Security Mode is defined. Here, we work around this by replacing that security mode with an
+                // 'if-possible' setting.
+                builder.setSecurityMode( ConnectionConfiguration.SecurityMode.ifpossible );
             }
-            SparkSSLContextCreator.Options options = ONLY_SERVER_SIDE;
-            builder.setSocketFactory( new SparkSSLSocketFactory(options) );
-            // SMACK 4.1.9  does not recognize an 'old-style' SSL socket as being secure, which will cause a failure when
-            // the 'required' Security Mode is defined. Here, we work around this by replacing that security mode with an
-            // 'if-possible' setting.
-            builder.setSecurityMode( ConnectionConfiguration.SecurityMode.ifpossible );
         }
 
         final XMPPTCPConnectionConfiguration configuration = builder.build();

--- a/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
+++ b/core/src/main/java/org/jivesoftware/AccountCreationWizard.java
@@ -52,6 +52,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.UnrecoverableKeyException;
 
+import static org.jivesoftware.sparkimpl.certificates.SparkSSLContextCreator.Options.ONLY_SERVER_SIDE;
+
 /**
  * Allows the creation of accounts on an XMPP server.
  */
@@ -365,13 +367,14 @@ public class AccountCreationWizard extends JPanel {
         if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useDirectTls) {
             // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
             // plain connections which is 5222.
+            SparkSSLContextCreator.Options options = ONLY_SERVER_SIDE;
             try {
-                SSLContext context = SparkSSLContextCreator.setUpContext(SparkSSLContextCreator.Options.ONLY_SERVER_SIDE);
-                builder.setSslContextFactory(() -> { return context; });
+                SSLContext context = SparkSSLContextCreator.setUpContext(options);
+                builder.setSslContextFactory(() -> context);
                 builder.setSecurityMode( securityMode );
                 builder.setCustomX509TrustManager(new SparkTrustManager());
             } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
-                Log.warning("Couldnt establish secured connection", e);
+                Log.warning("Could not establish secured connection", e);
             }
         }
         
@@ -389,7 +392,8 @@ public class AccountCreationWizard extends JPanel {
                 builder.setHost( resolvedAddresses.get( 0 ).getHostName() );
                 builder.setPort( 5223 );
             }
-            builder.setSocketFactory( new SparkSSLSocketFactory(SparkSSLContextCreator.Options.ONLY_SERVER_SIDE) );
+            SparkSSLContextCreator.Options options = ONLY_SERVER_SIDE;
+            builder.setSocketFactory( new SparkSSLSocketFactory(options) );
             // SMACK 4.1.9  does not recognize an 'old-style' SSL socket as being secure, which will cause a failure when
             // the 'required' Security Mode is defined. Here, we work around this by replacing that security mode with an
             // 'if-possible' setting.

--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -278,9 +278,6 @@ public class LoginDialog {
             .setCompressionEnabled(localPref.isCompressionEnabled())
             .setSecurityMode(securityMode);
 
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && localPref.isDisableHostnameVerification()) {
-            TLSUtils.disableHostnameVerificationForTlsCertificates(builder);
-        }
         if (localPref.isDebuggerEnabled()) {
             builder.enableDefaultDebugger();
         }
@@ -294,6 +291,9 @@ public class LoginDialog {
         }
 
         if (securityMode != ConnectionConfiguration.SecurityMode.disabled) {
+            if (localPref.isDisableHostnameVerification()) {
+                TLSUtils.disableHostnameVerificationForTlsCertificates(builder);
+            }
             if (!useDirectTls) {
                 // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
                 // plain connections which is 5222.
@@ -326,9 +326,6 @@ public class LoginDialog {
                 // 'if-possible' setting.
                 builder.setSecurityMode(ConnectionConfiguration.SecurityMode.ifpossible);
             }
-        }
-
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled) {
             SASLAuthentication.registerSASLMechanism(new SASLExternalMechanism());
         }
 

--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -230,7 +230,7 @@ public class LoginDialog {
         }
 
         ConnectionConfiguration.SecurityMode securityMode = localPref.getSecurityMode();
-        boolean useOldSSL = localPref.isSSL();
+        boolean useDirectTls = localPref.isDirectTls();
         boolean hostPortConfigured = localPref.isHostAndPortConfigured();
 
         ProxyInfo proxyInfo = null;
@@ -291,7 +291,7 @@ public class LoginDialog {
             builder.setProxyInfo(proxyInfo);
         }
 
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useOldSSL) {
+        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useDirectTls) {
             // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
             // plain connections which is 5222.
             SparkSSLContextCreator.Options options;
@@ -310,7 +310,7 @@ public class LoginDialog {
             }
         }
 
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && useOldSSL) {
+        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && useDirectTls) {
             if (!hostPortConfigured) {
                 // SMACK 4.1.9 does not support XEP-0368, and does not apply a port change, if the host is not changed too.
                 // Here, we force the host to be set (by doing a DNS lookup), and force the port to 5223 (which is the
@@ -1619,7 +1619,7 @@ public class LoginDialog {
         //  localPref.setProxyUsername("");
         localPref.setResource(localPref.getResource());
         localPref.setSaslGssapiSmack3Compatible(localPref.isSaslGssapiSmack3Compatible());
-        localPref.setSSL(localPref.isSSL());
+        localPref.setDirectTls(localPref.isDirectTls());
         localPref.setSecurityMode(localPref.getSecurityMode());
         localPref.setSSOEnabled(localPref.isSSOEnabled());
         localPref.setSSOMethod("file");

--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -289,45 +289,7 @@ public class LoginDialog {
         if (localPref.isProxyEnabled()) {
             builder.setProxyInfo(proxyInfo);
         }
-
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled) {
-            if (localPref.isDisableHostnameVerification()) {
-                TLSUtils.disableHostnameVerificationForTlsCertificates(builder);
-            }
-            if (!useDirectTls) {
-                // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
-                // plain connections which is 5222.
-                SparkSSLContextCreator.Options options = localPref.isAllowClientSideAuthentication() ? BOTH : ONLY_SERVER_SIDE;
-                try {
-                    SSLContext context = SparkSSLContextCreator.setUpContext(options);
-                    builder.setSslContextFactory(() -> context);
-                    builder.setSecurityMode(securityMode);
-                    builder.setCustomX509TrustManager(new SparkTrustManager());
-                } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
-                    Log.warning("Could not establish secured connection", e);
-                }
-            } else { // useDirectTls
-                if (!hostPortConfigured) {
-                    // SMACK 4.1.9 does not support XEP-0368, and does not apply a port change, if the host is not changed too.
-                    // Here, we force the host to be set (by doing a DNS lookup), and force the port to 5223 (which is the
-                    // default 'old-style' SSL port).
-                    DnsName serverNameDnsName = DnsName.from(loginServer);
-                    java.util.List<InetAddress> resolvedAddresses = DNSUtil.getDNSResolver().lookupHostAddress(serverNameDnsName, null, DnssecMode.disabled);
-                    if (resolvedAddresses.isEmpty()) {
-                        throw new RuntimeException("Could not resolve " + serverNameDnsName);
-                    }
-                    builder.setHost(resolvedAddresses.get(0).getHostName());
-                    builder.setPort(5223);
-                }
-                SparkSSLContextCreator.Options options = localPref.isAllowClientSideAuthentication() ? BOTH : ONLY_SERVER_SIDE;
-                builder.setSocketFactory(new SparkSSLSocketFactory(options));
-                // SMACK 4.1.9  does not recognize an 'old-style' SSL socket as being secure, which will cause a failure when
-                // the 'required' Security Mode is defined. Here, we work around this by replacing that security mode with an
-                // 'if-possible' setting.
-                builder.setSecurityMode(ConnectionConfiguration.SecurityMode.ifpossible);
-            }
-            SASLAuthentication.registerSASLMechanism(new SASLExternalMechanism());
-        }
+        configureConnectionTls(builder, securityMode, useDirectTls, hostPortConfigured, loginServer);
 
         // SPARK-1747: Don't use the GSS-API SASL mechanism when SSO is disabled.
         SASLAuthentication.unregisterSASLMechanism(SASLGSSAPIMechanism.class.getName());
@@ -356,6 +318,47 @@ public class LoginDialog {
 //        	config.setTruststorePassword(localPref.getTrustStorePassword());
 //        }
         return builder.build();
+    }
+
+    private void configureConnectionTls(XMPPTCPConnectionConfiguration.Builder builder, ConnectionConfiguration.SecurityMode securityMode, boolean useDirectTls, boolean hostPortConfigured, String serverName) {
+        if (securityMode != ConnectionConfiguration.SecurityMode.disabled) {
+            if (localPref.isDisableHostnameVerification()) {
+                TLSUtils.disableHostnameVerificationForTlsCertificates(builder);
+            }
+            if (!useDirectTls) {
+                // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
+                // plain connections which is 5222.
+                SparkSSLContextCreator.Options options = localPref.isAllowClientSideAuthentication() ? BOTH : ONLY_SERVER_SIDE;
+                try {
+                    SSLContext context = SparkSSLContextCreator.setUpContext(options);
+                    builder.setSslContextFactory(() -> context);
+                    builder.setSecurityMode(securityMode);
+                    builder.setCustomX509TrustManager(new SparkTrustManager());
+                } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
+                    Log.warning("Could not establish secured connection", e);
+                }
+            } else { // useDirectTls
+                if (!hostPortConfigured) {
+                    // SMACK 4.1.9 does not support XEP-0368, and does not apply a port change, if the host is not changed too.
+                    // Here, we force the host to be set (by doing a DNS lookup), and force the port to 5223 (which is the
+                    // default 'old-style' SSL port).
+                    DnsName serverNameDnsName = DnsName.from(serverName);
+                    java.util.List<InetAddress> resolvedAddresses = DNSUtil.getDNSResolver().lookupHostAddress(serverNameDnsName, null, DnssecMode.disabled);
+                    if (resolvedAddresses.isEmpty()) {
+                        throw new RuntimeException("Could not resolve " + serverNameDnsName);
+                    }
+                    builder.setHost(resolvedAddresses.get(0).getHostName());
+                    builder.setPort(5223);
+                }
+                SparkSSLContextCreator.Options options = localPref.isAllowClientSideAuthentication() ? BOTH : ONLY_SERVER_SIDE;
+                builder.setSocketFactory(new SparkSSLSocketFactory(options));
+                // SMACK 4.1.9  does not recognize an 'old-style' SSL socket as being secure, which will cause a failure when
+                // the 'required' Security Mode is defined. Here, we work around this by replacing that security mode with an
+                // 'if-possible' setting.
+                builder.setSecurityMode(ConnectionConfiguration.SecurityMode.ifpossible);
+            }
+            SASLAuthentication.registerSASLMechanism(new SASLExternalMechanism());
+        }
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -95,6 +95,8 @@ import java.util.*;
 import java.util.List;
 
 import static org.jivesoftware.spark.util.StringUtils.modifyWildcards;
+import static org.jivesoftware.sparkimpl.certificates.SparkSSLContextCreator.Options.BOTH;
+import static org.jivesoftware.sparkimpl.certificates.SparkSSLContextCreator.Options.ONLY_SERVER_SIDE;
 
 /**
  * Dialog to log in a user into the Spark Server. The LoginDialog is used only
@@ -294,19 +296,14 @@ public class LoginDialog {
         if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useDirectTls) {
             // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
             // plain connections which is 5222.
-            SparkSSLContextCreator.Options options;
-            if (localPref.isAllowClientSideAuthentication()) {
-                options = SparkSSLContextCreator.Options.BOTH;
-            } else {
-                options = SparkSSLContextCreator.Options.ONLY_SERVER_SIDE;
-            }
+            SparkSSLContextCreator.Options options = localPref.isAllowClientSideAuthentication() ? BOTH : ONLY_SERVER_SIDE;
             try {
                 SSLContext context = SparkSSLContextCreator.setUpContext(options);
-                builder.setSslContextFactory(() -> { return context; });
+                builder.setSslContextFactory(() -> context);
                 builder.setSecurityMode(securityMode);
                 builder.setCustomX509TrustManager(new SparkTrustManager());
             } catch (NoSuchAlgorithmException | KeyManagementException | UnrecoverableKeyException | KeyStoreException | NoSuchProviderException e) {
-                Log.warning("Couldnt establish secured connection", e);
+                Log.warning("Could not establish secured connection", e);
             }
         }
 
@@ -323,12 +320,7 @@ public class LoginDialog {
                 builder.setHost(resolvedAddresses.get(0).getHostName());
                 builder.setPort(5223);
             }
-            SparkSSLContextCreator.Options options;
-            if (localPref.isAllowClientSideAuthentication()) {
-                options = SparkSSLContextCreator.Options.BOTH;
-            } else {
-                options = SparkSSLContextCreator.Options.ONLY_SERVER_SIDE;
-            }
+            SparkSSLContextCreator.Options options = localPref.isAllowClientSideAuthentication() ? BOTH : ONLY_SERVER_SIDE;
             builder.setSocketFactory(new SparkSSLSocketFactory(options));
             // SMACK 4.1.9  does not recognize an 'old-style' SSL socket as being secure, which will cause a failure when
             // the 'required' Security Mode is defined. Here, we work around this by replacing that security mode with an

--- a/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
+++ b/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
@@ -689,7 +689,7 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
         }
 
         ConnectionConfiguration.SecurityMode securityMode = localPref.getSecurityMode();
-        boolean useOldSSL = localPref.isSSL();
+        boolean useDirectTls = localPref.isDirectTls();
         boolean hostPortConfigured = localPref.isHostAndPortConfigured();
 
         ProxyInfo proxyInfo = null;
@@ -750,7 +750,7 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
             builder.setProxyInfo(proxyInfo);
         }
 
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useOldSSL) {
+        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && !useDirectTls) {
             // This use STARTTLS which starts initially plain connection to upgrade it to TLS, it use the same port as
             // plain connections which is 5222.
             SparkSSLContextCreator.Options options;
@@ -769,7 +769,7 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
             }
         }
 
-        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && useOldSSL) {
+        if (securityMode != ConnectionConfiguration.SecurityMode.disabled && useDirectTls) {
             if (!hostPortConfigured) {
                 // SMACK 4.1.9 does not support XEP-0368, and does not apply a port change, if the host is not changed too.
                 // Here, we force the host to be set (by doing a DNS lookup), and force the port to 5223 (which is the
@@ -1719,7 +1719,7 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
         //  localPref.setProxyUsername("");
         localPref.setResource(localPref.getResource());
         localPref.setSaslGssapiSmack3Compatible(localPref.isSaslGssapiSmack3Compatible());
-        localPref.setSSL(localPref.isSSL());
+        localPref.setDirectTls(localPref.isDirectTls());
         localPref.setSecurityMode(localPref.getSecurityMode());
         localPref.setSSOEnabled(localPref.isSSOEnabled());
         localPref.setSSOMethod("file");

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/SecurityLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/SecurityLoginSettingsPanel.java
@@ -45,8 +45,8 @@ public class SecurityLoginSettingsPanel extends JPanel
     private final JRadioButton modeIfPossibleRadio;
     private final JRadioButton modeDisabledRadio;
 
-    // Checkbox that toggles between 'old' style SSL (socket encryption, typically on port 5223), or STARTTLS. A check indicates 'old' behavior.
-    private final JCheckBox useSSLBox;
+    // Checkbox that toggles between 'old' style Direct TLS (socket encryption, typically on port 5223), or STARTTLS. A check indicates 'old' behavior.
+    private final JCheckBox useDirectTlsBox;
 
     private final JCheckBox disableHostnameVerificationBox;
     private final JCheckBox allowClientSideAuthentication;
@@ -73,7 +73,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         modeDisabledRadio = new JRadioButton();
         modeDisabledRadio.setToolTipText( Res.getString( "tooltip.encryptionmode.disabled" ) );
 
-        useSSLBox = new JCheckBox();
+        useDirectTlsBox = new JCheckBox();
         disableHostnameVerificationBox = new JCheckBox();
         allowClientSideAuthentication  = new JCheckBox();
 
@@ -84,7 +84,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         ResourceUtils.resButton( modeRequiredRadio,              Res.getString( "radio.encryptionmode.required" ) );
         ResourceUtils.resButton( modeIfPossibleRadio,            Res.getString( "radio.encryptionmode.ifpossible" ) );
         ResourceUtils.resButton( modeDisabledRadio,              Res.getString( "radio.encryptionmode.disabled" ) );
-        ResourceUtils.resButton( useSSLBox,                      Res.getString( "label.old.ssl" ) );
+        ResourceUtils.resButton( useDirectTlsBox,                Res.getString( "label.old.ssl" ) );
         ResourceUtils.resButton( disableHostnameVerificationBox, Res.getString( "checkbox.disable.hostname.verification" ) );
         ResourceUtils.resButton( allowClientSideAuthentication,  Res.getString( "checkbox.allow.client.side.authentication" ) );
         ResourceUtils.resButton( deleteSavedPasswords,           Res.getString( "button.delete.saved.passwords" ) );
@@ -98,7 +98,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         // ... add event handler that disables the UI of encryption-related config, when encryption itself is disabled.
         modeDisabledRadio.addChangeListener( e -> {
             final boolean encryptionPossible = !modeDisabledRadio.isSelected();
-            useSSLBox.setEnabled( encryptionPossible );
+            useDirectTlsBox.setEnabled( encryptionPossible );
             disableHostnameVerificationBox.setEnabled( encryptionPossible );
             allowClientSideAuthentication.setEnabled( encryptionPossible );
         } );
@@ -107,7 +107,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         modeRequiredRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.required );
         modeIfPossibleRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.ifpossible );
         modeDisabledRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.disabled );
-        useSSLBox.setSelected( localPreferences.isSSL() );
+        useDirectTlsBox.setSelected( localPreferences.isSSL() );
         disableHostnameVerificationBox.setSelected( localPreferences.isDisableHostnameVerification() );
         allowClientSideAuthentication.setSelected(true);
 
@@ -122,7 +122,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         encryptionModePanel.add( modeRequiredRadio,   new GridBagConstraints( 0, 0, 1, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
         encryptionModePanel.add( modeIfPossibleRadio, new GridBagConstraints( 0, 1, 1, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
         encryptionModePanel.add( modeDisabledRadio,   new GridBagConstraints( 0, 2, 1, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
-        encryptionModePanel.add( useSSLBox,           new GridBagConstraints( 0, 3, 2, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
+        encryptionModePanel.add( useDirectTlsBox,     new GridBagConstraints( 0, 3, 2, 1, 1.0, 0.0, WEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
 
         // ... place the titled-border panel on the global panel.
         add( encryptionModePanel,            new GridBagConstraints( 0, 0, 1, 1, 1.0, 0.0, NORTHWEST, HORIZONTAL, DEFAULT_INSETS, 0, 0 ) );
@@ -144,7 +144,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         modeDisabledRadio.setSelected(Default.getString(Default.SECURITY_MODE).equals("disabled"));
         disableHostnameVerificationBox.setSelected(Default.getBoolean(Default.DISABLE_HOSTNAME_VERIFICATION));
         allowClientSideAuthentication.setSelected(Default.getBoolean(Default.ALLOW_CLIENT_SIDE_AUTH));
-        useSSLBox.setSelected(Default.getBoolean(Default.OLD_SSL_ENABLED));
+        useDirectTlsBox.setSelected(Default.getBoolean(Default.OLD_SSL_ENABLED));
     }
     
     public void saveSettings()
@@ -161,7 +161,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         {
             localPreferences.setSecurityMode( ConnectionConfiguration.SecurityMode.disabled );
         }
-        localPreferences.setSSL( useSSLBox.isSelected() );
+        localPreferences.setSSL( useDirectTlsBox.isSelected() );
         localPreferences.setDisableHostnameVerification( disableHostnameVerificationBox.isSelected() );
         localPreferences.setAllowClientSideAuthentication( allowClientSideAuthentication.isSelected() );
         SettingsManager.saveSettings();

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/SecurityLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/SecurityLoginSettingsPanel.java
@@ -107,7 +107,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         modeRequiredRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.required );
         modeIfPossibleRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.ifpossible );
         modeDisabledRadio.setSelected( localPreferences.getSecurityMode() == ConnectionConfiguration.SecurityMode.disabled );
-        useDirectTlsBox.setSelected( localPreferences.isSSL() );
+        useDirectTlsBox.setSelected( localPreferences.isDirectTls() );
         disableHostnameVerificationBox.setSelected( localPreferences.isDisableHostnameVerification() );
         allowClientSideAuthentication.setSelected(true);
 
@@ -161,7 +161,7 @@ public class SecurityLoginSettingsPanel extends JPanel
         {
             localPreferences.setSecurityMode( ConnectionConfiguration.SecurityMode.disabled );
         }
-        localPreferences.setSSL( useDirectTlsBox.isSelected() );
+        localPreferences.setDirectTls( useDirectTlsBox.isSelected() );
         localPreferences.setDisableHostnameVerification( disableHostnameVerificationBox.isSelected() );
         localPreferences.setAllowClientSideAuthentication( allowClientSideAuthentication.isSelected() );
         SettingsManager.saveSettings();

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
@@ -485,31 +485,30 @@ public class LocalPreferences {
         props.setProperty( "securityMode", securityMode.toString() );
     }
 
-	/**
-	 * Returns true to use 'old style' SSL.
+    /**
+     * Returns true to use 'old style' Direct TLS.
+     * <p>
+     * This type of encryption typically occurs on port 5223, and causes the socket to be TLS-encrypted immediately.
+     * <p>
+     * When this option is <em>disabled</em>, but encryption is still to be used, STARTTLS will be used instead.
      *
-     * This type of encryption typically occurs on port 5223, and causes the socket to be SSL-encrypted immediately.
-     *
-     * When this options is <em>disabled</em>, but encryption is still to be used, STARTTLS will be used instead.
-	 *
-	 * @return true if we should connect via 'old-style' SSL (otherwise, STARTTLS might be used).
-	 */
-	public boolean isSSL() {
+     * @return true if we should connect via 'old-style' Direct TLS (otherwise, STARTTLS might be used).
+     */
+	public boolean isDirectTls() {
 		return getBoolean("sslEnabled", Default.getBoolean(Default.OLD_SSL_ENABLED));
 	}
 
-	/**
-	 * Sets if the agent should use 'old style' SSL for connecting.
-	 *
+    /**
+     * Sets if the agent should use 'old style' Direct TLS for connecting.
+     * <p>
      * This type of encryption typically occurs on port 5223, and causes the socket to be SSL-encrypted immediately.
+     * <p>
+     * When this option is <em>disabled</em>, but encryption is still to be used, STARTTLS will be used instead.
      *
-     * When this options is <em>disabled</em>, but encryption is still to be used, STARTTLS will be used instead.
-     *
-	 * @param ssl
-	 *            true if we should be using SSL, false if STARTTLS is to be used for encryption.
-	 */
-	public void setSSL(boolean ssl) {
-		props.setProperty("sslEnabled", Boolean.toString(ssl));
+     * @param directTls true if we should be using Direct TLS, false if STARTTLS is to be used for encryption.
+     */
+	public void setDirectTls(boolean directTls) {
+		props.setProperty("sslEnabled", Boolean.toString(directTls));
 	}
 
 	/**


### PR DESCRIPTION
The code uses a term "Old SSL" for Direct TLS connections on port 5223.
This is supported by [XEP-0368](https://xmpp.org/extensions/xep-0368.html) and may be not necessary for old clients.
To make the code follow same terminology as XEP I renamed the LocalPreferences.isSSL() to isDirectTls(). The property name in properties file internally remains same.

Additionally extract the similar code to configure TLS in the Login and AccountCreationWizard.