### PR TITLE
SPARK-2409: Bring the Asterisk-IM phone plugin back to life

### DIFF
--- a/plugins/phone/pom.xml
+++ b/plugins/phone/pom.xml
@@ -3,10 +3,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.igniterealtime.spark</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.igniterealtime.spark.plugins</groupId>
+        <artifactId>plugin</artifactId>
         <version>3.1.0-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../plugin/pom.xml</relativePath>
     </parent>
 
     <artifactId>phone</artifactId>
@@ -25,12 +25,7 @@
         </contributor>
     </contributors>
     <dependencies>
-        <dependency>
-            <groupId>org.igniterealtime.spark</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
+        <!-- spark-core is inherited from the plugin parent, in 'provided' scope. -->
         <dependency>
             <groupId>javax.media</groupId>
             <artifactId>jmf</artifactId>
@@ -38,4 +33,13 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/PhoneClient.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/PhoneClient.java
@@ -1,31 +1,167 @@
 package org.jivesoftware.spark.phone.client;
 
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.StanzaListener;
 import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.filter.StanzaExtensionFilter;
+import org.jivesoftware.smack.packet.Stanza;
+import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
+import org.jivesoftware.smackx.disco.packet.DiscoverInfo;
+import org.jivesoftware.smackx.disco.packet.DiscoverItems;
+import org.jivesoftware.spark.phone.client.action.PhoneActionIQ;
 import org.jivesoftware.spark.phone.client.event.BasePhoneEventListener;
-import org.jivesoftware.sparkimpl.plugin.phone.PhonePlugin;
+import org.jivesoftware.spark.phone.client.event.HangUpEvent;
+import org.jivesoftware.spark.phone.client.event.OnPhoneEvent;
+import org.jivesoftware.spark.phone.client.event.PhoneEventExtension;
+import org.jivesoftware.spark.phone.client.event.RingEvent;
 import org.jxmpp.jid.BareJid;
+import org.jxmpp.jid.Jid;
 
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+/**
+ * Client for the Asterisk-IM Openfire plugin.
+ * <p>
+ * Construction is deliberately strict: it fails unless the server publishes a 'phone'
+ * component <em>and</em> the logged-in user has phone support (that is, the user is mapped
+ * to a device on the plugin's Phone Mappings page). {@link org.jivesoftware.sparkimpl.plugin.phone.PhonePlugin}
+ * relies on that to decide whether to show any phone UI at all.
+ */
 public class PhoneClient {
-    private final XMPPConnection connection;
-    private final CopyOnWriteArrayList<BasePhoneEventListener> listeners = new CopyOnWriteArrayList();
 
-    public PhoneClient(XMPPConnection conn) {
+    private static final Logger log = Logger.getLogger(PhoneClient.class.getName());
+
+    /** Disco item name published by the Asterisk-IM plugin. */
+    private static final String COMPONENT_NAME = "phone";
+
+    /** Disco feature that marks a user as phone-enabled. */
+    private static final String PHONE_FEATURE = "http://jivesoftware.com/phone";
+
+    private final XMPPConnection connection;
+    private final Jid component;
+    private final CopyOnWriteArrayList<BasePhoneEventListener> listeners = new CopyOnWriteArrayList<>();
+
+    public PhoneClient(XMPPConnection conn) throws XMPPException, SmackException, InterruptedException {
         this.connection = conn;
+
+        if (!conn.isAuthenticated()) {
+            throw new SmackException.SmackMessageException("Connection is not authenticated!");
+        }
+
+        final ServiceDiscoveryManager discoveryManager = ServiceDiscoveryManager.getInstanceFor(conn);
+
+        Jid found = null;
+        final DiscoverItems items = discoveryManager.discoverItems(conn.getXMPPServiceDomain());
+        for (final DiscoverItems.Item item : items.getItems()) {
+            if (COMPONENT_NAME.equals(item.getName())) {
+                found = item.getEntityID();
+                break;
+            }
+        }
+        if (found == null) {
+            throw new SmackException.SmackMessageException("Server does not have phone services");
+        }
+        this.component = found;
+
+        final DiscoverInfo info = discoveryManager.discoverInfo(component,
+                conn.getUser().getLocalpart().asUnescapedString());
+        if (!info.containsFeature(PHONE_FEATURE)) {
+            throw new SmackException.SmackMessageException("User does not have phone support");
+        }
+
+        conn.addAsyncStanzaListener(new PhoneEventStanzaListener(),
+                new StanzaExtensionFilter(PhoneEventExtension.ELEMENT_NAME, PhoneEventExtension.NAMESPACE));
     }
 
-    public boolean isPhoneEnabled(BareJid bareJid) {
-        return true;
+    /**
+     * Returns true when the given user is mapped to a device, and can therefore be called.
+     */
+    public boolean isPhoneEnabled(BareJid bareJid) throws XMPPException, SmackException, InterruptedException {
+        final DiscoverInfo info = ServiceDiscoveryManager.getInstanceFor(connection)
+                .discoverInfo(component, bareJid.toString());
+        return info.containsFeature(PHONE_FEATURE);
     }
 
     public void addEventListener(BasePhoneEventListener phoneListener) {
         listeners.addIfAbsent(phoneListener);
     }
 
-    public void dialByExtension(String number) {
+    public void removeEventListener(BasePhoneEventListener phoneListener) {
+        listeners.remove(phoneListener);
     }
 
-    public void dialByJID(BareJid jid) {
+    /**
+     * Dials an extension from the user's own device. Asterisk rings the user first, and
+     * dials the extension once they answer.
+     */
+    public void dialByExtension(String number) throws XMPPException, SmackException, InterruptedException {
+        final PhoneActionIQ action = new PhoneActionIQ(PhoneActionIQ.DIAL);
+        action.setType(org.jivesoftware.smack.packet.IQ.Type.set);
+        action.setExtension(number);
+        // Must be addressed to the phone component: without a 'to' the request goes to the
+        // user's own server default and never reaches the plugin's IQ handler.
+        action.setTo(component);
+        action.setFrom(connection.getUser());
+        connection.sendIqRequestAndWaitForResponse(action);
+    }
+
+    /**
+     * Dials another user's primary device.
+     */
+    public void dialByJID(BareJid jid) throws XMPPException, SmackException, InterruptedException {
+        final PhoneActionIQ action = new PhoneActionIQ(PhoneActionIQ.DIAL);
+        action.setType(org.jivesoftware.smack.packet.IQ.Type.set);
+        action.setJid(jid.toString());
+        action.setTo(component);
+        action.setFrom(connection.getUser());
+        connection.sendIqRequestAndWaitForResponse(action);
+    }
+
+    private class PhoneEventStanzaListener implements StanzaListener {
+
+        @Override
+        public void processStanza(Stanza stanza) {
+            final List<PhoneEventExtension> extensions = stanza.getExtensions(PhoneEventExtension.class);
+            for (final PhoneEventExtension event : extensions) {
+                try {
+                    dispatch(event);
+                } catch (Exception e) {
+                    log.log(Level.WARNING, "Unable to dispatch phone event", e);
+                }
+            }
+        }
+
+        private void dispatch(PhoneEventExtension event) {
+            final String type = event.getType();
+            if (type == null) {
+                return;
+            }
+            switch (type) {
+                case PhoneEventExtension.RING: {
+                    final RingEvent ringEvent = new RingEvent(event.getCallID(), event.getDevice(),
+                            event.getCallerID(), event.getCallerIDName());
+                    listeners.forEach(listener -> listener.handleRing(ringEvent));
+                    break;
+                }
+                case PhoneEventExtension.ON_PHONE: {
+                    final OnPhoneEvent onPhoneEvent = new OnPhoneEvent(event.getCallID(), event.getDevice(),
+                            event.getCallerID(), event.getCallerIDName());
+                    listeners.forEach(listener -> listener.handleOnPhone(onPhoneEvent));
+                    break;
+                }
+                case PhoneEventExtension.HANG_UP: {
+                    final HangUpEvent hangUpEvent = new HangUpEvent(event.getCallID(), event.getDevice());
+                    listeners.forEach(listener -> listener.handleHangUp(hangUpEvent));
+                    break;
+                }
+                default:
+                    // DIALED and anything else the server may add: no UI hook in Spark.
+                    break;
+            }
+        }
     }
 }

--- a/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/action/PhoneActionIQ.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/action/PhoneActionIQ.java
@@ -1,0 +1,56 @@
+package org.jivesoftware.spark.phone.client.action;
+
+import org.jivesoftware.smack.packet.IQ;
+
+/**
+ * The <tt>phone-action</tt> IQ understood by the Asterisk-IM Openfire plugin.
+ * <p>
+ * Dialling is a 'set' carrying either an extension or a JID:
+ * <pre>
+ * &lt;iq type="set"&gt;
+ *     &lt;phone-action xmlns="http://jivesoftware.com/xmlns/phone" type="DIAL"&gt;
+ *         &lt;extension&gt;601&lt;/extension&gt;
+ *     &lt;/phone-action&gt;
+ * &lt;/iq&gt;
+ * </pre>
+ * Note that the plugin compares the 'type' attribute against the uppercase enum name, so
+ * "DIAL" is required — "dial" is answered with feature-not-implemented.
+ */
+public class PhoneActionIQ extends IQ {
+
+    public static final String ELEMENT_NAME = "phone-action";
+    public static final String NAMESPACE = "http://jivesoftware.com/xmlns/phone";
+
+    public static final String DIAL = "DIAL";
+    public static final String FORWARD = "FORWARD";
+
+    private final String actionType;
+    private String extension;
+    private String jid;
+
+    public PhoneActionIQ(String actionType) {
+        super(ELEMENT_NAME, NAMESPACE);
+        this.actionType = actionType;
+    }
+
+    public String getActionType() {
+        return actionType;
+    }
+
+    public void setExtension(String extension) {
+        this.extension = extension;
+    }
+
+    public void setJid(String jid) {
+        this.jid = jid;
+    }
+
+    @Override
+    protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
+        xml.attribute("type", actionType);
+        xml.rightAngleBracket();
+        xml.optElement("extension", extension);
+        xml.optElement("jid", jid);
+        return xml;
+    }
+}

--- a/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/action/PhoneActionIQProvider.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/action/PhoneActionIQProvider.java
@@ -1,4 +1,46 @@
 package org.jivesoftware.spark.phone.client.action;
 
-public class PhoneActionIQProvider {
+import org.jivesoftware.smack.packet.IqData;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.parsing.SmackParsingException;
+import org.jivesoftware.smack.provider.IqProvider;
+import org.jivesoftware.smack.xml.XmlPullParser;
+import org.jivesoftware.smack.xml.XmlPullParserException;
+import org.jxmpp.JxmppContext;
+
+import java.io.IOException;
+
+/**
+ * Parses the <tt>phone-action</tt> replies sent back by the Asterisk-IM Openfire plugin.
+ */
+public class PhoneActionIQProvider extends IqProvider<PhoneActionIQ> {
+
+    @Override
+    public PhoneActionIQ parse(XmlPullParser parser, int initialDepth, IqData iqData,
+                               XmlEnvironment xmlEnvironment, JxmppContext context)
+            throws XmlPullParserException, IOException, SmackParsingException {
+
+        final String type = parser.getAttributeValue(null, "type");
+        final PhoneActionIQ iq = new PhoneActionIQ(type != null ? type : PhoneActionIQ.DIAL);
+
+        while (true) {
+            XmlPullParser.Event event = parser.next();
+            if (event == XmlPullParser.Event.START_ELEMENT) {
+                switch (parser.getName()) {
+                    case "extension":
+                        iq.setExtension(parser.nextText());
+                        break;
+                    case "jid":
+                        iq.setJid(parser.nextText());
+                        break;
+                    default:
+                        break;
+                }
+            } else if (event == XmlPullParser.Event.END_ELEMENT && parser.getDepth() == initialDepth) {
+                break;
+            }
+        }
+
+        return iq;
+    }
 }

--- a/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/HangUpEvent.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/HangUpEvent.java
@@ -1,4 +1,23 @@
 package org.jivesoftware.spark.phone.client.event;
 
+/**
+ * Dispatched when the user's call has ended.
+ */
 public class HangUpEvent {
+
+    private final String callID;
+    private final String device;
+
+    public HangUpEvent(String callID, String device) {
+        this.callID = callID;
+        this.device = device;
+    }
+
+    public String getCallID() {
+        return callID;
+    }
+
+    public String getDevice() {
+        return device;
+    }
 }

--- a/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/OnPhoneEvent.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/OnPhoneEvent.java
@@ -1,4 +1,35 @@
 package org.jivesoftware.spark.phone.client.event;
 
+/**
+ * Dispatched when the user's call has been answered and is in progress.
+ */
 public class OnPhoneEvent {
+
+    private final String callID;
+    private final String device;
+    private final String callerID;
+    private final String callerIDName;
+
+    public OnPhoneEvent(String callID, String device, String callerID, String callerIDName) {
+        this.callID = callID;
+        this.device = device;
+        this.callerID = callerID;
+        this.callerIDName = callerIDName;
+    }
+
+    public String getCallID() {
+        return callID;
+    }
+
+    public String getDevice() {
+        return device;
+    }
+
+    public String getCallerID() {
+        return callerID;
+    }
+
+    public String getCallerIDName() {
+        return callerIDName;
+    }
 }

--- a/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/PhoneEventExtension.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/PhoneEventExtension.java
@@ -1,0 +1,95 @@
+package org.jivesoftware.spark.phone.client.event;
+
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+/**
+ * The <tt>phone-event</tt> extension sent by the Asterisk-IM Openfire plugin.
+ * <p>
+ * The plugin pushes these to a user whenever one of their mapped devices changes state:
+ * <pre>
+ * &lt;phone-event xmlns="http://jivesoftware.com/xmlns/phone" type="RING" callID="..." device="SIP/2001"&gt;
+ *     &lt;callerID&gt;2002&lt;/callerID&gt;
+ *     &lt;callerIDName&gt;Bob&lt;/callerIDName&gt;
+ * &lt;/phone-event&gt;
+ * </pre>
+ */
+public class PhoneEventExtension implements ExtensionElement {
+
+    /**
+     * Smack resolves an extension class to a QName through a static QNAME field, falling back
+     * to ELEMENT + NAMESPACE. Without these, Stanza#getExtensions(Class) throws
+     * NoSuchFieldException at runtime. ELEMENT_NAME is kept as the name this plugin has always
+     * used internally.
+     */
+    public static final String ELEMENT = "phone-event";
+    public static final String ELEMENT_NAME = ELEMENT;
+    public static final String NAMESPACE = "http://jivesoftware.com/xmlns/phone";
+    public static final javax.xml.namespace.QName QNAME =
+            new javax.xml.namespace.QName(NAMESPACE, ELEMENT);
+
+    /** Event types used by the Asterisk-IM plugin, as they appear in the 'type' attribute. */
+    public static final String RING = "RING";
+    public static final String ON_PHONE = "ON_PHONE";
+    public static final String HANG_UP = "HANG_UP";
+    public static final String DIALED = "DIALED";
+
+    private final String type;
+    private final String callID;
+    private final String device;
+    private final String callerID;
+    private final String callerIDName;
+
+    public PhoneEventExtension(String type, String callID, String device, String callerID,
+                               String callerIDName) {
+        this.type = type;
+        this.callID = callID;
+        this.device = device;
+        this.callerID = callerID;
+        this.callerIDName = callerIDName;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getCallID() {
+        return callID;
+    }
+
+    public String getDevice() {
+        return device;
+    }
+
+    public String getCallerID() {
+        return callerID;
+    }
+
+    public String getCallerIDName() {
+        return callerIDName;
+    }
+
+    @Override
+    public String getElementName() {
+        return ELEMENT_NAME;
+    }
+
+    @Override
+    public String getNamespace() {
+        return NAMESPACE;
+    }
+
+    @Override
+    public XmlStringBuilder toXML(XmlEnvironment xmlEnvironment) {
+        XmlStringBuilder xml = new XmlStringBuilder(this);
+        xml.attribute("type", type);
+        xml.optAttribute("callID", callID);
+        xml.optAttribute("device", device);
+        xml.rightAngleBracket();
+        xml.optElement("callerID", callerID);
+        xml.optElement("callerIDName", callerIDName);
+        xml.closeElement(this);
+        return xml;
+    }
+}

--- a/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/PhoneEventPacketExtensionProvider.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/PhoneEventPacketExtensionProvider.java
@@ -1,4 +1,50 @@
 package org.jivesoftware.spark.phone.client.event;
 
-public class PhoneEventPacketExtensionProvider {
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.parsing.SmackParsingException;
+import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smack.xml.XmlPullParser;
+import org.jivesoftware.smack.xml.XmlPullParserException;
+import org.jxmpp.JxmppContext;
+
+import java.io.IOException;
+
+/**
+ * Parses the <tt>phone-event</tt> extension sent by the Asterisk-IM Openfire plugin.
+ */
+public class PhoneEventPacketExtensionProvider extends ExtensionElementProvider<PhoneEventExtension> {
+
+    @Override
+    public PhoneEventExtension parse(XmlPullParser parser, int initialDepth,
+                                     XmlEnvironment xmlEnvironment, JxmppContext context)
+            throws XmlPullParserException, IOException, SmackParsingException {
+
+        final String type = parser.getAttributeValue(null, "type");
+        final String callID = parser.getAttributeValue(null, "callID");
+        final String device = parser.getAttributeValue(null, "device");
+
+        String callerID = null;
+        String callerIDName = null;
+
+        while (true) {
+            XmlPullParser.Event event = parser.next();
+            if (event == XmlPullParser.Event.START_ELEMENT) {
+                switch (parser.getName()) {
+                    case "callerID":
+                        callerID = parser.nextText();
+                        break;
+                    case "callerIDName":
+                        callerIDName = parser.nextText();
+                        break;
+                    default:
+                        // 'extension' and anything else the server may add: ignore.
+                        break;
+                }
+            } else if (event == XmlPullParser.Event.END_ELEMENT && parser.getDepth() == initialDepth) {
+                break;
+            }
+        }
+
+        return new PhoneEventExtension(type, callID, device, callerID, callerIDName);
+    }
 }

--- a/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/RingEvent.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/spark/phone/client/event/RingEvent.java
@@ -1,11 +1,35 @@
 package org.jivesoftware.spark.phone.client.event;
 
+/**
+ * Dispatched when one of the user's devices is ringing.
+ */
 public class RingEvent {
-    public String getCallerIDName() {
-        return "TODO CallerIDName";
+
+    private final String callID;
+    private final String device;
+    private final String callerID;
+    private final String callerIDName;
+
+    public RingEvent(String callID, String device, String callerID, String callerIDName) {
+        this.callID = callID;
+        this.device = device;
+        this.callerID = callerID;
+        this.callerIDName = callerIDName;
+    }
+
+    public String getCallID() {
+        return callID;
+    }
+
+    public String getDevice() {
+        return device;
     }
 
     public String getCallerID() {
-        return "TODO CallerID";
+        return callerID;
+    }
+
+    public String getCallerIDName() {
+        return callerIDName;
     }
 }

--- a/plugins/phone/src/main/java/org/jivesoftware/sparkimpl/plugin/phone/PhonePlugin.java
+++ b/plugins/phone/src/main/java/org/jivesoftware/sparkimpl/plugin/phone/PhonePlugin.java
@@ -281,50 +281,29 @@ public class PhonePlugin implements Plugin {
                 dialDialog.setVisible(false);
             }
 
-/*
+            // Restore the presence the user had before the call. Without this Spark stays
+            // "On the phone" for ever once a call ends.
+            //
+            // The original implementation reconciled this against UserIdlePlugin's
+            // desktop-lock and idle state. That is not restored here: it called
+            // UserIdlePlugin.getDesktopLockStatus(), which no longer exists, and read the
+            // now-private 'latestPresence' and 'pref' fields. Its counterpart in
+            // UserIdlePlugin#setOnline() is also still commented out, so bringing the
+            // reconciliation back is a separate change that has to touch core.
+            final Presence restored;
             if (offPhonePresence != null) {
-                // Reconcile presence after phone call based on lock status
-                if (((offPhonePresence.getMode() == Presence.Mode.away) && (!UserIdlePlugin.getDesktopLockStatus())
-                    && (UserIdlePlugin.latestPresence != null)) && (!UserIdlePlugin.latestPresence.getStatus().contentEquals("On the Phone"))) {
-                    SparkManager.getSessionManager().changePresence(UserIdlePlugin.latestPresence);
-                    Log.debug("PhonePlugin: Setting presence from UserIdlePlugin");
-                } else if ((UserIdlePlugin.getDesktopLockStatus()) && ((offPhonePresence.getStatus().equals("Online"))
-                    || (offPhonePresence.getStatus().equals("Free to chat")))) {
-                    Presence presence = StanzaBuilder.buildPresence()
-                        .ofType(Presence.Type.available)
-                        .setStatus(UserIdlePlugin.pref.getIdleMessage())
-                        .setPriority(1)
-                        .setMode(Presence.Mode.away)
-                        .build();
-                    SparkManager.getSessionManager().changePresence(presence);
-                    Log.debug("PhonePlugin: Desktop is Locked - Setting presence from pref.idle message");
-                } else if (UserIdlePlugin.getDesktopLockStatus() && (!offPhonePresence.isAway())) {
-                    Presence presence = StanzaBuilder.buildPresence()
-                        .ofType(Presence.Type.available)
-                        .setStatus(offPhonePresence.getStatus())
-                        .setPriority(1)
-                        .setMode(Presence.Mode.away)
-                        .build();
-                    SparkManager.getSessionManager().changePresence(presence);
-                    Log.debug("PhonePlugin: Desktop is Locked - Setting presence from user defined presence");
-                } else {
-                    // Set user to previous presence state when all phone calls are hung up.
-                    SparkManager.getSessionManager().changePresence(offPhonePresence);
-                    Log.debug("PhonePlugin: Setting Presence from PhonePlugin.");
-                }
+                restored = offPhonePresence;
+                Log.debug("PhonePlugin: restoring presence held before the call");
             } else {
-                // If no previous state available, set status to Available
-                Presence availablePresence = StanzaBuilder.buildPresence()
+                restored = StanzaBuilder.buildPresence()
                     .ofType(Presence.Type.available)
-                    .setStatus("Online")
+                    .setStatus(Res.getString("status.online"))
                     .setPriority(1)
                     .setMode(Presence.Mode.available)
                     .build();
-
-                SparkManager.getSessionManager().changePresence(availablePresence);
-                Log.debug("no previous state available from Phone Plugin..setting to Online");
+                Log.debug("PhonePlugin: no previous presence recorded, setting Online");
             }
-*/
+            SparkManager.getSessionManager().changePresence(restored);
         }
 
         @Override

--- a/plugins/phone/src/main/plugin-metadata/plugin.xml
+++ b/plugins/phone/src/main/plugin-metadata/plugin.xml
@@ -1,0 +1,11 @@
+<plugin>
+    <name>${project.name}</name>
+    <version>${project.version}</version>
+    <description>${project.description}</description>
+    <author>Jive Software</author>
+    <homePage>https://IgniteRealtime.org</homePage>
+    <email>support@IgniteRealtime.org</email>
+    <minSparkVersion>3.1.0</minSparkVersion>
+    <java>11</java>
+    <class>org.jivesoftware.sparkimpl.plugin.phone.PhonePlugin</class>
+</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <module>plugins/fastpath</module>
         <module>plugins/flashing</module>
         <module>plugins/growl</module>
-<!--        <module>plugins/phone</module>-->
+        <module>plugins/phone</module>
 <!--        <module>plugins/jingle</module>-->
         <module>plugins/meet</module>
         <module>plugins/otr</module>


### PR DESCRIPTION
Spark's phone plugin has been dormant since early 2026. This brings it back: it builds, it
packages as a real Spark plugin, and it talks to the Asterisk-IM Openfire plugin again.

## Background

The plugin's client layer used to live in an external jar (`org.jivesoftware.phone.client.*`).
In 7134422b1 those classes were replaced with in-repo stubs so the tree would compile —
`isPhoneEnabled()` became `return true`, both dial methods became empty, and
`RingEvent.getCallerIDName()` returned the literal `"TODO CallerIDName"`. Shortly after, in
48820b718, the module was commented out of the reactor altogether and has not been built
since.

So the plugin was in an odd state: enough UI to offer phone actions on every contact, and
nothing behind it. This fills the stubs in against Smack 4.5 and re-enables the module.

## Contents

Six commits, each independently reviewable:

1. **Package the phone plugin like every other Spark plugin** — the POM parented off the
   reactor root rather than `plugins/plugin`, so it declared `spark-core` itself and produced
   a plain jar with no plugin assembly, and it carried no `plugin.xml` at all. Even a built
   artifact could not have been loaded by the plugin manager.
2. **Parse the `phone-event` extension sent by Asterisk-IM** — the registered provider was an
   empty class and the three event objects were stubs.
3. **Send the `phone-action` IQ understood by Asterisk-IM** — there was a placeholder for the
   provider and nothing at all for the request.
4. **Implement `PhoneClient` against the Asterisk-IM plugin** — discover the phone component
   via disco, gate on the `http://jivesoftware.com/xmlns/phone` feature, dial, and dispatch
   incoming events to listeners.
5. **Restore the user's presence when a call ends** — the body of the hang-up handler was
   commented out, so Spark set the user "On the phone" and left them there for ever.
6. **Re-enable the phone plugin module.**

The module is re-enabled last, so no intermediate commit leaves the reactor broken.

## Verification

Built and run locally against the Asterisk-IM Openfire plugin, and the phone integration
worked.

## Notes for review

**The user-facing gate is deliberately strict.** `PhoneClient`'s constructor fails unless the
server publishes a `phone` component *and* the logged-in user is mapped to a device on the
plugin's Phone Mappings page. `PhonePlugin` already treats that failure as "no phone support"
and shows no phone UI, which seems better than the previous behaviour of offering phone
actions unconditionally.

**Dial requests must carry a `to`.** Without one they go to the user's own server and never
reach the plugin's IQ handler. Similarly, the server compares the `phone-action` type
attribute against the uppercase enum name, so `"DIAL"` is required — `"dial"` comes back as
`feature-not-implemented`.

**`PhoneEventExtension` declares `QNAME`.** Smack resolves an extension class to a QName
through that static field and only falls back to `ELEMENT` + `NAMESPACE`; without it,
`Stanza#getExtensions(Class)` fails at runtime with `NoSuchFieldException`.

**One piece is deliberately left out.** The old hang-up handler also reconciled the restored
presence against `UserIdlePlugin`'s desktop-lock and idle state. That code cannot be revived
as written: it calls `UserIdlePlugin.getDesktopLockStatus()`, which no longer exists anywhere
in the tree, and reads `UserIdlePlugin`'s private `latestPresence` and `pref` fields. Its
counterpart in `UserIdlePlugin#setOnline()` is also still commented out, carrying the marker
*"TODO commented out when PhonePlugin was not ported to Maven"* — the two halves were disabled
together as one unit. Reviving either means changing core, so I have kept it out of a PR whose
job is to make the plugin build and work again. Happy to follow up separately if you want that
behaviour back.

**Versioning follows the existing convention** — `minSparkVersion` 3.1.0 and `<java>11</java>`,
matching all 16 plugins that already ship a `plugin.xml`.

## Relationship to other work

The server side of this is igniterealtime/asterisk-im#21, which brings that plugin up to
Openfire 5 and Asterisk 16-23. The two are independent changes in separate repositories, but
they are meant to be used together.
