### PR TITLE
i18n: remove preamble from files

### DIFF
--- a/core/src/main/resources/i18n/spark_i18n.properties
+++ b/core/src/main/resources/i18n/spark_i18n.properties
@@ -1,30 +1,6 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
+## For translation use https://explore.transifex.com/igniterealtime/spark/
 ## In property strings that are parameterized, single quotes can be used to
 ## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept = Accept
 is.active = Active
 add = Add

--- a/core/src/main/resources/i18n/spark_i18n_cs.properties
+++ b/core/src/main/resources/i18n/spark_i18n_cs.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 ok = Ok
 cancel = Storno
 add = Přidat

--- a/core/src/main/resources/i18n/spark_i18n_de.properties
+++ b/core/src/main/resources/i18n/spark_i18n_de.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept = Akzeptieren
 is.active = Aktiv
 add = Hinzufügen

--- a/core/src/main/resources/i18n/spark_i18n_es.properties
+++ b/core/src/main/resources/i18n/spark_i18n_es.properties
@@ -1,34 +1,6 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-##
 ## Traduccion al espanol por Jeffrey Steve Borbon Sanabria (jeffto@aclibre.org)
 ## Corrección de Juan Gabriel
 ## Noviembre 2008
-
 accept = Aceptar
 
 action.clear = Limpiar

--- a/core/src/main/resources/i18n/spark_i18n_fi.properties
+++ b/core/src/main/resources/i18n/spark_i18n_fi.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 administrator = Pääkäyttäjä
 apply = Ota käyttöön
 ok = Ok

--- a/core/src/main/resources/i18n/spark_i18n_fr.properties
+++ b/core/src/main/resources/i18n/spark_i18n_fr.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-##
 ## French Translation by Ben LeBlond & Jonathan Pitre
 ## ben@jivesfotware.com - jakeld@gmail.com
 ## August 2011

--- a/core/src/main/resources/i18n/spark_i18n_it.properties
+++ b/core/src/main/resources/i18n/spark_i18n_it.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept = Accetta
 is.active = Attiva
 add = Aggiungi

--- a/core/src/main/resources/i18n/spark_i18n_ja.properties
+++ b/core/src/main/resources/i18n/spark_i18n_ja.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 ok = Ok
 cancel = キャンセル
 add = 追加

--- a/core/src/main/resources/i18n/spark_i18n_ko.properties
+++ b/core/src/main/resources/i18n/spark_i18n_ko.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept = 수락
 is.active = 활성화
 add = 추가

--- a/core/src/main/resources/i18n/spark_i18n_ky.properties
+++ b/core/src/main/resources/i18n/spark_i18n_ky.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept= Кабыл алуу
 action.clear=Тазалоо
 action.copy=Көчүрүү

--- a/core/src/main/resources/i18n/spark_i18n_lt.properties
+++ b/core/src/main/resources/i18n/spark_i18n_lt.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept = Priimti
 is.active = Aktyvu
 add = Pridėti

--- a/core/src/main/resources/i18n/spark_i18n_nl.properties
+++ b/core/src/main/resources/i18n/spark_i18n_nl.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept = Accepteer
 is.active = Actief
 add = Toevoegen

--- a/core/src/main/resources/i18n/spark_i18n_pl.properties
+++ b/core/src/main/resources/i18n/spark_i18n_pl.properties
@@ -1,32 +1,4 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-##
 ## Tlumaczenie wersji pl stworzyl i na biezaco korektuje TEAM MOPR Bytom (informatycy@mopr.bytom.pl) - korekty mile widziane ;)
-
 accept = Akceptuj
 is.active = Aktywny
 add = Dodaj

--- a/core/src/main/resources/i18n/spark_i18n_pt_BR.properties
+++ b/core/src/main/resources/i18n/spark_i18n_pt_BR.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-        
 ok = OK
 cancel = Cancelar
 use.default = Usar padrão

--- a/core/src/main/resources/i18n/spark_i18n_ru_RU.properties
+++ b/core/src/main/resources/i18n/spark_i18n_ru_RU.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept = Принять
 is.active = Active
 add = Добавить

--- a/core/src/main/resources/i18n/spark_i18n_sv.properties
+++ b/core/src/main/resources/i18n/spark_i18n_sv.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 ok = Ok
 cancel = Avbryt
 add = Lägg till

--- a/core/src/main/resources/i18n/spark_i18n_tr.properties
+++ b/core/src/main/resources/i18n/spark_i18n_tr.properties
@@ -1,33 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-##
-## Turkish translator: Ali Erkan IMREK      <alierkanimrek [at] gmail.com>
-## Please contact for translation errors and ideas.
-
 accept = Kabul
 is.active = Aktif
 add = Ekle

--- a/core/src/main/resources/i18n/spark_i18n_uk_UA.properties
+++ b/core/src/main/resources/i18n/spark_i18n_uk_UA.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 1.2.840.113533.7.65.0  = Розширення версії Entrust
 1.3.6.1.4.1.311.10.3.4 = Автоматично отримано з OID'ів асоційованих з криптографією Microsoft
 1.3.6.1.4.1.311.20.2   = Розширення типу сертифіката szOID_ENROLL_CERTTYPE_EXTENSION

--- a/core/src/main/resources/i18n/spark_i18n_zh_CN.properties
+++ b/core/src/main/resources/i18n/spark_i18n_zh_CN.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-
 accept = 接受
 is.active = 活动
 add = 添加

--- a/core/src/main/resources/i18n/spark_i18n_zh_TW.properties
+++ b/core/src/main/resources/i18n/spark_i18n_zh_TW.properties
@@ -1,30 +1,3 @@
-##
-## Spark Resource Bundle
-##
-## Additional locales can be specified by creating a new resource file in this
-## directory using the following conventions:
-##
-##   spark_i18n "_" language "_" country ".properties"
-##   spark_i18n "_" language ".properties"
-##
-## e.g.
-##    spark_i18n_en.properties       <- English resources
-##    spark_i18n_en_US.properties   <- American US resources
-##    spark_i18n_de.properties      <- German resources
-##    spark_i18n_ja.properties      <- Japanese resources
-##
-## Please note that the two digit language code should be lower case, and the
-## two digit country code should be in uppercase. Often, it is not necessary to
-## specify the country code.
-##
-## A list of language codes can be found at
-## https://www.loc.gov/standards/iso639-2/php/code_list.php
-## and a list of country codes can be found at
-## http://kirste.userpage.fu-berlin.de/diverse/doc/ISO_3166.html
-##
-## In property strings that are parameterized, single quotes can be used to
-## quote the "{" (curly brace) if necessary. A real single quote is represented by ''.
-		
 ok	=	確定
 cancel	=	取消
 add	=	新增


### PR DESCRIPTION
The preamble is not really useful and it definitely must not be copied to translations. Instead I added a link to the Transifex so that users will see the proper way to submit translations.
This also reduced size of i18n from 976K down to 956K i.e. saved 20kb.