### PR TITLE
Bump FlatLaf, JNA and dom4j

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.4</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
@@ -221,12 +221,12 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna-platform</artifactId>
-            <version>5.12.1</version>
+            <version>5.19.1</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.12.1</version>
+            <version>5.19.1</version>
         </dependency>
 
         <dependency>
@@ -285,7 +285,7 @@
         <dependency>
         <groupId>com.formdev</groupId>
         <artifactId>flatlaf</artifactId>
-        <version>3.1.1</version>
+        <version>3.7.1</version>
         <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
Another small, focused pull request split out from #977.

This bumps three dependencies in core:

FlatLaf from 3.1.1 to 3.7.1
JNA from 5.12.1 to 5.19.1 (both jna and jna-platform)
dom4j from 2.1.4 to 2.2.0

Only version numbers change, no source changes are needed for these.

BouncyCastle is deliberately left out of this PR, since dependabot already covers that bump to 1.84 in #967 and #968.
