### PR TITLE
SPARK-2337 refactoring, cleanup and minor perf improvement

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/SoundManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/SoundManager.java
@@ -49,15 +49,16 @@ public class SoundManager {
      * @return the AudioClip found. If no audio clip was found, returns null.
      */
     public AudioClip getClip(String clip) {
-        if (!clipMap.containsKey(clip)) {
+        AudioClip audioClip = clipMap.get(clip);
+        if (audioClip == null) {
             // Add new clip
-            final AudioClip newClip = loadClipForURL(clip);
-            if (newClip != null) {
-                clipMap.put(clip, newClip);
+            audioClip = loadClipForURL(clip);
+            if (audioClip != null) {
+                clipMap.put(clip, audioClip);
             }
         }
 
-        return clipMap.get(clip);
+        return audioClip;
     }
 
     /**

--- a/core/src/main/java/org/jivesoftware/spark/UserManager.java
+++ b/core/src/main/java/org/jivesoftware/spark/UserManager.java
@@ -395,9 +395,8 @@ public class UserManager {
         for (ContactGroup contactGroup : contactList.getContactGroups()) {
             contactGroup.clearSelection();
             for (ContactItem contactItem : contactGroup.getContactItems()) {
-                if (!contactMap.containsKey(contactItem.getJid().toString())) {
+                if (contactMap.putIfAbsent(contactItem.getJid().toString(), contactItem) == null) {
                     contacts.add(contactItem);
-                    contactMap.put(contactItem.getJid().toString(), contactItem);
                 }
             }
         }

--- a/core/src/main/java/org/jivesoftware/spark/component/AutoCompleteDocument.java
+++ b/core/src/main/java/org/jivesoftware/spark/component/AutoCompleteDocument.java
@@ -54,8 +54,7 @@ public class AutoCompleteDocument extends PlainDocument {
     }
 
     public String autoComplete(String text) {
-        for (Object aDictionary : dictionary) {
-            String word = (String) aDictionary;
+        for (String word : dictionary) {
             if (word.startsWith(text)) {
                 return word.substring(text.length());
             }

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1705,37 +1705,35 @@ public class ContactList extends JPanel implements ActionListener,
 
 
     private void sendMessages(Collection<ContactItem> items) {
-        StringBuilder buf = new StringBuilder();
         InputDialog dialog = new InputDialog();
         final String messageText = dialog.getInput(Res.getString("title.broadcast.message"), Res.getString("message.enter.broadcast.message"), SparkRes.getImageIcon(SparkRes.BLANK_IMAGE), SparkManager.getMainWindow());
-        if (ModelUtil.hasLength(messageText)) {
-
-            final Map<String, Message> broadcastMessages = new HashMap<>();
-            for (ContactItem item : items) {
-                final Message message = new Message();
-                message.setTo(item.getJid());
-                final Map<String, Object> properties = new HashMap<>();
-                properties.put("broadcast", true);
-                message.addExtension(new JivePropertiesExtension(properties));
-                message.setBody(messageText);
-                if (!broadcastMessages.containsKey(item.getJid().toString())) {
-                    buf.append(item.getDisplayName()).append("\n");
-                    broadcastMessages.put(item.getJid().toString(), message);
-                }
+        if (!ModelUtil.hasLength(messageText)) {
+            return;
+        }
+        StringBuilder buf = new StringBuilder();
+        final Map<String, Message> broadcastMessages = new HashMap<>();
+        for (ContactItem item : items) {
+            final Message message = new Message();
+            message.setTo(item.getJid());
+            final Map<String, Object> properties = new HashMap<>();
+            properties.put("broadcast", true);
+            message.addExtension(new JivePropertiesExtension(properties));
+            message.setBody(messageText);
+            if (!broadcastMessages.containsKey(item.getJid().toString())) {
+                buf.append(item.getDisplayName()).append('\n');
+                broadcastMessages.put(item.getJid().toString(), message);
             }
-
-            for (Message message : broadcastMessages.values()) {
-                try {
-                    SparkManager.getConnection().sendStanza(message);
-                } catch (SmackException.NotConnectedException | InterruptedException e) {
-                    Log.warning("Unable to send broadcast to " + message.getTo(), e);
-                }
-            }
-            UIManager.put("OptionPane.okButtonText", Res.getString("ok"));
-            JOptionPane.showMessageDialog(SparkManager.getMainWindow(), Res.getString("message.hasbeenbroadcast.to", buf.toString()), Res.getString("title.notification"), JOptionPane.INFORMATION_MESSAGE);
         }
 
-
+        for (Message message : broadcastMessages.values()) {
+            try {
+                SparkManager.getConnection().sendStanza(message);
+            } catch (SmackException.NotConnectedException | InterruptedException e) {
+                Log.warning("Unable to send broadcast to " + message.getTo(), e);
+            }
+        }
+        UIManager.put("OptionPane.okButtonText", Res.getString("ok"));
+        JOptionPane.showMessageDialog(SparkManager.getMainWindow(), Res.getString("message.hasbeenbroadcast.to", buf.toString()), Res.getString("title.notification"), JOptionPane.INFORMATION_MESSAGE);
     }
 
     // For plugin use only

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactList.java
@@ -1719,9 +1719,8 @@ public class ContactList extends JPanel implements ActionListener,
             properties.put("broadcast", true);
             message.addExtension(new JivePropertiesExtension(properties));
             message.setBody(messageText);
-            if (!broadcastMessages.containsKey(item.getJid().toString())) {
+            if (broadcastMessages.putIfAbsent(item.getJid().toString(), message) == null) {
                 buf.append(item.getDisplayName()).append('\n');
-                broadcastMessages.put(item.getJid().toString(), message);
             }
         }
 

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/GSSAPIConfiguration.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/GSSAPIConfiguration.java
@@ -67,9 +67,9 @@ public class GSSAPIConfiguration extends Configuration
 	public AppConfigurationEntry[] getAppConfigurationEntry( String name )
     {
         AppConfigurationEntry[] a = new AppConfigurationEntry[ 1 ];
-        if ( configs.containsKey( name ) )
+        Vector<AppConfigurationEntry> v = configs.get( name );
+        if ( v != null )
         {
-            Vector<AppConfigurationEntry> v = configs.get( name );
             a = v.toArray( a );
             return a;
         }
@@ -81,16 +81,7 @@ public class GSSAPIConfiguration extends Configuration
 
     public boolean putAppConfigurationEntry( String name, String module, AppConfigurationEntry.LoginModuleControlFlag controlFlag, Map<String, String> options )
     {
-        Vector<AppConfigurationEntry> v;
-        if ( configs.containsKey( name ) )
-        {
-            v = configs.get( name );
-        }
-        else
-        {
-            v = new Vector<>();
-            configs.put( name, v );
-        }
+        Vector<AppConfigurationEntry> v = configs.computeIfAbsent(name, k -> new Vector<>());
 
         return v.add( new AppConfigurationEntry( module, controlFlag, options ) );
     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/certificates/OIDTranslator.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/certificates/OIDTranslator.java
@@ -104,8 +104,9 @@ public final class OIDTranslator {
 	}
 
 	public static String getDescription(String oid) {
-		if (OIDtoDescriptionMap.containsKey(oid)) {
-			return OIDtoDescriptionMap.get(oid);
+		String description = OIDtoDescriptionMap.get(oid);
+		if (description != null) {
+			return description;
 		} else {
 			Log.warning("Unknown description for  Object ID (OID: " + oid + ")");
 			return Res.getString("cert.unknown.oid");

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/history/ConversationHistoryPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/history/ConversationHistoryPlugin.java
@@ -37,6 +37,7 @@ import java.awt.*;
 import java.awt.event.*;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -285,9 +286,7 @@ public class ConversationHistoryPlugin implements Plugin {
         // Write out new File
         try {
             File conFile = new File(transcriptDir, "conversations.xml");
-            BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(conFile), StandardCharsets.UTF_8));
-            out.write(builder.toString());
-            out.close();
+            Files.write(conFile.toPath(), builder.toString().getBytes(StandardCharsets.UTF_8));
         }
         catch (IOException e) {
             Log.error(e);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/transcripts/ChatTranscripts.java
@@ -28,15 +28,13 @@ import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -122,9 +120,7 @@ public final class ChatTranscripts {
             // Write out new File
             try {
                 transcriptFile.getParentFile().mkdirs();
-                BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(transcriptFile), StandardCharsets.UTF_8));
-                out.write(builder.toString());
-                out.close();
+                Files.write(transcriptFile.toPath(), builder.toString().getBytes(StandardCharsets.UTF_8));
             }
             catch (IOException e) {
                 Log.error(e);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -515,11 +515,11 @@ public class PluginViewer extends JPanel implements Plugin
             PublicPlugin publicPlugin = new PublicPlugin();
 
             String clazz;
-            String name = null;
             try
             {
                 Element plugin = (Element) plugin1;
 
+                String name = plugin.selectSingleNode("name").getText();
                 try
                 {
                     String minSparkVersion = plugin.selectSingleNode( "minSparkVersion" ).getText();
@@ -535,7 +535,6 @@ public class PluginViewer extends JPanel implements Plugin
                     continue;
                 }
 
-                name = plugin.selectSingleNode( "name" ).getText();
                 clazz = plugin.selectSingleNode( "class" ).getText();
                 publicPlugin.setPluginClass( clazz );
                 publicPlugin.setName( name );

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -520,18 +520,10 @@ public class PluginViewer extends JPanel implements Plugin
                 Element plugin = (Element) plugin1;
 
                 String name = plugin.selectSingleNode("name").getText();
-                try
+                String minSparkVersion = plugin.selectSingleNode( "minSparkVersion" ).getText();
+                if ( !isGreaterOrEqual( sparkVersion, minSparkVersion ) )
                 {
-                    String minSparkVersion = plugin.selectSingleNode( "minSparkVersion" ).getText();
-                    if ( !isGreaterOrEqual( sparkVersion, minSparkVersion ) )
-                    {
-                        Log.error( "Unable to load plugin " + name + " due to min version incompatibility." );
-                        continue;
-                    }
-                }
-                catch ( Exception e )
-                {
-                    Log.error( "Unable to load plugin " + name + " due to no minSparkVersion." );
+                    Log.error( "Unable to load plugin " + name + " due to min version incompatibility." );
                     continue;
                 }
 
@@ -608,8 +600,6 @@ public class PluginViewer extends JPanel implements Plugin
             {
                 Log.error(ex);
             }
-
-
         }
         return pluginList;
     }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -55,6 +55,7 @@ import java.io.*;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -504,10 +505,10 @@ public class PluginViewer extends JPanel implements Plugin
         catch ( DocumentException | SAXException e )
         {
             Log.error( e );
+            return Collections.emptyList();
         }
 
         List<? extends Node> plugins = pluginXML.selectNodes( "/plugins/plugin" );
-
         for ( Node plugin1 : plugins )
         {
             PublicPlugin publicPlugin = new PublicPlugin();
@@ -605,7 +606,7 @@ public class PluginViewer extends JPanel implements Plugin
             }
             catch ( Exception ex )
             {
-                ex.printStackTrace();
+                Log.error(ex);
             }
 
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -135,9 +135,8 @@ public class PluginViewer extends JPanel implements Plugin
     {
         PluginManager pluginManager = PluginManager.getInstance();
         List<PublicPlugin> plugins = pluginManager.getPublicPlugins();
-        for ( Object plugin1 : plugins )
+        for ( PublicPlugin plugin : plugins )
         {
-            PublicPlugin plugin = (PublicPlugin) plugin1;
             final SparkPlugUI ui = new SparkPlugUI( plugin );
             ui.useLocalIcon();
             installedPanel.add( ui );

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -508,6 +508,7 @@ public class PluginViewer extends JPanel implements Plugin
             return Collections.emptyList();
         }
 
+        String sparkVersion = JiveInfo.getVersion();
         List<? extends Node> plugins = pluginXML.selectNodes( "/plugins/plugin" );
         for ( Node plugin1 : plugins )
         {
@@ -521,8 +522,8 @@ public class PluginViewer extends JPanel implements Plugin
 
                 try
                 {
-                    String version = plugin.selectSingleNode( "minSparkVersion" ).getText();
-                    if ( !isGreaterOrEqual( JiveInfo.getVersion(), version ) )
+                    String minSparkVersion = plugin.selectSingleNode( "minSparkVersion" ).getText();
+                    if ( !isGreaterOrEqual( sparkVersion, minSparkVersion ) )
                     {
                         Log.error( "Unable to load plugin " + name + " due to min version incompatibility." );
                         continue;

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/viewer/PluginViewer.java
@@ -512,9 +512,6 @@ public class PluginViewer extends JPanel implements Plugin
         List<? extends Node> plugins = pluginXML.selectNodes( "/plugins/plugin" );
         for ( Node plugin1 : plugins )
         {
-            PublicPlugin publicPlugin = new PublicPlugin();
-
-            String clazz;
             try
             {
                 Element plugin = (Element) plugin1;
@@ -527,7 +524,8 @@ public class PluginViewer extends JPanel implements Plugin
                     continue;
                 }
 
-                clazz = plugin.selectSingleNode( "class" ).getText();
+                String clazz = plugin.selectSingleNode("class").getText();
+                PublicPlugin publicPlugin = new PublicPlugin();
                 publicPlugin.setPluginClass( clazz );
                 publicPlugin.setName( name );
 

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -449,9 +449,9 @@ public class VCardManager {
     }
 
 	/**
-	 * Returns the VCard. You should always use useChachedVCards. VCardManager
-	 * will keep the VCards up to date. If you wan't to force a network reload
-	 * of the VCard you can set useChachedVCards to false. That means that you
+	 * Returns the VCard. You should always use useCachedVCards. VCardManager
+	 * will keep the VCards up to date. If you want to force a network reload
+	 * of the VCard you can set useCachedVCards to false. That means that you
 	 * have to wait for the vcard response. The method will block until the
 	 * result is available or a timeout occurs (like reloadVCard(String jid)).
 	 * If there is no response from server this method a dummy vcard with an

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -56,6 +56,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -759,9 +760,7 @@ public class VCardManager {
 
         // write xml to file
         try {
-            BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(vcardFile), StandardCharsets.UTF_8));
-            out.write(xml);
-            out.close();
+            Files.write(vcardFile.toPath(), xml.getBytes(StandardCharsets.UTF_8));
         }
         catch (IOException e) {
             Log.error(e);

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -430,8 +430,9 @@ public class VCardManager {
 	 */
     public VCard getVCardFromMemory(BareJid jid) {
         // Check in memory first.
-        if (vcards.containsKey(jid)) {
-            return vcards.get(jid);
+        VCard currentVcard = vcards.get(jid);
+        if (currentVcard != null) {
+            return currentVcard;
         }
 
         // if not in memory
@@ -540,7 +541,8 @@ public class VCardManager {
         if (vcard == null)
         	return; 
         vcard.setJabberId(jid.toString());
-        if (vcards.containsKey(jid) && vcards.get(jid).getError() == null && vcard.getError()!= null)
+        VCard currentVcard = vcards.get(jid);
+        if (currentVcard != null && currentVcard.getError() == null && vcard.getError()!= null)
         {
         	return;
         	

--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/JiveInfo.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/JiveInfo.java
@@ -42,7 +42,7 @@ public class JiveInfo {
             return version.trim();
         }
 
-        return null;
+        return "3.0.3"; // avoid null and return at least some current version
     }
 
     public static String getOS() {


### PR DESCRIPTION
Fixed some problems that were highlighted by IntelliJ.
Removed almost all usages of `map.containsKey(key)` and the `map.get(key)` to improve performance and make the lookup only once.

Cleaned code for the PluginViewer while investigated an issue of missing plugins explained here https://discourse.igniterealtime.org/t/spark-plugins-repositiry-is-empty/94464

The diff looks huge but just use the IntelliJ to see changes that can hide spaces and you'll find that most of changes are simple and straightforward