### PR TITLE
SPARK-2346 make default-jre or any other JRE for Linux Deb

### DIFF
--- a/distribution/src/installer/spark.install4j
+++ b/distribution/src/installer/spark.install4j
@@ -834,7 +834,7 @@ return console.askYesNo(message, true);
       </exclude>
       <jreBundle jreBundleSource="none" />
     </linuxRPM>
-    <linuxDeb name="Linux Deb Archive" id="166" dependencies="default-jre | java-runtime (>= 8)">
+    <linuxDeb name="Linux Deb Archive" id="166" dependencies="default-jre | java-runtime (&gt;= 8)">
       <exclude>
         <entry location="bin/startup.bat" />
         <entry location="documentation" />

--- a/distribution/src/installer/spark.install4j
+++ b/distribution/src/installer/spark.install4j
@@ -34,7 +34,7 @@
   </files>
   <launchers>
     <launcher name="Spark" id="4" icnsFile="images/message.icns">
-      <executable name="Spark" iconSet="true" iconFile="images/spark.ico" executableDir="." stderrFile="logs/error.log" redirectStdout="true" stdoutFile="logs/output.log" executableMode="gui" singleInstance="true" serviceDescription="communicator" dpiAware="false">
+      <executable name="Spark" iconSet="true" iconFile="images/spark.ico" executableDir="." executableMode="gui" singleInstance="true" serviceDescription="communicator" dpiAware="false">
         <versionInfo include="true" fileDescription="${compiler:sys.shortName}" legalCopyright="${compiler:sys.publisher}" internalName="${compiler:sys.shortName}" />
       </executable>
       <java mainClass="org.jivesoftware.launcher.Startup" vmParameters="&quot;-Dappdir=${launcher:sys.launcherDirectory}&quot; -Dsun.java2d.noddraw=true &quot;-Djava.library.path=${launcher:sys.launcherDirectory}\lib\windows&quot;" preferredVM="client">

--- a/distribution/src/installer/spark.install4j
+++ b/distribution/src/installer/spark.install4j
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="10.0.3" transformSequenceNumber="10">
+<install4j version="10.0.9" transformSequenceNumber="10">
   <directoryPresets config="../../target/distribution-base/lib" />
   <application name="Spark" applicationId="3057-7228-2063-7466" mediaDir="../../target/" mediaFilePattern="spark_${compiler:sys.version}" compression="9" lzmaCompression="true" commonExternalFiles="true" shortName="Spark" publisher="Ignite Realtime" publisherWeb="http://www.igniterealtime.org" version="3.0.0" allPathsRelative="true" macVolumeId="ccfadd9e467a1ebd" javaMinVersion="1.8" jdkMode="runtimeJre">
     <languages skipLanguageSelection="true">
@@ -34,7 +34,7 @@
   </files>
   <launchers>
     <launcher name="Spark" id="4" icnsFile="images/message.icns">
-      <executable name="Spark" iconSet="true" iconFile="images/spark.ico" executableDir="." executableMode="gui" singleInstance="true" serviceDescription="communicator" dpiAware="false">
+      <executable name="Spark" iconSet="true" iconFile="images/spark.ico" executableDir="." redirectStderr="false" executableMode="gui" singleInstance="true" serviceDescription="communicator" dpiAware="false">
         <versionInfo include="true" fileDescription="${compiler:sys.shortName}" legalCopyright="${compiler:sys.publisher}" internalName="${compiler:sys.shortName}" />
       </executable>
       <java mainClass="org.jivesoftware.launcher.Startup" vmParameters="&quot;-Dappdir=${launcher:sys.launcherDirectory}&quot; -Dsun.java2d.noddraw=true &quot;-Djava.library.path=${launcher:sys.launcherDirectory}\lib\windows&quot;" preferredVM="client">

--- a/distribution/src/installer/spark.install4j
+++ b/distribution/src/installer/spark.install4j
@@ -834,7 +834,7 @@ return console.askYesNo(message, true);
       </exclude>
       <jreBundle jreBundleSource="none" />
     </linuxRPM>
-    <linuxDeb name="Linux Deb Archive" id="166" dependencies="default-jre">
+    <linuxDeb name="Linux Deb Archive" id="166" dependencies="default-jre | java-runtime (>= 8)">
       <exclude>
         <entry location="bin/startup.bat" />
         <entry location="documentation" />


### PR DESCRIPTION
https://igniterealtime.atlassian.net/browse/SPARK-2346

The launcher has a the std out/err log redirection that doesn’t work and when I starting the Spark I see the exception: 

 

    java.io.FileNotFoundException: log file directory '/opt/Spark/logs' doesn't exist.
    	at com.exe4j.runtime.LauncherEngine.checkRedirectionFile(LauncherEngine.java:196)
    	at com.exe4j.runtime.LauncherEngine.doRedirection(LauncherEngine.java:172)
    	at com.exe4j.runtime.LauncherEngine.launch(LauncherEngine.java:59)
    	at com.install4j.runtime.launcher.UnixLauncher.start(UnixLauncher.java:69)
    	at install4j.org.jivesoftware.launcher.Startup.main(Unknown Source)