### PR TITLE
SPARK-2411: Move vCard reload off UI thread to prevent UI freezes

### DIFF
--- a/core/src/main/java/org/jivesoftware/spark/ui/ContactItem.java
+++ b/core/src/main/java/org/jivesoftware/spark/ui/ContactItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2004-2011 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2011 Jive Software, 2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -269,9 +269,7 @@ public class ContactItem extends JPanel {
                 }
                 this.hash = hash;
                 if (!hashExists(hash)) {
-                    // Persists the avatar locally based on the new hash.
-                    SparkManager.getVCardManager().reloadVCard(getJid().asEntityBareJidIfPossible());
-                    updateAvatarInSideIcon();
+                    SparkManager.getVCardManager().addToQueue(getJid().asEntityBareJidIfPossible());
                 }
             }
         }

--- a/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
+++ b/core/src/main/java/org/jivesoftware/sparkimpl/profile/VCardManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2004-2011 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2011 Jive Software, 2026 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
@@ -378,7 +379,12 @@ public class VCardManager {
             addVCard(jid, vcard);
             persistVCard(jid, vcard);
             ContactItem item = SparkManager.getWorkspace().getContactList().getContactItemByJID(jid);
-            item.setNickname(vcard.getNickName());
+            if (item != null) {
+                SwingUtilities.invokeLater(() -> {
+                    item.setNickname(vcard.getNickName());
+                    item.updateAvatarInSideIcon();
+                });
+            }
             return vcard;
         }
         catch (XMPPException | SmackException | InterruptedException e) {


### PR DESCRIPTION
Presence updates now queue vCard reloads on the background worker instead of performing blocking XMPP requests on a UI thread. Once the vCard and avatar are persisted, the contact UI is updated back on the UI thread.