### PR TITLE
SPARK-2410: Correct the bookmark button state in the room browser

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceRoomBrowser.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/conferences/ConferenceRoomBrowser.java
@@ -457,13 +457,13 @@ public class ConferenceRoomBrowser extends JPanel implements ActionListener, Com
                     joinRoomItem.setEnabled(true);
                     addRoomButton.setEnabled(true);
                     addRoomItem.setEnabled(true);
-                    addBookmarkUI(!isBookmarked(roomInfo.getRoom()));
+                    addBookmarkUI(isBookmarked(roomInfo.getRoom()));
                 } else {
                     joinRoomButton.setEnabled(false);
                     addRoomButton.setEnabled(false);
                     joinRoomItem.setEnabled(false);
                     addRoomItem.setEnabled(false);
-                    addBookmarkUI(true);
+                    addBookmarkUI(false);
                 }
             });
     }
@@ -717,10 +717,10 @@ public class ConferenceRoomBrowser extends JPanel implements ActionListener, Com
     /**
      * Toggles the bookmark room button depending on it's state.
      *
-     * @param addBookmark true if the button should display itself as bookmarkable :)
+     * @param isBookmarked true if the selected room is already bookmarked, in which case the button offers to remove it.
      */
-    private void addBookmarkUI(boolean addBookmark) {
-        if (addBookmark) {
+    private void addBookmarkUI(boolean isBookmarked) {
+        if (isBookmarked) {
             ResourceUtils.resButton(addRoomButton, Res.getString("button.remove.bookmark"));
             addRoomButton.setIcon(SparkRes.getImageIcon(SparkRes.Icon.DELETE_BOOKMARK_ICON));
         } else {


### PR DESCRIPTION
Selecting a room in the conference room browser labels the bookmark button with the
opposite of the room's actual state. A room that is not bookmarked offers "Remove
bookmark" with the delete icon, and a room that is already bookmarked offers to bookmark
it again. Clicking the button still does the right thing, so the effect is purely that the
button describes the wrong action — but it makes the feature hard to trust.

## Cause

`addBookmarkUI(boolean)` means "the room is bookmarked, so offer to remove it". That is
already how `bookmarkRoom()` calls it, passing the state that results from the toggle it
has just performed. Only the table selection listener negated the value before passing it.

The javadoc on the parameter described the inverted meaning, which is probably how the
mistake survived.

## Change

Drop the negation in the selection listener, and pass `false` rather than `true` when
nothing is selected, so the disabled button rests on "Bookmark room" instead of "Remove
bookmark". The parameter is renamed to `isBookmarked` and its javadoc corrected, so the
next reader is not misled the same way.

One file, no behavioural change beyond the button label and icon.

## Testing

Built and exercised in a local Spark against a live server. The button now describes the
correct action for both bookmarked and unbookmarked rooms; confirmed fixed.
