### PR TITLE
SPARK-2353: Disable by default notification when user joins or leaves a group chat

### DIFF
--- a/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/settings/local/LocalPreferences.java
@@ -1329,17 +1329,8 @@ public class LocalPreferences {
 
     public List<String> getDeactivatedPlugins()
     {
-	String plugs = getString("deactivatedPlugins", "");
-	ArrayList<String> liste = new ArrayList<>();
-
-	StringTokenizer tokenz = new StringTokenizer(plugs, ",");
-
-	while(tokenz.hasMoreTokens())
-	{
-	    String x = tokenz.nextToken();
-	    liste.add(x);
-	}
-	return liste;
+        String plugs = getString("deactivatedPlugins", "");
+        return Arrays.asList(plugs.split(","));
     }
 
     public void setDeactivatedPlugins(List<String> list) {


### PR DESCRIPTION
https://igniterealtime.atlassian.net/browse/SPARK-2353
When you have a large room with many users who are on mobile internet then this messages floods all the chat history. Probably this notifications made some sense in old days but now this needs to be changed.
The problem is that we have two separate events that XMPP doesn't allow to distinguish:
* user joins a chat i.e. this is a completely new participant (which happens rarely)
* a user become available now and he will probably read your message if you write in the chat (it's not that important). Maybe for small rooms with a few participants this is needed sometimes.

Generally speaking this is something that needs to be discussed with other clients or at least with Modern XMPP project https://github.com/modernxmpp/modernxmpp/issues/65.

I would like to propose to disable this notification by default for new installations. The old installations already have this options set to `true` in their saved properties so they won't be affected. If needed a user can open Settings / Group chats and enable the "Show join and leave messages" checkbox.

