### PR TITLE
SPARK-2118: Move 'multiple resources' to 'view client version' 

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactGroup.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2004-2011 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2011 Jive Software, 2026 Ignite Realtime Foundation. All rights reserved.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,10 +66,10 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
     private final ContactItem noContacts = UIComponentRegistry.createContactGroupItem(Res.getString("group.empty"));
     private final ListMotionListener motionListener = new ListMotionListener();
     private boolean canShowPopup;
-    private boolean mouseDragged = false;
     private final LocalPreferences preferences = SettingsManager.getLocalPreferences();
     private ContactList contactList = Workspace.getInstance().getContactList();
-    private DisplayWindowTask timerTask = null;
+    private SwingTimerTask timerTask = null;
+    private ContactItem hoverItem;
 
     /**
      * Create a new ContactGroup.
@@ -515,32 +515,10 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
 
     @Override
     public void mouseEntered(MouseEvent e) {
-        int loc = contactItemList.locationToIndex(e.getPoint());
-        Object o = model.getElementAt(loc);
-        if (!(o instanceof ContactItem)) {
-            return;
-        }
-        contactItemList.setCursor(GraphicUtils.HAND_CURSOR);
     }
 
     @Override
     public void mouseExited(MouseEvent e) {
-        Object o;
-        try {
-            int loc = contactItemList.locationToIndex(e.getPoint());
-            if (loc == -1) {
-                return;
-            }
-            o = model.getElementAt(loc);
-            if (!(o instanceof ContactItem)) {
-                UIComponentRegistry.getContactInfoWindow().hideWindow();
-                return;
-            }
-        } catch (Exception e1) {
-            Log.error(e1);
-            return;
-        }
-        contactItemList.setCursor(GraphicUtils.DEFAULT_CURSOR);
     }
 
     @Override
@@ -818,76 +796,74 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
             @Override
             public void mouseEntered(MouseEvent mouseEvent) {
                 canShowPopup = true;
-                timerTask = new DisplayWindowTask(mouseEvent);
-                TaskEngine.getInstance().schedule(timerTask, 750, 1000);
+                contactItemList.setCursor(GraphicUtils.HAND_CURSOR);
             }
 
             @Override
             public void mouseExited(MouseEvent mouseEvent) {
-                if (timerTask != null) {
-                    TaskEngine.getInstance().cancelScheduledTask(timerTask);
-                }
                 canShowPopup = false;
+                hoverItem = null;
+                cancelExistingTimer();
                 UIComponentRegistry.getContactInfoWindow().hideWindow();
+                contactItemList.setCursor(GraphicUtils.DEFAULT_CURSOR);
             }
         });
         contactItemList.addMouseMotionListener(motionListener);
     }
 
-    private class DisplayWindowTask extends SwingTimerTask {
-        private MouseEvent event;
-        private boolean newPopupShown = false;
-
-        public DisplayWindowTask(MouseEvent e) {
-            event = e;
-        }
-
-        @Override
-        public void doRun() {
-            if (canShowPopup) {
-                if (!newPopupShown && !mouseDragged) {
-                    displayWindow(event);
-                    newPopupShown = true;
-                }
-            }
-        }
-
-        public void setEvent(MouseEvent event) {
-            this.event = event;
-        }
-
-        public void setNewPopupShown(boolean popupChanged) {
-            this.newPopupShown = popupChanged;
-        }
-
-        public boolean isNewPopupShown() {
-            return newPopupShown;
+    private void cancelExistingTimer() {
+        if (timerTask != null) {
+            TaskEngine.getInstance().cancelScheduledTask(timerTask);
+            timerTask = null;
         }
     }
 
     private class ListMotionListener extends MouseMotionAdapter {
         @Override
         public void mouseMoved(MouseEvent e) {
-            if (!canShowPopup) {
+            int index = contactItemList.locationToIndex(e.getPoint());
+            if (index < 0) {
                 return;
             }
-            if (e == null) {
-                return;
-            }
-            timerTask.setEvent(e);
-            if (needToChangePopup(e) && timerTask.isNewPopupShown()) {
-                UIComponentRegistry.getContactInfoWindow().hideWindow();
-                timerTask.setNewPopupShown(false);
-            }
-            mouseDragged = false;
-        }
 
-        @Override
-        public void mouseDragged(MouseEvent e) {
-            if (timerTask.isNewPopupShown()) {
+            Rectangle bounds = contactItemList.getCellBounds(index, index);
+            if (bounds == null || !bounds.contains(e.getPoint())) {
+                hoverItem = null;
+                cancelExistingTimer();
                 UIComponentRegistry.getContactInfoWindow().hideWindow();
+                contactItemList.setCursor(GraphicUtils.DEFAULT_CURSOR);
+                return;
             }
-            mouseDragged = true;
+
+            contactItemList.setCursor(GraphicUtils.HAND_CURSOR);
+            ContactItem item = model.get(index);
+
+            if (item == hoverItem) {
+                return;
+            }
+            hoverItem = item;
+
+            cancelExistingTimer();
+
+            UIComponentRegistry.getContactInfoWindow().hideWindow();
+
+            timerTask = new SwingTimerTask() {
+                @Override
+                public void doRun() {
+                    timerTask = null;
+                    if (!canShowPopup) {
+                        return;
+                    }
+
+                    if (hoverItem != item) {
+                        return; // Mouse moved elsewhere.
+                    }
+
+                    displayWindow(e);
+                }
+            };
+
+            TaskEngine.getInstance().schedule(timerTask, 750);
         }
     }
 
@@ -908,14 +884,6 @@ public class ContactGroup extends CollapsiblePane implements MouseListener {
             }
         };
         worker.start();
-    }
-
-    private boolean needToChangePopup(MouseEvent e) {
-        ContactInfoWindow contactInfoWindow = UIComponentRegistry.getContactInfoWindow();
-        int loc = getList().locationToIndex(e.getPoint());
-        ContactItem item = getList().getModel().getElementAt(loc);
-        ContactItem currentlyShownItem = contactInfoWindow.getContactItem();
-        return (item == null || currentlyShownItem == null) || !currentlyShownItem.getJid().equals(item.getJid());
     }
 
     protected DefaultListModel<ContactItem> getModel() {

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
@@ -80,7 +80,6 @@ public class ContactInfoWindow extends JPanel {
     private final JLabel iconLabel = new JLabel();
     private final JLabel titleLabel = new JLabel();
     private final JLabel phoneLabel = new JLabel();
-    private final JTextArea clientResourcesLabel = new JTextArea();
 
     private ContactItem contactItem;
 
@@ -109,7 +108,6 @@ public class ContactInfoWindow extends JPanel {
         add(titleLabel, new GridBagConstraints(2, 4, 1, 1, 1, 0, NORTHWEST, HORIZONTAL, new Insets(0, 0, 2, 2), 0, 0));
         add(phoneLabel, new GridBagConstraints(2, 5, 1, 1, 1, 0, NORTHWEST, HORIZONTAL, new Insets(0, 0, 2, 2), 0, 0));
         add(fullJIDLabel, new GridBagConstraints(0, 6, 4, 1, 1, 1, SOUTHWEST, HORIZONTAL, new Insets(0, 2, 2, 2), 0, 0));
-        add(clientResourcesLabel, new GridBagConstraints(0, 7, 4, 1, 1, 1, SOUTHWEST, HORIZONTAL, new Insets(0, 2, 2, 2), 0, 0));
 
         Font dialogFont = new Font("Dialog", Font.PLAIN, 12);
         nicknameLabel.setFont(new Font("Dialog", Font.BOLD, 14));
@@ -128,9 +126,6 @@ public class ContactInfoWindow extends JPanel {
         fullJIDLabel.setFont(dialogFont);
         fullJIDLabel.setForeground(COLOR_TEXT);
         fullJIDLabel.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, COLOR_TEXT));
-        clientResourcesLabel.setLineWrap(true);
-        clientResourcesLabel.setWrapStyleWord(true);
-        clientResourcesLabel.setEditable(false);
         phoneLabel.setBorder(null);
 
         setBorder(BorderFactory.createLineBorder(COLOR_TEXT, 1));
@@ -213,7 +208,6 @@ public class ContactInfoWindow extends JPanel {
         idleLabel.setText("");
         titleLabel.setText("");
         phoneLabel.setText("");
-        showClientResources(isOnLeave, contactItem.getJid());
 
         // Reserve avatar space immediately so the layout does not change later.
         final ImageIcon placeholder = GraphicUtils.scaleImageIcon(SparkRes.getImageIcon(SparkRes.Icon.DEFAULT_AVATAR_64x64_IMAGE), Sizes.Avatar.PROFILE, Sizes.Avatar.PROFILE);
@@ -299,21 +293,6 @@ public class ContactInfoWindow extends JPanel {
             fullJIDLabel.setText(localPart);
             fullJIDLabel.setIcon(null);
         }
-    }
-
-    private void showClientResources(boolean isOnLeave, BareJid contactJid) {
-        if (isOnLeave) {
-            clientResourcesLabel.setText("");
-            return;
-        }
-        String clientResources = "";
-        List<Presence> allPresences = SparkManager.getRoster().getAvailablePresences(contactJid);
-        for (Presence p : allPresences) {
-            clientResources += p.getFrom().getResourceOrEmpty() + " " +
-                (p.getMode() != available ? p.getMode() : "") + " " +
-                (p.getStatus() != null ? p.getStatus() : "") + "\n";
-        }
-        clientResourcesLabel.setText(clientResources);
     }
 
     private String retrieveIdleTimeText(ContactItem contactItem, boolean isOnLeave) {

--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactInfoWindow.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2004-2011 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2011 Jive Software, 2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.JWindow;
-import javax.swing.SwingUtilities;
 
 import org.jivesoftware.MainWindow;
 import org.jivesoftware.resource.Res;
@@ -41,6 +40,7 @@ import org.jivesoftware.smackx.iqlast.LastActivityManager;
 import org.jivesoftware.spark.SparkManager;
 import org.jivesoftware.spark.util.GraphicUtils;
 import org.jivesoftware.spark.util.ModelUtil;
+import org.jivesoftware.spark.util.SwingWorker;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.plugin.gateways.transports.Transport;
 import org.jivesoftware.sparkimpl.plugin.gateways.transports.TransportUtils;
@@ -211,10 +211,84 @@ public class ContactInfoWindow extends JPanel {
         }
         statusLabel.setText(status);
         idleLabel.setText("");
-        if (isOnLeave || isAway) {
-            SwingUtilities.invokeLater(() -> retrieveIdleTime(isOnLeave));
-        }
+        titleLabel.setText("");
+        phoneLabel.setText("");
         showClientResources(isOnLeave, contactItem.getJid());
+
+        // Reserve avatar space immediately so the layout does not change later.
+        final ImageIcon placeholder = GraphicUtils.scaleImageIcon(SparkRes.getImageIcon(SparkRes.Icon.DEFAULT_AVATAR_64x64_IMAGE), Sizes.Avatar.PROFILE, Sizes.Avatar.PROFILE);
+        avatarLabel.setIcon(placeholder);
+        avatarLabel.setBorder(BorderFactory.createLineBorder(Color.lightGray, 1, true));
+
+        // Load expensive data asynchronously.
+        final ContactItem currentItem = contactItem;
+
+        new SwingWorker() {
+            private String title;
+            private String phone;
+            private ImageIcon avatar;
+            private String idleText;
+
+            @Override
+            public Object construct() {
+                // Avatar
+                try {
+                    URL avatarURL = currentItem.getAvatarURL();
+                    if (avatarURL != null) {
+                        ImageIcon icon = new ImageIcon(avatarURL);
+                        if (icon.getIconHeight() > 1) {
+                            avatar = GraphicUtils.scaleImageIcon(icon, Sizes.Avatar.PROFILE, Sizes.Avatar.PROFILE);
+                        }
+                    }
+                }
+                catch (Exception e) {
+                    Log.warning("Unable to update avatar in contact info window", e);
+                }
+
+                if (avatar == null) {
+                    avatar = GraphicUtils.scaleImageIcon(SparkRes.getImageIcon(SparkRes.Icon.DEFAULT_AVATAR_64x64_IMAGE), Sizes.Avatar.PROFILE, Sizes.Avatar.PROFILE);
+                }
+
+                // VCard
+                try {
+                    VCard vcard = SparkManager.getVCardManager().getVCard(currentItem.getJid());
+                    if (vcard != null) {
+                        title = vcard.getField("TITLE");
+                        phone = vcard.getPhoneWork("VOICE");
+                    }
+                }
+                catch (Exception e) {
+                    Log.warning("Unable to load VCard", e);
+                }
+
+                // Idle time
+                if (isOnLeave || isAway) {
+                    idleText = retrieveIdleTimeText(currentItem, isOnLeave);
+                }
+
+                return null;
+            }
+
+            @Override
+            public void finished() {
+                if (contactItem != currentItem) {
+                    return;
+                }
+
+                avatarLabel.setIcon(avatar);
+                avatarLabel.setBorder(BorderFactory.createLineBorder(Color.lightGray, 1, true));
+
+                titleLabel.setText(title);
+                phoneLabel.setText(phone);
+
+                if (idleText != null) {
+                    idleLabel.setText(idleText);
+                }
+
+                revalidate();
+                repaint();
+            }
+        }.start();
 
         Transport transport = TransportUtils.getTransport(contactItem.getJid().asDomainBareJid());
         String localPart = contactItem.getJid().getLocalpartOrThrow().asUnescapedString();
@@ -224,33 +298,6 @@ public class ContactInfoWindow extends JPanel {
         } else {
             fullJIDLabel.setText(localPart);
             fullJIDLabel.setIcon(null);
-        }
-
-        avatarLabel.setBorder(null);
-
-        try {
-            URL avatarURL = contactItem.getAvatarURL();
-            ImageIcon icon = null;
-            if (avatarURL != null) {
-                icon = new ImageIcon(avatarURL);
-            }
-            if (icon != null && icon.getIconHeight() > 1) {
-                icon = GraphicUtils.scaleImageIcon(icon, Sizes.Avatar.PROFILE, Sizes.Avatar.PROFILE);
-            } else {
-                icon = SparkRes.getImageIcon(SparkRes.Icon.DEFAULT_AVATAR_64x64_IMAGE);
-            }
-            avatarLabel.setIcon(icon);
-            avatarLabel.setBorder(BorderFactory.createLineBorder(Color.lightGray, 1, true));
-        } catch (Exception e) {
-            Log.warning("Unable to update avatar in contact info window", e);
-        }
-
-        VCard vcard = SparkManager.getVCardManager().getVCard(contactItem.getJid());
-        if (vcard != null) {
-            String title = vcard.getField("TITLE");
-            String phone = vcard.getPhoneWork("VOICE");
-            titleLabel.setText(title);
-            phoneLabel.setText(phone);
         }
     }
 
@@ -269,31 +316,26 @@ public class ContactInfoWindow extends JPanel {
         clientResourcesLabel.setText(clientResources);
     }
 
-    private void retrieveIdleTime(boolean isOnLeave) {
-        // When the window was closed the contactItem is cleared
-        if (contactItem == null) {
-            return;
-        }
-        //If user is offline or away, try to see last activity
+    private String retrieveIdleTimeText(ContactItem contactItem, boolean isOnLeave) {
         try {
             //If user is away (not offline), last activity request is sent to client
-            Jid client = isOnLeave ? contactItem.getJid() : contactItem.getPresence().getFrom();
-            LastActivity activity = LastActivityManager.getInstanceFor(SparkManager.getConnection()).getLastActivity(client);
+            final Jid client = isOnLeave ? contactItem.getJid() : contactItem.getPresence().getFrom();
+            final LastActivity activity = LastActivityManager.getInstanceFor(SparkManager.getConnection()).getLastActivity(client);
             long idleTimeSec = activity.getIdleTime();
             if (idleTimeSec > 0) {
-                String idleText = formatIdleTime(isOnLeave, idleTimeSec);
-                idleLabel.setText(idleText);
+                return formatIdleTime(isOnLeave, idleTimeSec);
             }
         } catch (XMPPException.XMPPErrorException e) {
             Condition condition = e.getStanzaError().getCondition();
             if (condition == Condition.feature_not_implemented || condition == Condition.service_unavailable || condition == Condition.subscription_required || condition == Condition.forbidden) {
                 // ignore
-                return;
+                return null;
             }
-            Log.warning("Unable to get Last Activity from: " + contactItem + ": " + e);
+            Log.warning("Unable to get Last Activity from: " + contactItem, e);
         } catch (Exception e) {
             Log.warning("Unable to get Last Activity from: " + contactItem, e);
         }
+        return null;
     }
 
     private static String formatIdleTime(boolean isOnLeave, long idleTimeSec) {

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/JabberVersion.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/JabberVersion.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2004-2011 Jive Software. All rights reserved.
+/**
+ * Copyright (C) 2004-2011 Jive Software, 2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,15 +31,16 @@ import org.jivesoftware.spark.util.SwingWorker;
 import org.jivesoftware.spark.util.log.Log;
 import org.jivesoftware.sparkimpl.settings.JiveInfo;
 import org.jivesoftware.resource.Res;
-import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.FullJid;
 
 import javax.swing.*;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
 import java.time.ZonedDateTime;
-import java.util.Collection;
-import java.util.Date;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Jabber Version.
@@ -133,7 +134,15 @@ public class JabberVersion implements Plugin {
                     JOptionPane.INFORMATION_MESSAGE);
                 return;
             }
-            final Jid jid = presence.getFrom();
+
+            // Collect all available full JIDs for the selected user.
+            final Set<FullJid> allFullJids = SparkManager.getRoster()
+                .getAvailablePresences(presence.getFrom().asBareJid())
+                .stream()
+                .map(p -> p.getFrom().asFullJidIfPossible())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
             SwingWorker worker = new SwingWorker() {
                 @Override
 				public Object construct() {
@@ -143,12 +152,12 @@ public class JabberVersion implements Plugin {
                     catch (InterruptedException e1) {
                         // Nothing to do
                     }
-                    return jid;
+                    return allFullJids;
                 }
 
                 @Override
 				public void finished() {
-                    VersionViewer.viewVersion(jid);
+                    VersionViewer.viewVersion(allFullJids);
                 }
             };
             worker.start();

--- a/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/VersionViewer.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/plugin/jabber/VersionViewer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2004-2011 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2011 Jive Software, 2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,21 +26,63 @@ import org.jivesoftware.spark.UserManager;
 import org.jivesoftware.spark.component.MessageDialog;
 import org.jivesoftware.spark.util.ResourceUtils;
 import org.jivesoftware.spark.util.log.Log;
+import org.jxmpp.jid.FullJid;
 import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.parts.Resourcepart;
 
 import javax.swing.*;
-
 import java.awt.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.Collection;
 
 public class VersionViewer {
 
     private VersionViewer() {
-
     }
 
-    public static void viewVersion(Jid jid) {
+    public static void viewVersion(Collection<FullJid> fullJids) {
+        final XMPPConnection connection = SparkManager.getConnection();
+
+        final JTabbedPane tabbedPane = new JTabbedPane();
+        for (FullJid fullJid : fullJids) {
+            final JPanel card = createResourceCard(connection, fullJid);
+            final Resourcepart resource = fullJid.getResourceOrNull();
+            final String title = (resource != null)
+                ? resource.toString()
+                : fullJid.toString();
+            tabbedPane.addTab(title, card);
+        }
+
+        // Explanatory text above the tabs.
+        final JTextArea explanation = new JTextArea(Res.getString("message.client.information.multiple.resources"));
+        explanation.setEditable(false);
+        explanation.setLineWrap(true);
+        explanation.setWrapStyleWord(true);
+        explanation.setOpaque(false);
+        explanation.setBorder(BorderFactory.createEmptyBorder(5, 5, 8, 5));
+        explanation.setFont(UIManager.getFont("Label.font"));
+
+        final JPanel content = new JPanel(new BorderLayout());
+        content.add(explanation, BorderLayout.NORTH);
+        content.add(tabbedPane, BorderLayout.CENTER);
+
+        // Use the bare JID of the first entry for the dialog's header text.
+        final Jid first = fullJids.iterator().next();
+        MessageDialog.showComponent(
+            Res.getString("title.version.and.time"),
+            Res.getString("message.client.information", UserManager.unescapeJID(first.asBareJid())),
+            SparkRes.getImageIcon(SparkRes.Icon.PROFILE_IMAGE_24x24),
+            content,
+            SparkManager.getMainWindow(),
+            450, 420, false);
+    }
+
+    /**
+     * Builds a loading/data card pair (CardLayout) for a single resource and fires the Version + Time requests to
+     * populate it asynchronously.
+     */
+    private static JPanel createResourceCard(final XMPPConnection connection, final Jid jid) {
         final JPanel loadingCard = new JPanel();
         final ImageIcon icon = new ImageIcon( VersionViewer.class.getClassLoader().getResource( "images/ajax-loader.gif"));
         loadingCard.add(new JLabel("loading... ", icon, JLabel.CENTER));
@@ -90,8 +132,7 @@ public class VersionViewer {
         cards.add(loadingCard);
         cards.add(dataCard);
 
-        final XMPPConnection connection = SparkManager.getConnection();
-        // Load Version
+        // Load version
         final Version versionRequest = Version.builder(connection)
             .ofType(IQ.Type.get)
             .to(jid)
@@ -132,7 +173,9 @@ public class VersionViewer {
                 cardLayout.last(cards);
             });
 
-        MessageDialog.showComponent(Res.getString("title.version.and.time"), Res.getString("message.client.information", UserManager.unescapeJID(jid)), SparkRes.getImageIcon(SparkRes.Icon.PROFILE_IMAGE_24x24), cards, SparkManager.getMainWindow(), 400, 300, false);
+        // Wrap so the card pair sits nicely inside a tab.
+        final JPanel wrapper = new JPanel(new BorderLayout());
+        wrapper.add(cards, BorderLayout.CENTER);
+        return wrapper;
     }
-
 }

--- a/core/src/main/resources/i18n/spark_i18n.properties
+++ b/core/src/main/resources/i18n/spark_i18n.properties
@@ -479,6 +479,7 @@ message.cert.verification.failed=Unable to verify certificate
 message.chat.session.ended=Chat session has ended on {0}
 message.click.to.open=Click to open
 message.client.information=Client information for {0}
+message.client.information.multiple.resources=A contact can be connected with more than one client at the same time. A tab is shown for each client that the contact is currently using. Each tab is named after the client's "resource-part": a unique identifier that distinguishes concurrent clients from one another.
 message.close.other.chats=Close all other chats
 message.close.stale.chats=Close stale chats
 message.close.this.chat=Close this chat


### PR DESCRIPTION
This reverts the previous solution to show all resources for a user (which was displayed in the contactlist tooltip for each user - introducing confusing behavior in a very visible place).

Instead, the resources are now displayed in the 'view client version' menu item, which adds a descriptive disclaimer. This is a less visible place (which will lead to less confusion) and as a bonus, the functionality now no longer returns data from one client when multiple clients are online.