### PR TITLE
Use APP_NAME from spark.properties

### DIFF
--- a/core/src/main/java/org/jivesoftware/LoginDialog.java
+++ b/core/src/main/java/org/jivesoftware/LoginDialog.java
@@ -142,7 +142,7 @@ public class LoginDialog {
 
         // Construct Dialog
         EventQueue.invokeLater(() -> {
-            loginDialog = new JFrame(Default.getString(Default.APPLICATION_NAME));
+            loginDialog = new JFrame(JiveInfo.getName());
             loginDialog.setIconImage(SparkManager.getApplicationImage().getImage());
             LoginPanel loginPanel = new LoginPanel();
             final JPanel mainPanel = new LoginBackgroundPanel();

--- a/core/src/main/java/org/jivesoftware/MainWindow.java
+++ b/core/src/main/java/org/jivesoftware/MainWindow.java
@@ -95,7 +95,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
      */
     public static synchronized MainWindow getInstance() {
         if (null == singleton) {
-            singleton = new MainWindow(Default.getString(Default.APPLICATION_NAME), SparkManager.getApplicationImage());
+            singleton = new MainWindow(JiveInfo.getName(), SparkManager.getApplicationImage());
         }
         return singleton;
     }
@@ -713,7 +713,7 @@ public final class MainWindow extends ChatFrame implements ActionListener {
 
         // Construct About Box text
         StringBuilder aboutBoxText = new StringBuilder();
-        aboutBoxText.append(Default.getString(Default.APPLICATION_NAME)).append(" ").append(JiveInfo.getVersion());
+        aboutBoxText.append(JiveInfo.getName()).append(" ").append(JiveInfo.getVersion());
 
         // Add APPLICATION_INFO1 if not empty
         if (!("".equals(APPLICATION_INFO1))) {

--- a/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
+++ b/core/src/main/java/org/jivesoftware/gui/LoginUIPanel.java
@@ -621,7 +621,7 @@ public class LoginUIPanel extends javax.swing.JPanel implements KeyListener, Act
         } catch (Exception e) {
             Log.error(e);
         }
-        loginDialog = new JFrame(Default.getString(Default.APPLICATION_NAME));
+        loginDialog = new JFrame(JiveInfo.getName());
 
         // Construct Dialog
         EventQueue.invokeLater(() -> {

--- a/core/src/main/java/org/jivesoftware/resource/Default.java
+++ b/core/src/main/java/org/jivesoftware/resource/Default.java
@@ -36,7 +36,6 @@ public class Default {
     private static final Map<String,ImageIcon> cache = new HashMap<>();
 
     public static final String MAIN_IMAGE = "MAIN_IMAGE";
-    public static final String APPLICATION_NAME = "APPLICATION_NAME";
     public static final String APPLICATION_INFO1 = "APPLICATION_INFO1";
     public static final String APPLICATION_INFO2 = "APPLICATION_INFO2";
     public static final String APPLICATION_INFO3 = "APPLICATION_INFO3";

--- a/core/src/main/java/org/jivesoftware/spark/ui/login/GeneralLoginSettingsPanel.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/login/GeneralLoginSettingsPanel.java
@@ -152,7 +152,7 @@ class GeneralLoginSettingsPanel extends JPanel implements ActionListener
         boolean isSelected = useVersionAsResourceBox.isSelected();
         if ( isSelected )
         {
-            String resource = Default.getString( Default.APPLICATION_NAME ) + " " + JiveInfo.getVersion();
+            String resource = JiveInfo.getName() + " " + JiveInfo.getVersion();
             resourceField.setText( resource );
             useHostnameAsResourceBox.setSelected( false );
         }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/systray/SysTrayPlugin.java
@@ -52,6 +52,7 @@ import org.jivesoftware.spark.ui.status.StatusBar;
 import org.jivesoftware.spark.ui.status.StatusItem;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.plugin.manager.Enterprise;
+import org.jivesoftware.sparkimpl.settings.JiveInfo;
 import org.jivesoftware.sparkimpl.settings.local.LocalPreferences;
 import org.jivesoftware.sparkimpl.settings.local.SettingsManager;
 import org.jivesoftware.smackx.chatstates.ChatStateListener;
@@ -253,7 +254,7 @@ public class SysTrayPlugin implements Plugin, NativeHandler, ChatStateListener {
 		
 		
 		trayIcon = new TrayIcon(availableIcon.getImage(),
-			Default.getString(Default.APPLICATION_NAME), null);
+            JiveInfo.getName(), null);
 		trayIcon.setImageAutoSize(true);
 
 		trayIcon.addMouseListener(new MouseListener() {

--- a/core/src/main/resources/default.properties
+++ b/core/src/main/resources/default.properties
@@ -4,7 +4,6 @@
 # The Login image
 # suggested image dimensions 244 x 188 pixels
 MAIN_IMAGE = images/spark.gif
-APPLICATION_NAME = Spark
 SHORT_NAME = Spark
 
 USER_DIRECTORY_WINDOWS = Spark


### PR DESCRIPTION
Use APP_NAME from spark.properties instead of APPLICATION_NAME from default.properties.
This is confusing to have two similar properties with the same value in two separate configs.