### PR TITLE
 SPARK-2352: BookmarkPlugin.setBookmarks(): avoid NPE on null names

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/bookmarks/BookmarkPlugin.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/bookmarks/BookmarkPlugin.java
@@ -154,9 +154,11 @@ public class BookmarkPlugin implements Plugin {
                 if (manager != null) {
 
                     final List<BookmarkedConference> bookmarkedConferences = manager.getBookmarkedConferences()
-                        .stream().sorted(Comparator.comparing(BookmarkedConference::getName)).collect(Collectors.toList());;
+                        .stream().sorted(Comparator.comparing(BookmarkedConference::getName, Comparator.nullsFirst(Comparator.naturalOrder())))
+                        .collect(Collectors.toList());
                     final List<BookmarkedURL> bookmarkedLinks = manager.getBookmarkedURLs()
-                        .stream().sorted(Comparator.comparing(BookmarkedURL::getName)).collect(Collectors.toList());
+                        .stream().sorted(Comparator.comparing(BookmarkedURL::getName, Comparator.nullsFirst(Comparator.naturalOrder())))
+                        .collect(Collectors.toList());
 
                     for (BookmarkedURL bookmarkedLink : bookmarkedLinks) {
                         final BookmarkedURL link = bookmarkedLink;


### PR DESCRIPTION
Normally the conference bookmark looks like this:
```xml
    <conference name='smack' autojoin='true' jid='smack@conference.igniterealtime.org'>
        <nick>stokito</nick>
    </conference>
```

I tested the Spark with other public servers (not OF) and don't know how I made this and in which client, but I have a room bookmark that doesn't have a conference name and even a nick:

    <conference autojoin='false' jid='char@example.com'></conference>

This causes an NPE:
```
java.lang.NullPointerException: Cannot invoke "java.lang.Comparable.compareTo(Object)" because the return value of "java.util.function.Function.apply(Object)" is null
	at java.base/java.util.Comparator.lambda$comparing$77a9974f$1(Comparator.java:473)
	at java.base/java.util.Arrays.sort(Arrays.java:1307)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at org.jivesoftware.sparkimpl.plugin.bookmarks.BookmarkPlugin$1.setBookmarks(BookmarkPlugin.java:158)
	at org.jivesoftware.sparkimpl.plugin.bookmarks.BookmarkPlugin$1.createMenu(BookmarkPlugin.java:138)
	at org.jivesoftware.sparkimpl.plugin.bookmarks.BookmarkPlugin$1.initialize(BookmarkPlugin.java:79)
```

To avoid this I added `Comparator.nullsFirst` that will allow to sort even the null values.